### PR TITLE
Improve max limit handling for movements

### DIFF
--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -1766,7 +1766,7 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
-  it('it should not be successfully performed by the getMovements method, a greater limit is needed', async function () {
+  it('it should not be successfully performed by the getLedgers method, a greater limit is needed', async function () {
     this.timeout(5000)
 
     const res = await agent
@@ -1774,7 +1774,7 @@ describe('Sync mode API with SQLite', () => {
       .type('json')
       .send({
         auth,
-        method: 'getMovements',
+        method: 'getLedgers',
         params: {
           symbol: 'BTC',
           start: 0,
@@ -1791,6 +1791,49 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body.error, 'code', 400)
     assert.propertyVal(res.body.error, 'message', 'A greater limit is needed as to show the data correctly')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getMovements method, without MinLimitParamError error', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMovements',
+        params: {
+          symbol: 'BTC',
+          start: 0,
+          end,
+          limit: 25
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'currency',
+      'currencyName',
+      'mtsStarted',
+      'mtsUpdated',
+      'status',
+      'amount',
+      'fees',
+      'destinationAddress',
+      'transactionId'
+    ])
   })
 
   it('it should not be successfully performed by a fake method', async function () {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -92,7 +92,10 @@ class ReportService extends BaseReportService {
         'mts',
         params.limit,
         params.notThrowError,
-        params.notCheckNextPage
+        params.notCheckNextPage,
+        null,
+        null,
+        'candles'
       )
     }, '_getCandles')
   }

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -322,7 +322,8 @@ class SqliteDAO extends DAO {
       symbolFieldName,
       sort: _sort,
       model,
-      dataStructureConverter
+      dataStructureConverter,
+      name
     } = { ...methodColl }
     params.limit = maxLimit
       ? getLimitNotMoreThan(params.limit, maxLimit)
@@ -385,7 +386,8 @@ class SqliteDAO extends DAO {
         params.notThrowError,
         params.notCheckNextPage,
         symbols,
-        symbolFieldName
+        symbolFieldName,
+        name
       )
     }
 


### PR DESCRIPTION
This PR improves max limit handling for movements. If limit sent is === to MAX LIMIT, instead of returning a response that the limit should be bigger, will return the response anyway

**Depends** on this PR [bitfinexcom/bfx-report#145](https://github.com/bitfinexcom/bfx-report/pull/145)