### PR TITLE
Add readme to temp dir

### DIFF
--- a/workers/loc.api/queue/temp/.gitkeep
+++ b/workers/loc.api/queue/temp/.gitkeep
@@ -1,1 +1,0 @@
-.gitkeep

--- a/workers/loc.api/queue/temp/README.md
+++ b/workers/loc.api/queue/temp/README.md
@@ -1,0 +1,1 @@
+# Here are contain temporary files


### PR DESCRIPTION
This PR adds a `readme.md` file to the temp directory `bfx-reports-framework/workers/loc.api/queue/temp`. It is necessary for the electron app building