### PR TITLE
Add margin trades sub-calculation for risk report

### DIFF
--- a/workers/loc.api/sync/get-risk/get-funding-payment.js
+++ b/workers/loc.api/sync/get-risk/get-funding-payment.js
@@ -78,7 +78,7 @@ module.exports = async (dao, args) => {
       isExcludePrivate: true
     }
   )
-  const res = groupByTimeframe(
+  const res = await groupByTimeframe(
     ledgers,
     timeframe,
     symbol,

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -10,7 +10,10 @@ const {
   getModelsMap,
   getMethodCollMap
 } = require('../schema')
-const { groupByTimeframe } = require('./helpers')
+const {
+  groupByTimeframe,
+  calcGroupedData
+} = require('./helpers')
 
 const _checkFeeFn = (item) => {
   const regExp = new RegExp(`${item.feeCurrency}$`)
@@ -125,6 +128,12 @@ module.exports = async (dao, args) => {
     dao
   )
 
-  // TODO:
-  return tradesRes
+  const res = calcGroupedData(
+    {
+      tradesRes
+    },
+    true
+  )
+
+  return res
 }

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -291,7 +291,6 @@ module.exports = async (dao, args) => {
     }
   )
   const convertedTrades = await _convertTradesCurr(dao, trades)
-  console.log('---convertedTrades---'.bgRed, convertedTrades)
 
   const positionsHistory = await dao.getElemsInCollBy(
     ALLOWED_COLLS.POSITIONS_HISTORY,

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -23,7 +23,7 @@ const _isAllowedSymb = (currSymb, symbol) => {
   return regExp.test(symbol)
 }
 
-const _checkFeeFn = (item) => (
+const _isAllowedConvFeeFn = (item) => (
   !_isAllowedSymb(item.feeCurrency, item.symbol)
 )
 
@@ -33,7 +33,7 @@ const _getTradesConvSchema = () => {
     dateFieldName: 'mtsCreate',
     convFields: [
       { inputField: 'execAmount', outputField: 'execAmountForex' },
-      { inputField: 'fee', outputField: 'feeForex', checkFn: _checkFeeFn }
+      { inputField: 'fee', outputField: 'feeForex', isAllowedConvFieldFn: _isAllowedConvFeeFn }
     ],
     getCandlesSymbFn: (item) => item.symbol
   }

--- a/workers/loc.api/sync/get-risk/get-margin-trades.js
+++ b/workers/loc.api/sync/get-risk/get-margin-trades.js
@@ -1,8 +1,92 @@
 'use strict'
 
-// TODO: returns just mock data for now
-module.exports = async (dao, args) => {
-  const res = []
+const {
+  getInsertableArrayObjectsFilter
+} = require('bfx-report/workers/loc.api/sync/dao/helpers')
 
-  return res
+const ALLOWED_COLLS = require('../allowed.colls')
+const {
+  getModelsMap,
+  getMethodCollMap
+} = require('../schema')
+const { groupByTimeframe } = require('./helpers')
+
+// TODO: need to add crypto currency conversation
+const _calcTradesData = (
+  data = [],
+  symbolFieldName,
+  symbol = []
+) => {
+  return symbol.reduce((accum, currSymb) => {
+    const _sum = data.reduce((sum, trade) => {
+      const { execAmount } = trade
+      const symb = trade[symbolFieldName]
+      const regExp = new RegExp(`${currSymb}$`)
+
+      return (
+        regExp.test(symb) &&
+        Number.isFinite(execAmount)
+      )
+        ? sum + execAmount
+        : sum
+    }, 0)
+    const res = _sum ? { [currSymb]: _sum } : {}
+
+    return {
+      ...accum,
+      ...res
+    }
+  }, {})
+}
+
+module.exports = async (dao, args) => {
+  const {
+    // eslint-disable-next-line camelcase
+    auth: { _id: user_id },
+    params: {
+      symbol,
+      timeframe,
+      start,
+      end
+    } = {}
+  } = { ...args }
+  const tradesModel = getModelsMap().get(ALLOWED_COLLS.TRADES)
+  const tradesMethodColl = getMethodCollMap().get('_getTrades')
+  const {
+    dateFieldName,
+    symbolFieldName
+  } = tradesMethodColl
+
+  const baseFilter = getInsertableArrayObjectsFilter(
+    tradesMethodColl,
+    {
+      start,
+      end
+    }
+  )
+
+  const trades = await dao.getElemsInCollBy(
+    ALLOWED_COLLS.TRADES,
+    {
+      filter: {
+        ...baseFilter,
+        user_id
+      },
+      sort: [['mtsCreate', -1]],
+      projection: tradesModel,
+      exclude: ['user_id'],
+      isExcludePrivate: true
+    }
+  )
+  const tradesRes = groupByTimeframe(
+    trades,
+    timeframe,
+    symbol,
+    dateFieldName,
+    symbolFieldName,
+    _calcTradesData
+  )
+
+  // TODO:
+  return tradesRes
 }

--- a/workers/loc.api/sync/get-risk/get-movement-fees.js
+++ b/workers/loc.api/sync/get-risk/get-movement-fees.js
@@ -77,7 +77,7 @@ module.exports = async (dao, args) => {
       isExcludePrivate: true
     }
   )
-  const res = groupByTimeframe(
+  const res = await groupByTimeframe(
     movements,
     timeframe,
     symbol,

--- a/workers/loc.api/sync/get-risk/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/get-risk/helpers/calc-grouped-data.js
@@ -73,26 +73,35 @@ const _mergeData = (data) => {
   return orderBy(res, ['mts'], ['desc'])
 }
 
-module.exports = (data, isSubCalc) => {
+const _calcDataItem = (item = []) => {
+  const _item = Object.values(omit(item, ['mts']))
+
+  return _item.reduce((accum, curr) => {
+    Object.entries(curr).forEach(([symb, val]) => {
+      if (!Number.isFinite(val)) {
+        return
+      }
+      if (Number.isFinite(accum[symb])) {
+        accum[symb] += val
+
+        return
+      }
+
+      accum[symb] = val
+    })
+
+    return accum
+  }, {})
+}
+
+module.exports = (
+  data,
+  isSubCalc,
+  calcDataItem = _calcDataItem
+) => {
   const _data = _mergeData(data)
   return _data.map(item => {
-    const res = Object.values(omit(item, ['mts']))
-      .reduce((accum, curr) => {
-        Object.entries(curr).forEach(([symb, val]) => {
-          if (!Number.isFinite(val)) {
-            return
-          }
-          if (Number.isFinite(accum[symb])) {
-            accum[symb] += val
-
-            return
-          }
-
-          accum[symb] = val
-        })
-
-        return accum
-      }, {})
+    const res = calcDataItem(item)
 
     return {
       mts: item.mts,

--- a/workers/loc.api/sync/get-risk/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/get-risk/helpers/calc-grouped-data.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { pick, omit, orderBy } = require('lodash')
+
+const _getDataKeys = (data) => {
+  return Object.keys(data)
+    .filter(key => (
+      Array.isArray(data[key]) &&
+      data[key].length > 0
+    ))
+}
+
+const _getMaxLength = (data) => {
+  const dataArr = Object.values(data)
+
+  if (dataArr.length === 0) {
+    return 0
+  }
+
+  return Math.max(
+    ...dataArr.map(item => item.length)
+  )
+}
+
+const _mergeData = (data) => {
+  if (
+    !data ||
+    typeof data !== 'object'
+  ) {
+    return []
+  }
+
+  const dataKeys = _getDataKeys(data)
+  const _data = pick(data, dataKeys)
+  const maxLength = _getMaxLength(_data)
+  const res = []
+
+  for (let i = 0; maxLength > i; i += 1) {
+    dataKeys.forEach(key => {
+      const { mts, vals } = { ..._data[key][i] }
+
+      if (
+        !Number.isInteger(mts) ||
+        !vals ||
+        typeof vals !== 'object' ||
+        Object.keys(vals).length === 0
+      ) {
+        return
+      }
+      if (
+        res.length === 0 ||
+        res.every(item => mts !== item.mts)
+      ) {
+        res.push({
+          mts,
+          [key]: { ...vals }
+        })
+
+        return
+      }
+
+      res.forEach((item, index) => {
+        if (mts === item.mts) {
+          res[index] = {
+            ...item,
+            [key]: { ...vals }
+          }
+        }
+      })
+    })
+  }
+
+  return orderBy(res, ['mts'], ['desc'])
+}
+
+module.exports = (data, isSubCalc) => {
+  const _data = _mergeData(data)
+  return _data.map(item => {
+    const res = Object.values(omit(item, ['mts']))
+      .reduce((accum, curr) => {
+        Object.entries(curr).forEach(([symb, val]) => {
+          if (!Number.isFinite(val)) {
+            return
+          }
+          if (Number.isFinite(accum[symb])) {
+            accum[symb] += val
+
+            return
+          }
+
+          accum[symb] = val
+        })
+
+        return accum
+      }, {})
+
+    return {
+      mts: item.mts,
+      ...(isSubCalc ? { vals: { ...res } } : res)
+    }
+  })
+}

--- a/workers/loc.api/sync/get-risk/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/get-risk/helpers/group-by-timeframe.js
@@ -96,17 +96,18 @@ const _isNotEmptyGroupItem = ({ mts, vals }) => {
   )
 }
 
-const _getGroupItem = (
+const _getGroupItem = async (
   data,
   timeframe,
   symbol,
   dateFieldName,
   symbolFieldName,
-  calcDataFn
+  calcDataFn,
+  dao
 ) => {
   const { last } = _getFirstAndLastDate(data, dateFieldName)
   const mts = _getStartMtsByTimeframe(last, timeframe)
-  const vals = calcDataFn(data, symbolFieldName, symbol)
+  const vals = await calcDataFn(data, symbolFieldName, symbol, dao)
 
   return {
     mts,
@@ -122,13 +123,14 @@ const _addFragment = (res, subRes, groupItem) => {
   subRes.splice(0, subRes.length)
 }
 
-module.exports = (
+module.exports = async (
   data,
   timeframe,
   symbol,
   dateFieldName,
   symbolFieldName,
-  calcDataFn
+  calcDataFn,
+  dao
 ) => {
   if (
     !Array.isArray(data) ||
@@ -161,13 +163,14 @@ module.exports = (
       subRes.unshift(item)
     }
     if (_isDailyTimeframe(paramsToCheck)) {
-      const groupItem = _getGroupItem(
+      const groupItem = await _getGroupItem(
         subRes,
         timeframe,
         symbol,
         dateFieldName,
         symbolFieldName,
-        calcDataFn
+        calcDataFn,
+        dao
       )
 
       _addFragment(res, subRes, groupItem)
@@ -175,13 +178,14 @@ module.exports = (
       continue
     }
     if (_isMonthlyTimeframe(paramsToCheck)) {
-      const groupItem = _getGroupItem(
+      const groupItem = await _getGroupItem(
         subRes,
         timeframe,
         symbol,
         dateFieldName,
         symbolFieldName,
-        calcDataFn
+        calcDataFn,
+        dao
       )
 
       _addFragment(res, subRes, groupItem)
@@ -189,13 +193,14 @@ module.exports = (
       continue
     }
     if (_isYearlyTimeframe(paramsToCheck)) {
-      const groupItem = _getGroupItem(
+      const groupItem = await _getGroupItem(
         subRes,
         timeframe,
         symbol,
         dateFieldName,
         symbolFieldName,
-        calcDataFn
+        calcDataFn,
+        dao
       )
 
       _addFragment(res, subRes, groupItem)

--- a/workers/loc.api/sync/get-risk/helpers/index.js
+++ b/workers/loc.api/sync/get-risk/helpers/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const groupByTimeframe = require('./group-by-timeframe')
+const calcGroupedData = require('./calc-grouped-data')
 
 module.exports = {
-  groupByTimeframe
+  groupByTimeframe,
+  calcGroupedData
 }

--- a/workers/loc.api/sync/get-risk/index.js
+++ b/workers/loc.api/sync/get-risk/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const { pick, omit, orderBy } = require('lodash')
-
 const getTrades = require('./get-trades')
 const getMarginTrades = require('./get-margin-trades')
 const getFundingPayment = require('./get-funding-payment')
 const getMovementFees = require('./get-movement-fees')
+const { calcGroupedData } = require('./helpers')
 
 const _getData = async (dao, args) => {
   const { skip } = { ...args.params }
@@ -29,105 +28,6 @@ const _getData = async (dao, args) => {
   }
 
   return res
-}
-
-const _getDataKeys = (data) => {
-  return Object.keys(data)
-    .filter(key => (
-      Array.isArray(data[key]) &&
-      data[key].length > 0
-    ))
-}
-
-const _getMaxLength = (data) => {
-  const dataArr = Object.values(data)
-
-  if (dataArr.length === 0) {
-    return 0
-  }
-
-  return Math.max(
-    ...dataArr.map(item => item.length)
-  )
-}
-
-const _mergeData = (data) => {
-  if (
-    !data ||
-    typeof data !== 'object'
-  ) {
-    return []
-  }
-
-  const dataKeys = _getDataKeys(data)
-  const _data = pick(data, dataKeys)
-  const maxLength = _getMaxLength(_data)
-  const res = []
-
-  for (let i = 0; maxLength > i; i += 1) {
-    dataKeys.forEach(key => {
-      const { mts, vals } = { ..._data[key][i] }
-
-      if (
-        !Number.isInteger(mts) ||
-        !vals ||
-        typeof vals !== 'object' ||
-        Object.keys(vals).length === 0
-      ) {
-        return
-      }
-      if (
-        res.length === 0 ||
-        res.every(item => mts !== item.mts)
-      ) {
-        res.push({
-          mts,
-          [key]: { ...vals }
-        })
-
-        return
-      }
-
-      res.forEach((item, index) => {
-        if (mts === item.mts) {
-          res[index] = {
-            ...item,
-            [key]: { ...vals }
-          }
-        }
-      })
-    })
-  }
-
-  return orderBy(res, ['mts'], ['desc'])
-}
-
-const _calcData = (data) => {
-  const _data = _mergeData(data)
-  return _data.map(item => {
-    const res = Object.values(omit(item, ['mts']))
-      .reduce((accum, curr) => {
-        Object.entries(curr).forEach(([symb, val]) => {
-          if (!Number.isFinite(val)) {
-            return
-          }
-          if (Number.isFinite(accum[symb])) {
-            accum[symb] += val
-
-            return
-          }
-
-          accum[symb] = val
-        })
-
-        return accum
-      }, {})
-
-    return {
-      mts: item.mts,
-      ...res
-    }
-  })
 }
 
 module.exports = async (
@@ -154,7 +54,7 @@ module.exports = async (
     }
   }
   const data = await _getData(dao, args)
-  const res = _calcData(data)
+  const res = calcGroupedData(data)
 
   return res
 }

--- a/workers/loc.api/sync/helpers/convert-data-curr.js
+++ b/workers/loc.api/sync/helpers/convert-data-curr.js
@@ -22,7 +22,7 @@ module.exports = async (dao, data, convSchema) => {
     convertTo: 'USD',
     symbolFieldName: '',
     dateFieldName: '',
-    convFields: [{ inputField: '', outputField: '', checkFn: () => true }],
+    convFields: [{ inputField: '', outputField: '', isAllowedConvFieldFn: () => true }],
     getCandlesSymbFn: _getCandlesSymbFn,
     ...convSchema
   }
@@ -78,12 +78,12 @@ module.exports = async (dao, data, convSchema) => {
       continue
     }
 
-    convFields.forEach(({ inputField, outputField, checkFn = () => true }) => {
+    convFields.forEach(({ inputField, outputField, isAllowedConvFieldFn = () => true }) => {
       if (
         _isEmptyStr(inputField) ||
         _isEmptyStr(outputField) ||
         !Number.isFinite(item[inputField]) ||
-        !checkFn(item, inputField, outputField, candle.close)
+        !isAllowedConvFieldFn(item, inputField, outputField, candle.close)
       ) {
         return
       }

--- a/workers/loc.api/sync/helpers/convert-data-curr.js
+++ b/workers/loc.api/sync/helpers/convert-data-curr.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const { getMethodCollMap } = require('../schema')
+
+const _isEmptyStr = (str) => (
+  !str ||
+  typeof str !== 'string'
+)
+
+const _getCandlesSymbFn = (
+  item,
+  {
+    convertTo,
+    symbolFieldName
+  }
+) => (
+  `t${item[symbolFieldName]}${convertTo}`
+)
+
+module.exports = async (dao, data, convSchema) => {
+  const _convSchema = {
+    convertTo: 'USD',
+    symbolFieldName: '',
+    dateFieldName: '',
+    convFields: [{ inputField: '', outputField: '', checkFn: () => true }],
+    getCandlesSymbFn: _getCandlesSymbFn,
+    ...convSchema
+  }
+  const {
+    convertTo,
+    symbolFieldName,
+    dateFieldName,
+    convFields,
+    getCandlesSymbFn
+  } = _convSchema
+  const candlesSchema = getMethodCollMap().get('_getCandles')
+  const isArr = Array.isArray(data)
+  const elems = isArr
+    ? data
+    : [data]
+  const res = []
+
+  for (const obj of elems) {
+    const isNotObj = !obj || typeof obj !== 'object'
+    const item = isNotObj ? obj : { ...obj }
+
+    res.push(item)
+
+    if (
+      isNotObj ||
+      _isEmptyStr(convertTo) ||
+      _isEmptyStr(symbolFieldName) ||
+      _isEmptyStr(dateFieldName) ||
+      _isEmptyStr(item[symbolFieldName]) ||
+      !Number.isInteger(item[dateFieldName]) ||
+      !Array.isArray(convFields) ||
+      convFields.length === 0
+    ) {
+      continue
+    }
+
+    const candle = await dao.getElemInCollBy(
+      candlesSchema.name,
+      {
+        [candlesSchema.symbolFieldName]: getCandlesSymbFn(item, _convSchema),
+        end: item[dateFieldName],
+        _dateFieldName: [candlesSchema.dateFieldName]
+      },
+      candlesSchema.sort
+    )
+
+    if (
+      !candle ||
+      typeof candle !== 'object' ||
+      !candle.close ||
+      !Number.isFinite(candle.close)
+    ) {
+      continue
+    }
+
+    convFields.forEach(({ inputField, outputField, checkFn = () => true }) => {
+      if (
+        _isEmptyStr(inputField) ||
+        _isEmptyStr(outputField) ||
+        !Number.isFinite(item[inputField]) ||
+        !checkFn(item, inputField, outputField, candle.close)
+      ) {
+        return
+      }
+
+      item[outputField] = item[inputField] * candle.close
+    })
+  }
+
+  return isArr ? res : res[0]
+}

--- a/workers/loc.api/sync/helpers/convert-data-curr.js
+++ b/workers/loc.api/sync/helpers/convert-data-curr.js
@@ -22,7 +22,7 @@ module.exports = async (dao, data, convSchema) => {
     convertTo: 'USD',
     symbolFieldName: '',
     dateFieldName: '',
-    convFields: [{ inputField: '', outputField: '', isAllowedConvFieldFn: () => true }],
+    convFields: [{ inputField: '', outputField: '' }],
     getCandlesSymbFn: _getCandlesSymbFn,
     ...convSchema
   }
@@ -59,10 +59,16 @@ module.exports = async (dao, data, convSchema) => {
       continue
     }
 
+    const candlesSymb = getCandlesSymbFn(item, _convSchema)
+
+    if (!candlesSymb) {
+      continue
+    }
+
     const candle = await dao.getElemInCollBy(
       candlesSchema.name,
       {
-        [candlesSchema.symbolFieldName]: getCandlesSymbFn(item, _convSchema),
+        [candlesSchema.symbolFieldName]: candlesSymb,
         end: item[dateFieldName],
         _dateFieldName: [candlesSchema.dateFieldName]
       },
@@ -78,12 +84,11 @@ module.exports = async (dao, data, convSchema) => {
       continue
     }
 
-    convFields.forEach(({ inputField, outputField, isAllowedConvFieldFn = () => true }) => {
+    convFields.forEach(({ inputField, outputField }) => {
       if (
         _isEmptyStr(inputField) ||
         _isEmptyStr(outputField) ||
-        !Number.isFinite(item[inputField]) ||
-        !isAllowedConvFieldFn(item, inputField, outputField, candle.close)
+        !Number.isFinite(item[inputField])
       ) {
         return
       }

--- a/workers/loc.api/sync/helpers/index.js
+++ b/workers/loc.api/sync/helpers/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const convertDataCurr = require('./convert-data-curr')
+
+module.exports = {
+  convertDataCurr
+}


### PR DESCRIPTION
This PR adds the margin trades sub-calculation for risk report as one of the four parts of the general calculation. The margin trades includes four calculation: `positions / tradesExecAmount + tradesFees + usedFunding`:
  - `positions` is a selection from `positionsHistory` table by `symbol` and `mtsUpdate` sorted by `mtsUpdate: -1` and as a result there will be: `basePrice (from end) - closePrice (from start)`
  - `usedFunding` is a selection from `positionsHistory` table by `symbol` and `mtsUpdate` sorted by `mtsUpdate: -1` and as a result there will be a sum of `marginFunding` fields
  - `tradesExecAmount` is a selection from `trades` table by `symbol` and `mtsCreate` sorted by `mtsCreate: -1` and as a result there will be a sum of `execAmount` fields where cryptocurrency will be convert using the `candles` if `execAmount < 0`. If `execAmount > 0` that is mean execAmount already in forex currency
  - `tradesFees` is a selection from `trades` table by `symbol` and `mtsCreate` sorted by `mtsCreate: -1` and as a result there will be a sum of `fee` fields where cryptocurrency will be convert using the `candles`. But for `fee` there is a field `feeCurrency` which indicates that the value of `fee` is already converted to forex currency, and in this case, the cryptocurrency conversion is not done.