### PR TITLE
Improve filtering deposits/withdrawals for win/loss

### DIFF
--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -278,6 +278,7 @@ class WinLoss {
       this.ALLOWED_COLLS.MOVEMENTS,
       {
         filter: {
+          $not: { status: 'CANCELED' },
           $lt: { amount: 0 },
           $gte: { mtsStarted: start },
           $lte: { mtsStarted: end },
@@ -293,6 +294,7 @@ class WinLoss {
       this.ALLOWED_COLLS.MOVEMENTS,
       {
         filter: {
+          status: 'COMPLETED',
           $gt: { amount: 0 },
           $gte: { mtsUpdated: start },
           $lte: { mtsUpdated: end },


### PR DESCRIPTION
This PR improves filtering `deposits/withdrawals` for the `win/loss` report:
  - deposits are filtered by `COMPLETED` state
  - withdrawals are filtered by `!== 'CANCELED'` state