### PR TITLE
Replace DB data if exists when syncing

### DIFF
--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -219,7 +219,14 @@ class SqliteDAO extends DAO {
   /**
    * @override
    */
-  async insertElemsToDb (name, auth, data = []) {
+  async insertElemsToDb (
+    name,
+    auth,
+    data = [],
+    {
+      isReplacedIfExists
+    } = {}
+  ) {
     await mixUserIdToArrData(this, auth, data)
 
     await this._beginTrans(async () => {
@@ -235,8 +242,11 @@ class SqliteDAO extends DAO {
           placeholders,
           placeholderVal
         } = getPlaceholdersQuery(obj, keys)
+        const replace = isReplacedIfExists
+          ? ' OR REPLACE'
+          : ''
 
-        const sql = `INSERT INTO ${name}(${projection}) VALUES (${placeholders})`
+        const sql = `INSERT${replace} INTO ${name}(${projection}) VALUES (${placeholders})`
 
         await this._run(sql, placeholderVal)
       }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -639,7 +639,8 @@ class DataInserter extends EventEmitter {
       await this.dao.insertElemsToDb(
         collName,
         isPublic ? null : { ..._args.auth },
-        normalizeApiData(res, model)
+        normalizeApiData(res, model),
+        { isReplacedIfExists: true }
       )
 
       count += res.length


### PR DESCRIPTION
This PR replaces DB data if exists when syncing. That will not get sync progress errors when we get constraint errors of unique indexes