### PR TITLE
Add csv risk report export

### DIFF
--- a/workers/loc.api/helpers/check-params.js
+++ b/workers/loc.api/helpers/check-params.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const {
+  checkParams: checkParamsBase
+} = require('bfx-report/workers/loc.api/helpers')
+
+const schema = require('./schema')
+
+module.exports = (
+  args,
+  schemaName = 'paramsSchemaForCsv',
+  requireFields = [],
+  checkParamsField = false
+) => {
+  checkParamsBase(
+    args,
+    schemaName,
+    requireFields,
+    checkParamsField,
+    schema
+  )
+}

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const {
+  getCsvArgs,
+  checkJobAndGetUserData
+} = require('bfx-report/workers/loc.api/helpers')
+
+const checkParams = require('./check-params')
+
+const getCsvJobData = {
+  async getRiskCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForRiskCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getRisk',
+      fileNamesMap: [['getRisk', 'risk']],
+      args: csvArgs,
+      propNameForPagination: null,
+      columnsCsv: {
+        USD: 'USD',
+        EUR: 'EUR',
+        GBP: 'GBP',
+        JPY: 'JPY',
+        mts: 'DATE'
+      },
+      formatSettings: {
+        mts: 'date'
+      }
+    }
+
+    return jobData
+  }
+}
+
+module.exports = getCsvJobData

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -1,36 +1,11 @@
 'use strict'
 
-const {
-  getMethodLimit: getMethodLimitBase,
-  checkParams: checkParamsBase
-} = require('bfx-report/workers/loc.api/helpers')
-
-const schema = require('./schema')
-
-const getMethodLimit = (sendLimit, method) => {
-  const _methodsLimits = {
-    candles: { default: 500, max: 500 }
-  }
-
-  return getMethodLimitBase(sendLimit, method, _methodsLimits)
-}
-
-const checkParams = (
-  args,
-  schemaName = 'paramsSchemaForCsv',
-  requireFields = [],
-  checkParamsField = false
-) => {
-  checkParamsBase(
-    args,
-    schemaName,
-    requireFields,
-    checkParamsField,
-    schema
-  )
-}
+const checkParams = require('./check-params')
+const { getMethodLimit } = require('./limit-param.helpers')
+const getCsvJobData = require('./get-csv-job-data')
 
 module.exports = {
   getMethodLimit,
-  checkParams
+  checkParams,
+  getCsvJobData
 }

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {
+  getMethodLimit: getMethodLimitBase
+} = require('bfx-report/workers/loc.api/helpers')
+
+const getMethodLimit = (sendLimit, method) => {
+  const _methodsLimits = {
+    candles: { default: 500, max: 500 }
+  }
+
+  return getMethodLimitBase(sendLimit, method, _methodsLimits)
+}
+
+module.exports = {
+  getMethodLimit
+}

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -1,5 +1,11 @@
 'use strict'
 
+const { cloneDeep } = require('lodash')
+
+const {
+  paramsSchemaForCsv
+} = require('bfx-report/workers/loc.api/helpers/schema')
+
 const paramsSchemaForCandlesApi = {
   type: 'object',
   properties: {
@@ -47,6 +53,7 @@ const paramsSchemaForRiskApi = {
     skip: {
       type: 'array',
       minItems: 1,
+      maxItems: 3,
       items: {
         type: 'string',
         enum: [
@@ -60,7 +67,22 @@ const paramsSchemaForRiskApi = {
   }
 }
 
+const {
+  timezone,
+  dateFormat
+} = { ...paramsSchemaForCsv.properties }
+
+const paramsSchemaForRiskCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForRiskApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 module.exports = {
   paramsSchemaForCandlesApi,
-  paramsSchemaForRiskApi
+  paramsSchemaForRiskApi,
+  paramsSchemaForRiskCsv
 }


### PR DESCRIPTION
This PR adds csv report export via `getRiskCsv` or `getMultipleCsv` methods

**Depends** on this PR [bfx-report](https://github.com/bitfinexcom/bfx-report/pull/116)