### PR TITLE
Add win/loss report

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
       "after",
       "beforeEach",
       "afterEach"
+    ],
+    "ignore": [
+      "bfx-report-ui"
     ]
   },
   "nodemonConfig": {

--- a/test/1-sync-mode-sqlite.spec.js
+++ b/test/1-sync-mode-sqlite.spec.js
@@ -361,6 +361,51 @@ describe('Sync mode with SQLite', () => {
     }
   })
 
+  it('it should be successfully performed by the getWinLoss method', async function () {
+    this.timeout(5000)
+
+    const timeframeArr = ['day', 'month', 'year']
+    const paramsArr = Array(timeframeArr.length)
+      .fill({ start, end })
+      .map((item, i) => {
+        const timeframeIndex = i % timeframeArr.length
+
+        return {
+          ...item,
+          timeframe: timeframeArr[timeframeIndex]
+        }
+      })
+
+    for (const params of paramsArr) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getWinLoss',
+          params,
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isArray(res.body.result)
+
+      const resItem = res.body.result[0]
+
+      assert.isObject(resItem)
+      assert.containsAllKeys(resItem, [
+        'mts',
+        'USD',
+        'EUR',
+        'GBP',
+        'JPY'
+      ])
+    }
+  })
+
   it('it should be successfully performed by the getMultipleCsv method', async function () {
     this.timeout(60000)
 
@@ -438,6 +483,32 @@ describe('Sync mode with SQLite', () => {
       .send({
         auth,
         method: 'getBalanceHistoryCsv',
+        params: {
+          end,
+          start,
+          timeframe: 'day',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the getWinLossCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getWinLossCsv',
         params: {
           end,
           start,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -89,6 +89,47 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  async getWinLossCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForWinLossCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getWinLoss',
+      fileNamesMap: [['getWinLoss', 'win-loss']],
+      args: csvArgs,
+      propNameForPagination: null,
+      columnsCsv: {
+        USD: 'USD',
+        EUR: 'EUR',
+        GBP: 'GBP',
+        JPY: 'JPY',
+        mts: 'DATE'
+      },
+      formatSettings: {
+        mts: 'date'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -87,6 +87,26 @@ const paramsSchemaForBalanceHistoryApi = {
   }
 }
 
+const paramsSchemaForWinLossApi = {
+  type: 'object',
+  properties: {
+    timeframe: {
+      type: 'string',
+      enum: [
+        'day',
+        'month',
+        'year'
+      ]
+    },
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    }
+  }
+}
+
 const {
   timezone,
   dateFormat
@@ -110,10 +130,21 @@ const paramsSchemaForBalanceHistoryCsv = {
   }
 }
 
+const paramsSchemaForWinLossCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForWinLossApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 module.exports = {
   paramsSchemaForCandlesApi,
   paramsSchemaForRiskApi,
   paramsSchemaForBalanceHistoryApi,
+  paramsSchemaForWinLossApi,
   paramsSchemaForRiskCsv,
-  paramsSchemaForBalanceHistoryCsv
+  paramsSchemaForBalanceHistoryCsv,
+  paramsSchemaForWinLossCsv
 }

--- a/workers/loc.api/sync/data.inserter/convert-currency.js
+++ b/workers/loc.api/sync/data.inserter/convert-currency.js
@@ -15,6 +15,16 @@ const _getConvSchema = () => {
           { inputField: 'balance', outputField: 'balanceUsd' }
         ]
       }
+    ],
+    [
+      ALLOWED_COLLS.MOVEMENTS,
+      {
+        symbolFieldName: 'currency',
+        dateFieldName: 'mtsUpdated',
+        convFields: [
+          { inputField: 'amount', outputField: 'amountUsd' }
+        ]
+      }
     ]
   ])
 }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -196,11 +196,13 @@ class DataInserter extends BaseDataInserter {
 
       const start = (
         Array.isArray(startElemFromApi) &&
-        startElemFromApi[0] &&
-        typeof startElemFromApi[0] === 'object' &&
-        Number.isInteger(startElemFromApi[0][schema.dateFieldName])
+        startElemFromApi[startElemFromApi.length - 1] &&
+        typeof startElemFromApi[startElemFromApi.length - 1] === 'object' &&
+        Number.isInteger(
+          startElemFromApi[startElemFromApi.length - 1][schema.dateFieldName]
+        )
       )
-        ? startElemFromApi[0][schema.dateFieldName]
+        ? startElemFromApi[startElemFromApi.length - 1][schema.dateFieldName]
         : _start
 
       if (isEmpty(lastElemFromDb)) {

--- a/workers/loc.api/sync/get-balance-history/index.js
+++ b/workers/loc.api/sync/get-balance-history/index.js
@@ -5,15 +5,9 @@ const { isEmpty } = require('lodash')
 const {
   calcGroupedData,
   getMtsGroupedByTimeframe,
-  groupByTimeframe
+  groupByTimeframe,
+  isForexSymb
 } = require('../helpers')
-
-const _isForexSymb = (symbs = [], currSymb) => {
-  return (
-    Array.isArray(symbs) &&
-    symbs.some(symb => symb === currSymb)
-  )
-}
 
 const _calcWalletsInTimeframe = (
   data,
@@ -24,11 +18,11 @@ const _calcWalletsInTimeframe = (
     accum,
     { currency, balance, balanceUsd }
   ) => {
-    const isForexSymb = _isForexSymb(symbol, currency)
-    const _balance = isForexSymb
+    const _isForexSymb = isForexSymb(symbol, currency)
+    const _balance = _isForexSymb
       ? balance
       : balanceUsd
-    const symb = isForexSymb
+    const symb = _isForexSymb
       ? currency
       : 'USD'
 

--- a/workers/loc.api/sync/get-balance-history/index.js
+++ b/workers/loc.api/sync/get-balance-history/index.js
@@ -136,9 +136,10 @@ module.exports = async (
       start = 0,
       end = Date.now()
     } = {}
-  } = {}
+  } = {},
+  isSubCalc = false,
+  symbol = ['EUR', 'JPY', 'GBP', 'USD']
 ) => {
-  const symbol = ['EUR', 'JPY', 'GBP', 'USD']
   const args = {
     auth,
     timeframe,
@@ -167,7 +168,7 @@ module.exports = async (
       walletsGroupedByTimeframe,
       mtsGroupedByTimeframe
     },
-    false,
+    isSubCalc,
     _getWalletsByTimeframe(),
     true
   )

--- a/workers/loc.api/sync/get-win-loss/index.js
+++ b/workers/loc.api/sync/get-win-loss/index.js
@@ -1,16 +1,58 @@
 'use strict'
 
 const {
-  calcGroupedData
+  getInsertableArrayObjectsFilter
+} = require('bfx-report/workers/loc.api/sync/dao/helpers')
+
+const ALLOWED_COLLS = require('../allowed.colls')
+const {
+  getModelsMap,
+  getMethodCollMap
+} = require('../schema')
+const {
+  calcGroupedData,
+  groupByTimeframe,
+  isForexSymb
 } = require('../helpers')
 const getBalanceHistory = require('../get-balance-history')
 
-// TODO: need to implement calc of DEPOSIT/WITHDRAWALS
+const _sumMovementsWithPrevRes = (
+  symbol,
+  prevMovementsRes,
+  movementsGroupedByTimeframe
+) => {
+  return symbol.reduce((accum, symb) => {
+    const prevMovement = Number.isFinite(prevMovementsRes[symb])
+      ? prevMovementsRes[symb]
+      : 0
+    const movement = Number.isFinite(movementsGroupedByTimeframe[symb])
+      ? movementsGroupedByTimeframe[symb]
+      : 0
+    const res = prevMovement + movement
+
+    return {
+      ...accum,
+      [symb]: res
+    }
+  }, {})
+}
+
 const _getWinLossByTimeframe = (
   symbol = [],
   startWalletsVals = {}
 ) => {
-  return ({ walletsGroupedByTimeframe } = {}) => {
+  let prevMovementsRes = {}
+
+  return ({
+    walletsGroupedByTimeframe,
+    movementsGroupedByTimeframe
+  } = {}) => {
+    prevMovementsRes = _sumMovementsWithPrevRes(
+      symbol,
+      prevMovementsRes,
+      { ...movementsGroupedByTimeframe }
+    )
+
     return symbol.reduce((accum, symb) => {
       const startWallet = Number.isFinite(startWalletsVals[symb])
         ? startWalletsVals[symb]
@@ -18,7 +60,10 @@ const _getWinLossByTimeframe = (
       const wallet = Number.isFinite(walletsGroupedByTimeframe[symb])
         ? walletsGroupedByTimeframe[symb]
         : 0
-      const res = wallet - startWallet
+      const movements = Number.isFinite(prevMovementsRes[symb])
+        ? prevMovementsRes[symb]
+        : 0
+      const res = (wallet - startWallet) + movements
 
       return {
         ...accum,
@@ -28,8 +73,37 @@ const _getWinLossByTimeframe = (
   }
 }
 
+const _calcMovements = (
+  data = [],
+  symbolFieldName,
+  symbol = []
+) => {
+  return data.reduce((accum, movement = {}) => {
+    const { amount, amountUsd } = { ...movement }
+    const currSymb = movement[symbolFieldName]
+    const _isForexSymb = isForexSymb(symbol, currSymb)
+    const _amount = _isForexSymb
+      ? amount
+      : amountUsd
+    const symb = _isForexSymb
+      ? currSymb
+      : 'USD'
+
+    if (!Number.isFinite(_amount)) {
+      return { ...accum }
+    }
+
+    return {
+      ...accum,
+      [symb]: (Number.isFinite(accum[symb]))
+        ? accum[symb] + _amount
+        : _amount
+    }
+  }, {})
+}
+
 module.exports = async (
-  { dao },
+  rService,
   {
     auth = {},
     params: {
@@ -39,6 +113,9 @@ module.exports = async (
     } = {}
   } = {}
 ) => {
+  const { dao } = rService
+  const user = await rService.dao.checkAuthInDb({ auth })
+
   const symbol = ['EUR', 'JPY', 'GBP', 'USD']
   const args = {
     auth,
@@ -48,6 +125,42 @@ module.exports = async (
       end
     }
   }
+  const movementsModel = getModelsMap().get(ALLOWED_COLLS.MOVEMENTS)
+  const movementsMethodColl = getMethodCollMap().get('_getMovements')
+  const {
+    dateFieldName: movementsDateFieldName,
+    symbolFieldName: movementsSymbolFieldName
+  } = movementsMethodColl
+
+  const movementsBaseFilter = getInsertableArrayObjectsFilter(
+    movementsMethodColl,
+    {
+      start,
+      end
+    }
+  )
+
+  const movements = await dao.getElemsInCollBy(
+    ALLOWED_COLLS.MOVEMENTS,
+    {
+      filter: {
+        ...movementsBaseFilter,
+        user_id: user._id
+      },
+      sort: [['mtsUpdated', -1]],
+      projection: movementsModel,
+      exclude: ['user_id'],
+      isExcludePrivate: true
+    }
+  )
+  const movementsGroupedByTimeframe = await groupByTimeframe(
+    movements,
+    timeframe,
+    symbol,
+    movementsDateFieldName,
+    movementsSymbolFieldName,
+    _calcMovements
+  )
 
   const walletsGroupedByTimeframe = await getBalanceHistory(
     { dao },
@@ -64,7 +177,8 @@ module.exports = async (
 
   const res = await calcGroupedData(
     {
-      walletsGroupedByTimeframe
+      walletsGroupedByTimeframe,
+      movementsGroupedByTimeframe
     },
     false,
     _getWinLossByTimeframe(symbol, startWalletsInForex),

--- a/workers/loc.api/sync/get-win-loss/index.js
+++ b/workers/loc.api/sync/get-win-loss/index.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const {
+  calcGroupedData
+} = require('../helpers')
+const getBalanceHistory = require('../get-balance-history')
+
+// TODO: need to implement calc of DEPOSIT/WITHDRAWALS
+const _getWinLossByTimeframe = (
+  symbol = [],
+  startWalletsVals = {}
+) => {
+  return ({ walletsGroupedByTimeframe } = {}) => {
+    return symbol.reduce((accum, symb) => {
+      const startWallet = Number.isFinite(startWalletsVals[symb])
+        ? startWalletsVals[symb]
+        : 0
+      const wallet = Number.isFinite(walletsGroupedByTimeframe[symb])
+        ? walletsGroupedByTimeframe[symb]
+        : 0
+      const res = wallet - startWallet
+
+      return {
+        ...accum,
+        [symb]: res
+      }
+    }, {})
+  }
+}
+
+module.exports = async (
+  { dao },
+  {
+    auth = {},
+    params: {
+      timeframe = 'day',
+      start = 0,
+      end = Date.now()
+    } = {}
+  } = {}
+) => {
+  const symbol = ['EUR', 'JPY', 'GBP', 'USD']
+  const args = {
+    auth,
+    params: {
+      timeframe,
+      start,
+      end
+    }
+  }
+
+  const walletsGroupedByTimeframe = await getBalanceHistory(
+    { dao },
+    args,
+    true,
+    symbol
+  )
+
+  const startWalletsInForex = {
+    ...({
+      ...walletsGroupedByTimeframe[walletsGroupedByTimeframe.length - 1]
+    }).vals
+  }
+
+  const res = await calcGroupedData(
+    {
+      walletsGroupedByTimeframe
+    },
+    false,
+    _getWinLossByTimeframe(symbol, startWalletsInForex),
+    true
+  )
+
+  return res
+}

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -125,13 +125,6 @@ module.exports = async (
     const item = data[i]
     const isLastIter = i === 0
     const nextItem = data[i - 1]
-    const resToCheck = [nextItem, ...subRes]
-    const paramsToCheck = {
-      data: resToCheck,
-      dateFieldName,
-      timeframe,
-      isLastIter
-    }
 
     if (
       item &&
@@ -141,6 +134,15 @@ module.exports = async (
     ) {
       subRes.unshift(item)
     }
+
+    const resToCheck = [nextItem, ...subRes]
+    const paramsToCheck = {
+      data: resToCheck,
+      dateFieldName,
+      timeframe,
+      isLastIter
+    }
+
     if (_isDailyTimeframe(paramsToCheck)) {
       const groupItem = await _getGroupItem(
         subRes,

--- a/workers/loc.api/sync/helpers/index.js
+++ b/workers/loc.api/sync/helpers/index.js
@@ -5,11 +5,13 @@ const getStartMtsByTimeframe = require('./get-start-mts-by-timeframe')
 const getMtsGroupedByTimeframe = require('./get-mts-grouped-by-timeframe')
 const calcGroupedData = require('./calc-grouped-data')
 const groupByTimeframe = require('./group-by-timeframe')
+const isForexSymb = require('./is-forex-symb')
 
 module.exports = {
   convertDataCurr,
   getStartMtsByTimeframe,
   getMtsGroupedByTimeframe,
   calcGroupedData,
-  groupByTimeframe
+  groupByTimeframe,
+  isForexSymb
 }

--- a/workers/loc.api/sync/helpers/is-forex-symb.js
+++ b/workers/loc.api/sync/helpers/is-forex-symb.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = (symbs = [], currSymb) => {
+  return (
+    Array.isArray(symbs) &&
+    symbs.some(symb => symb === currSymb)
+  )
+}

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -36,6 +36,17 @@ const _models = new Map([
     )
   ],
   [
+    ALLOWED_COLLS.MOVEMENTS,
+    _addToModel(
+      ALLOWED_COLLS.MOVEMENTS,
+      {
+        amount: {
+          amountUsd: 'DECIMAL(22,12)'
+        }
+      }
+    )
+  ],
+  [
     ALLOWED_COLLS.CANDLES,
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',


### PR DESCRIPTION
This PR adds the `win/loss` report. Base changes:
  - adds `getWinLoss` method
  - adds `getWinLossCsv` method
  - adds corresponding tests
  - adds movements amount conversion to usd
  - fixes candles sync
  - fixes `groupByTimeframe` helper

**Depends** on this PR [bitfinexcom/bfx-report#127](https://github.com/bitfinexcom/bfx-report/pull/127)