### PR TITLE
Add status messages report to sync mode

### DIFF
--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -544,6 +544,85 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body.result[1], 'start', start)
   })
 
+  it('it should be successfully performed by the editStatusMessagesConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'editStatusMessagesConf',
+        params: [
+          {
+            start,
+            symbol: 'tBTCF0:USTF0'
+          }
+        ],
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should be successfully performed by the getSyncProgress method', async function () {
+    this.timeout(60000)
+
+    while (true) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getSyncProgress',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isNumber(res.body.result)
+
+      if (
+        typeof res.body.result !== 'number' ||
+        res.body.result === 100
+      ) {
+        break
+      }
+
+      await delay()
+    }
+  })
+
+  it('it should be successfully performed by the getStatusMessagesConf method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessagesConf',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.equal(res.body.result.length, 1)
+
+    assert.isObject(res.body.result[0])
+    assert.propertyVal(res.body.result[0], 'symbol', 'tBTCF0:USTF0')
+    assert.propertyVal(res.body.result[0], 'start', start)
+  })
+
   it('it should be successfully performed by the syncNow method', async function () {
     this.timeout(60000)
 
@@ -1475,6 +1554,43 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getStatusMessages method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessages',
+        params: {
+          symbol: 'tBTCF0:USTF0'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'key',
+      'timestamp',
+      'price',
+      'priceSpot',
+      'fundBal',
+      'fundingAccrued',
+      'fundingStep'
+    ])
+  })
+
   it('it should be successfully performed by the getOrderTrades method', async function () {
     this.timeout(5000)
 
@@ -2318,6 +2434,31 @@ describe('Sync mode API with SQLite', () => {
     assert.propertyVal(res.body.error, 'code', 500)
     assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getStatusMessagesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessagesCsv',
+        params: {
+          symbol: ['tBTCF0:USTF0'],
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getOrderTradesCsv method', async function () {

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -633,7 +633,6 @@ class FrameworkReportService extends ReportService {
             : symbol
         }
       }
-      console.log('[preparedArgs]:'.bgGreen, preparedArgs)
 
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
@@ -647,7 +646,6 @@ class FrameworkReportService extends ReportService {
 
       const _args = this._publicСollsСonfAccessors
         .getArgs(confs, preparedArgs)
-      console.log('[_args]:'.bgBlue, _args)
 
       return this._dao.findInCollBy(
         '_getStatusMessages',

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -604,6 +604,42 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
+   * @override
+   */
+  getStatusMessages (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        return super.getStatusMessages(space, args)
+      }
+
+      checkParams(args, 'paramsSchemaForStatusMessagesApi')
+
+      const confs = await this._publicСollsСonfAccessors
+        .getPublicСollsСonf(
+          'statusMessagesConf',
+          args
+        )
+
+      if (isEmpty(confs)) {
+        return emptyRes()
+      }
+
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
+
+      return this._dao.findInCollBy(
+        '_getStatusMessages',
+        _args,
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
+      )
+    }, 'getStatusMessages', cb)
+  }
+
+  /**
    * @override
    */
   getOrderTrades (space, args, cb) {

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -612,10 +612,33 @@ class FrameworkReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForStatusMessagesApi')
 
+      const { params } = { ...args }
+      const {
+        type = 'deriv',
+        symbol = ['ALL']
+      } = { ...params }
+      const preparedArgs = {
+        ...args,
+        params: {
+          ...params,
+          type,
+          symbol: (
+            symbol === 'ALL' ||
+            (
+              Array.isArray(symbol) &&
+              symbol[0] === 'ALL'
+            )
+          )
+            ? null
+            : symbol
+        }
+      }
+      console.log('[preparedArgs]:'.bgGreen, preparedArgs)
+
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
           'statusMessagesConf',
-          args
+          preparedArgs
         )
 
       if (isEmpty(confs)) {
@@ -623,7 +646,8 @@ class FrameworkReportService extends ReportService {
       }
 
       const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, args)
+        .getArgs(confs, preparedArgs)
+      console.log('[_args]:'.bgBlue, _args)
 
       return this._dao.findInCollBy(
         '_getStatusMessages',

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -423,6 +423,7 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
    * @override
    */
   getTickersHistory (space, args, cb) {
@@ -443,44 +444,12 @@ class FrameworkReportService extends ReportService {
         return emptyRes()
       }
 
-      const _symb = args.params.symbol
-        ? [args.params.symbol]
-        : []
-      const symbols = Array.isArray(args.params.symbol)
-        ? args.params.symbol
-        : _symb
-      const filteredSymbols = symbols.filter(symb => {
-        return confs.some(conf => symb === conf.symbol)
-      })
-
-      if (
-        !isEmpty(symbols) &&
-        isEmpty(filteredSymbols)
-      ) {
-        return emptyRes()
-      }
-
-      args.params.symbol = filteredSymbols
-
-      const minConfStart = confs.reduce(
-        (accum, conf) => {
-          return (accum === null || conf.start < accum)
-            ? conf.start
-            : accum
-        },
-        null
-      )
-
-      if (
-        Number.isFinite(args.params.start) &&
-        args.params.start < minConfStart
-      ) {
-        args.params.start = minConfStart
-      }
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
 
       return this._dao.findInCollBy(
         '_getTickersHistory',
-        args,
+        _args,
         {
           isPrepareResponse: true,
           isPublic: true
@@ -580,6 +549,7 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
+   * TODO:
    * @override
    */
   getPublicTrades (space, args, cb) {
@@ -590,34 +560,22 @@ class FrameworkReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForPublicTrades', ['symbol'])
 
-      const symbol = Array.isArray(args.params.symbol)
-        ? args.params.symbol[0]
-        : args.params.symbol
-      const { _id } = await this._dao.checkAuthInDb(args)
-      const conf = await this._dao.getElemInCollBy(
-        'publicСollsСonf',
-        {
-          confName: 'publicTradesConf',
-          user_id: _id,
-          symbol
-        },
-        [['symbol', 1]]
-      )
+      const confs = await this._publicСollsСonfAccessors
+        .getPublicСollsСonf(
+          'tickersHistoryConf',
+          args
+        )
 
-      if (isEmpty(conf)) {
+      if (isEmpty(confs)) {
         return emptyRes()
       }
 
-      if (
-        Number.isFinite(args.params.start) &&
-        args.params.start < conf.start
-      ) {
-        args.params.start = conf.start
-      }
+      const _args = this._publicСollsСonfAccessors
+        .getArgs(confs, args)
 
       return this._dao.findInCollBy(
         '_getPublicTrades',
-        args,
+        _args,
         {
           isPrepareResponse: true,
           isPublic: true

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -316,6 +316,13 @@ class FrameworkReportService extends ReportService {
     }, 'getTickersHistoryConf', cb)
   }
 
+  getStatusMessagesConf (space, args = {}, cb) {
+    return this._responder(() => {
+      return this._publicСollsСonfAccessors
+        .getPublicСollsСonf('statusMessagesConf', args)
+    }, 'getStatusMessagesConf', cb)
+  }
+
   editPublicTradesConf (space, args = {}, cb) {
     return this._responder(async () => {
       checkParams(args, 'paramsSchemaForEditPublicСollsСonf')
@@ -338,6 +345,18 @@ class FrameworkReportService extends ReportService {
 
       return true
     }, 'editTickersHistoryConf', cb)
+  }
+
+  editStatusMessagesConf (space, args = {}, cb) {
+    return this._responder(async () => {
+      checkParams(args, 'paramsSchemaForEditPublicСollsСonf')
+
+      await this._publicСollsСonfAccessors
+        .editPublicСollsСonf('statusMessagesConf', args)
+      await this._sync.start(true, this._ALLOWED_COLLS.STATUS_MESSAGES)
+
+      return true
+    }, 'editStatusMessagesConf', cb)
   }
 
   /**

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -442,7 +442,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getTickersHistory (space, args, cb) {
@@ -568,7 +567,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getPublicTrades (space, args, cb) {
@@ -581,7 +579,7 @@ class FrameworkReportService extends ReportService {
 
       const confs = await this._publicСollsСonfAccessors
         .getPublicСollsСonf(
-          'tickersHistoryConf',
+          'publicTradesConf',
           args
         )
 
@@ -604,7 +602,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getStatusMessages (space, args, cb) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -38,6 +38,10 @@ class ReportService extends BaseReportService {
     return super.getPublicTrades(null, args)
   }
 
+  _getStatusMessages (args) {
+    return super.getStatusMessages(null, args)
+  }
+
   _getOrders (args) {
     return super.getOrders(null, args)
   }

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -18,5 +18,6 @@ module.exports = {
   SYMBOLS: 'symbols',
   FUTURES: 'futures',
   CURRENCIES: 'currencies',
-  CANDLES: 'candles'
+  CANDLES: 'candles',
+  STATUS_MESSAGES: 'statusMessages'
 }

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -146,24 +146,20 @@ class PublicСollsСonfAccessors {
       : start
   }
 
-  getSymbol (confs, symbol) {
-    const isSymbolArr = Array.isArray(symbol)
+  getSymbol (confs) {
     const _confs = Array.isArray(confs)
       ? confs
       : [confs]
     const confsSymbols = _confs.map(({ symbol }) => symbol)
 
-    return isSymbolArr
-      ? confsSymbols
-      : confsSymbols[0]
+    return confsSymbols
   }
 
   getArgs (confs, args) {
     const { params } = { ...args }
 
     const symbol = this.getSymbol(
-      confs,
-      params.symbol
+      confs
     )
     const start = this.getStart(
       confs,

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick, isEmpty } = require('lodash')
 const {
   decorate,
   injectable,
@@ -103,13 +103,20 @@ class PublicСollsСonfAccessors {
 
   async getPublicСollsСonf (confName, args) {
     const { _id } = await this.dao.checkAuthInDb(args)
+    const { params } = { ...args }
+    const { symbol } = { ...params }
+    const baseFilter = {
+      confName,
+      user_id: _id
+    }
+    const filter = isEmpty(symbol)
+      ? baseFilter
+      : { ...baseFilter, symbol }
+
     const conf = await this.dao.getElemsInCollBy(
       'publicСollsСonf',
       {
-        filter: {
-          confName,
-          user_id: _id
-        },
+        filter,
         sort: [['symbol', 1]]
       }
     )

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -124,6 +124,61 @@ class PublicСollsСonfAccessors {
 
     return res
   }
+
+  getStart (confs, start = 0) {
+    const _confs = Array.isArray(confs)
+      ? confs
+      : [confs]
+    const minConfStart = _confs.reduce(
+      (accum, conf) => {
+        return (accum === null || conf.start < accum)
+          ? conf.start
+          : accum
+      },
+      null
+    )
+
+    return (
+      Number.isFinite(start) &&
+      start < minConfStart
+    )
+      ? minConfStart
+      : start
+  }
+
+  getSymbol (confs, symbol) {
+    const isSymbolArr = Array.isArray(symbol)
+    const _confs = Array.isArray(confs)
+      ? confs
+      : [confs]
+    const confsSymbols = _confs.map(({ symbol }) => symbol)
+
+    return isSymbolArr
+      ? confsSymbols
+      : confsSymbols[0]
+  }
+
+  getArgs (confs, args) {
+    const { params } = { ...args }
+
+    const symbol = this.getSymbol(
+      confs,
+      params.symbol
+    )
+    const start = this.getStart(
+      confs,
+      params.start
+    )
+
+    return {
+      ...args,
+      params: {
+        ...params,
+        symbol,
+        start
+      }
+    }
+  }
 }
 
 decorate(injectable(), PublicСollsСonfAccessors)

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -34,6 +34,7 @@ const {
   getOrderQuery,
   getUniqueIndexQuery,
   getInsertableArrayObjectsFilter,
+  getStatusMessagesFilter,
   getProjectionQuery,
   getPlaceholdersQuery,
   serializeVal,
@@ -348,10 +349,18 @@ class SqliteDAO extends DAO {
     const _model = { ...model, ...additionalModel }
 
     const exclude = ['_id']
-    const filter = getInsertableArrayObjectsFilter(
+    const statusMessagesfilter = getStatusMessagesFilter(
       methodColl,
       params
     )
+    const insertableArrayObjectsFilter = getInsertableArrayObjectsFilter(
+      methodColl,
+      params
+    )
+    const filter = {
+      ...insertableArrayObjectsFilter,
+      ...statusMessagesfilter
+    }
 
     if (!isPublic) {
       exclude.push('user_id')

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -1,20 +1,10 @@
 'use strict'
 
+const getSymbolFilter = require('./get-symbol-filter')
+
 const _isInsertableArrayObjects = (type = '') => {
   return /^((hidden:)|(public:)|())insertable:array:objects$/i
     .test(type)
-}
-
-const _getSymbFilter = ({ symbol } = {}) => {
-  if (typeof symbol === 'string') {
-    return symbol
-  }
-  if (
-    Array.isArray(symbol) &&
-    symbol.length === 1
-  ) {
-    return symbol[0]
-  }
 }
 
 module.exports = (
@@ -34,15 +24,18 @@ module.exports = (
   const {
     start = 0,
     end = Date.now(),
+    symbol,
     isMarginFundingPayment,
     filter: reqFilter = {}
   } = { ...params }
+  const symbFilter = getSymbolFilter(symbol, symbolFieldName)
   const filter = {
     ...reqFilter,
     _dateFieldName: dateFieldName,
     start,
     end,
-    ...additionalFilteringProps
+    ...additionalFilteringProps,
+    ...symbFilter
   }
 
   if (
@@ -51,12 +44,6 @@ module.exports = (
       .some(key => key === '_isMarginFundingPayment')
   ) {
     filter._isMarginFundingPayment = Number(isMarginFundingPayment)
-  }
-
-  const symbFilter = _getSymbFilter(params)
-
-  if (symbFilter) {
-    filter[symbolFieldName] = symbFilter
   }
 
   return filter

--- a/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const ALLOWED_COLLS = require('../../allowed.colls')
+const getSymbolFilter = require('./get-symbol-filter')
+
+module.exports = (
+  {
+    name,
+    symbolFieldName,
+    additionalFilteringProps
+  } = {},
+  params = {}
+) => {
+  if (name !== ALLOWED_COLLS.STATUS_MESSAGES) {
+    return {}
+  }
+
+  const {
+    type,
+    symbol,
+    filter: reqFilter = {}
+  } = { ...params }
+  const symbFilter = getSymbolFilter(symbol, symbolFieldName)
+  const filter = {
+    ...reqFilter,
+    _type: type,
+    ...additionalFilteringProps,
+    ...symbFilter
+  }
+
+  return filter
+}

--- a/workers/loc.api/sync/dao/helpers/get-symbol-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-symbol-filter.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = (symbol, symbolFieldName) => {
+  if (typeof symbol === 'string') {
+    return { [symbolFieldName]: symbol }
+  }
+  if (
+    Array.isArray(symbol) &&
+    symbol.length === 1
+  ) {
+    return { [symbolFieldName]: symbol[0] }
+  }
+
+  return {}
+}

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -19,6 +19,7 @@ const getGroupQuery = require('./get-group-query')
 const getSubQuery = require('./get-sub-query')
 const filterModelNameMap = require('./filter-model-name-map')
 const SQL_OPERATORS = require('./sql.operators')
+const getSymbolFilter = require('./get-symbol-filter')
 
 module.exports = {
   mixUserIdToArrData,
@@ -35,5 +36,6 @@ module.exports = {
   getGroupQuery,
   getSubQuery,
   filterModelNameMap,
-  SQL_OPERATORS
+  SQL_OPERATORS,
+  getSymbolFilter
 }

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -20,6 +20,7 @@ const getSubQuery = require('./get-sub-query')
 const filterModelNameMap = require('./filter-model-name-map')
 const SQL_OPERATORS = require('./sql.operators')
 const getSymbolFilter = require('./get-symbol-filter')
+const getStatusMessagesFilter = require('./get-status-messages-filter')
 
 module.exports = {
   mixUserIdToArrData,
@@ -37,5 +38,6 @@ module.exports = {
   getSubQuery,
   filterModelNameMap,
   SQL_OPERATORS,
-  getSymbolFilter
+  getSymbolFilter,
+  getStatusMessagesFilter
 }

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -7,6 +7,7 @@ const {
 } = require('inversify')
 
 const TYPES = require('../../di/types')
+const { addPropsToResIfExist } = require('./helpers')
 
 class ApiMiddlewareHandlerAfter {
   constructor (
@@ -88,19 +89,11 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getPublicTrades (args, apiRes) {
-    if (args.params.symbol) {
-      const res = apiRes.res.map(item => ({
-        ...item,
-        _symbol: args.params.symbol
-      }))
-
-      return {
-        ...apiRes,
-        res
-      }
-    }
-
-    return apiRes
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'symbol', to: '_symbol' }]
+    )
   }
 
   _getLedgers (args, apiRes) {
@@ -118,19 +111,20 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getCandles (args, apiRes) {
-    if (args.params.symbol) {
-      const res = apiRes.res.map(item => ({
-        ...item,
-        _symbol: args.params.symbol
-      }))
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'symbol', to: '_symbol' }]
+    )
+  }
 
-      return {
-        ...apiRes,
-        res
-      }
-    }
-
-    return apiRes
+  _getStatusMessages (args, apiRes) {
+    console.log('[status-mess-args]:'.bgBlue, args)
+    return addPropsToResIfExist(
+      args,
+      apiRes,
+      [{ from: 'type', to: '_type' }]
+    )
   }
 }
 

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -119,7 +119,6 @@ class ApiMiddlewareHandlerAfter {
   }
 
   _getStatusMessages (args, apiRes) {
-    console.log('[status-mess-args]:'.bgBlue, args)
     return addPropsToResIfExist(
       args,
       apiRes,

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -13,7 +13,8 @@ const {
   compareElemsDbAndApi,
   normalizeApiData,
   getAuthFromDb,
-  getAllowedCollsNames
+  getAllowedCollsNames,
+  addPropsToResIfExist
 } = require('./utils')
 const convertCurrency = require('./convert-currency')
 
@@ -27,5 +28,6 @@ module.exports = {
   normalizeApiData,
   getAuthFromDb,
   getAllowedCollsNames,
-  convertCurrency
+  convertCurrency,
+  addPropsToResIfExist
 }

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -100,6 +100,65 @@ const getAllowedCollsNames = (allowedColls) => {
     .filter(name => !(/^_.*/.test(name)))
 }
 
+const addPropsToResIfExist = (
+  args = {},
+  apiRes = [],
+  props = []
+) => {
+  const { params } = { ...args }
+  const isApiResObject = (
+    apiRes &&
+    typeof apiRes === 'object' &&
+    !Array.isArray(apiRes)
+  )
+  const incomingRes = (
+    isApiResObject &&
+    Array.isArray(apiRes.res)
+  )
+    ? apiRes.res
+    : apiRes
+  const isEmptyProps = props.every(({ from, to }) => {
+    return (
+      typeof to !== 'string' ||
+      typeof from !== 'string' ||
+      typeof params[from] === 'undefined'
+    )
+  })
+
+  if (
+    !Array.isArray(incomingRes) ||
+    isEmptyProps
+  ) {
+    return apiRes
+  }
+
+  const res = incomingRes.map((item) => {
+    const additionalProps = props.reduce((accum, { from, to }) => {
+      if (
+        typeof to !== 'string' ||
+        typeof from !== 'string' ||
+        typeof params[from] === 'undefined'
+      ) {
+        return accum
+      }
+
+      return {
+        ...accum,
+        [to]: params[from]
+      }
+    }, {})
+
+    return {
+      ...item,
+      ...additionalProps
+    }
+  })
+
+  return isApiResObject
+    ? { ...apiRes, res }
+    : res
+}
+
 module.exports = {
   invertSort,
   filterMethodCollMap,
@@ -107,5 +166,6 @@ module.exports = {
   compareElemsDbAndApi,
   normalizeApiData,
   getAuthFromDb,
-  getAllowedCollsNames
+  getAllowedCollsNames,
+  addPropsToResIfExist
 }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -731,7 +731,8 @@ class DataInserter extends EventEmitter {
           symbol,
           filter: {
             $gte: { [dateFieldName]: start }
-          }
+          },
+          type: 'deriv' // TODO:
         }
       )
       const apiRes = await this._getDataFromApi(methodApi, args)

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -694,6 +694,82 @@ class DataInserter extends EventEmitter {
     }
   }
 
+  async _updateConfigurableApiDataArrObjTypeToDb (
+    methodApi,
+    schema
+  ) {
+    const {
+      dateFieldName,
+      name: collName,
+      fields,
+      model
+    } = { ...schema }
+
+    const publicСollsСonf = await this.dao.getElemsInCollBy(
+      'publicСollsСonf',
+      {
+        filter: { confName: schema.confName },
+        minPropName: 'start',
+        groupPropName: 'symbol'
+      }
+    )
+
+    if (isEmpty(publicСollsСonf)) {
+      return
+    }
+
+    const elemsFromApi = []
+
+    for (const { symbol, start } of publicСollsСonf) {
+      const args = this._getMethodArgMap(
+        methodApi,
+        {},
+        null,
+        null,
+        null,
+        {
+          symbol,
+          filter: {
+            $gte: { [dateFieldName]: start }
+          }
+        }
+      )
+      const apiRes = await this._getDataFromApi(methodApi, args)
+      const oneSymbElemsFromApi = (
+        apiRes &&
+        typeof apiRes === 'object' &&
+        !Array.isArray(apiRes) &&
+        Array.isArray(apiRes.res)
+      )
+        ? apiRes.res
+        : apiRes
+
+      if (!Array.isArray(oneSymbElemsFromApi)) {
+        continue
+      }
+
+      elemsFromApi.push(...oneSymbElemsFromApi)
+    }
+
+    if (elemsFromApi.length > 0) {
+      const lists = fields.reduce((obj, curr) => {
+        obj[curr] = elemsFromApi.map(item => item[curr])
+
+        return obj
+      }, {})
+
+      await this.dao.removeElemsFromDbIfNotInLists(
+        collName,
+        lists
+      )
+      await this.dao.insertElemsToDbIfNotExists(
+        collName,
+        null,
+        normalizeApiData(elemsFromApi, model)
+      )
+    }
+  }
+
   async _updateApiDataArrObjTypeToDb (
     methodApi,
     schema
@@ -706,10 +782,33 @@ class DataInserter extends EventEmitter {
       name: collName,
       fields,
       model
-    } = schema
+    } = { ...schema }
 
-    const args = this._getMethodArgMap(methodApi, {}, null, null, null)
-    const elemsFromApi = await this._getDataFromApi(methodApi, args)
+    if (collName === this.ALLOWED_COLLS.STATUS_MESSAGES) {
+      await this._updateConfigurableApiDataArrObjTypeToDb(
+        methodApi,
+        schema
+      )
+
+      return
+    }
+
+    const args = this._getMethodArgMap(
+      methodApi,
+      {},
+      null,
+      null,
+      null
+    )
+    const apiRes = await this._getDataFromApi(methodApi, args)
+    const elemsFromApi = (
+      apiRes &&
+      typeof apiRes === 'object' &&
+      !Array.isArray(apiRes) &&
+      Array.isArray(apiRes.res)
+    )
+      ? apiRes.res
+      : apiRes
 
     if (
       Array.isArray(elemsFromApi) &&
@@ -738,8 +837,13 @@ class DataInserter extends EventEmitter {
     auth,
     limit,
     start = 0,
-    end = Date.now()
+    end = Date.now(),
+    params
   ) {
+    const _limit = limit !== null
+      ? limit
+      : this._methodCollMap.get(method).maxLimit
+
     return {
       auth: {
         ...(auth && typeof auth === 'object'
@@ -750,9 +854,8 @@ class DataInserter extends EventEmitter {
           })
       },
       params: {
-        limit: limit !== null
-          ? limit
-          : this._methodCollMap.get(method).maxLimit,
+        ...params,
+        limit: _limit,
         end,
         start
       }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -718,38 +718,41 @@ class DataInserter extends EventEmitter {
       return
     }
 
+    const syncingTypes = ['deriv']
     const elemsFromApi = []
 
     for (const { symbol, start } of publicСollsСonf) {
-      const args = this._getMethodArgMap(
-        methodApi,
-        {},
-        null,
-        null,
-        null,
-        {
-          symbol,
-          filter: {
-            $gte: { [dateFieldName]: start }
-          },
-          type: 'deriv' // TODO:
+      for (const type of syncingTypes) {
+        const args = this._getMethodArgMap(
+          methodApi,
+          {},
+          null,
+          null,
+          null,
+          {
+            symbol,
+            filter: {
+              $gte: { [dateFieldName]: start }
+            },
+            type
+          }
+        )
+        const apiRes = await this._getDataFromApi(methodApi, args)
+        const oneSymbElemsFromApi = (
+          apiRes &&
+          typeof apiRes === 'object' &&
+          !Array.isArray(apiRes) &&
+          Array.isArray(apiRes.res)
+        )
+          ? apiRes.res
+          : apiRes
+
+        if (!Array.isArray(oneSymbElemsFromApi)) {
+          continue
         }
-      )
-      const apiRes = await this._getDataFromApi(methodApi, args)
-      const oneSymbElemsFromApi = (
-        apiRes &&
-        typeof apiRes === 'object' &&
-        !Array.isArray(apiRes) &&
-        Array.isArray(apiRes.res)
-      )
-        ? apiRes.res
-        : apiRes
 
-      if (!Array.isArray(oneSymbElemsFromApi)) {
-        continue
+        elemsFromApi.push(...oneSymbElemsFromApi)
       }
-
-      elemsFromApi.push(...oneSymbElemsFromApi)
     }
 
     if (elemsFromApi.length > 0) {

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -436,6 +436,22 @@ const _methodCollMap = new Map([
     }
   ],
   [
+    '_getStatusMessages',
+    {
+      name: ALLOWED_COLLS.STATUS_MESSAGES,
+      maxLimit: 5000,
+      dateFieldName: 'timestamp',
+      symbolFieldName: 'key',
+      sort: [['timestamp', -1]],
+      hasNewData: false,
+      start: [],
+      confName: 'statusMessagesConf',
+      type: 'public:updatable:array:objects', // TODO:
+      fieldsOfUniqueIndex: ['timestamp', 'key'],
+      model: { ..._models.get(ALLOWED_COLLS.PUBLIC_TRADES) }
+    }
+  ],
+  [
     '_getOrders',
     {
       name: ALLOWED_COLLS.ORDERS,

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -278,6 +278,19 @@ const _models = new Map([
     }
   ],
   [
+    ALLOWED_COLLS.STATUS_MESSAGES,
+    {
+      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      key: 'VARCHAR(255)',
+      timestamp: 'BIGINT',
+      price: 'DECIMAL(22,12)',
+      priceSpot: 'DECIMAL(22,12)',
+      fundBal: 'DECIMAL(22,12)',
+      fundingAccrued: 'DECIMAL(22,12)',
+      fundingStep: 'DECIMAL(22,12)'
+    }
+  ],
+  [
     'publicСollsСonf',
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -440,15 +440,23 @@ const _methodCollMap = new Map([
     {
       name: ALLOWED_COLLS.STATUS_MESSAGES,
       maxLimit: 5000,
+      fields: [
+        'key',
+        'timestamp',
+        'price',
+        'priceSpot',
+        'fundBal',
+        'fundingAccrued',
+        'fundingStep'
+      ],
       dateFieldName: 'timestamp',
       symbolFieldName: 'key',
       sort: [['timestamp', -1]],
-      hasNewData: false,
-      start: [],
+      hasNewData: true,
       confName: 'statusMessagesConf',
-      type: 'public:updatable:array:objects', // TODO:
+      type: 'public:updatable:array:objects',
       fieldsOfUniqueIndex: ['timestamp', 'key'],
-      model: { ..._models.get(ALLOWED_COLLS.PUBLIC_TRADES) }
+      model: { ..._models.get(ALLOWED_COLLS.STATUS_MESSAGES) }
     }
   ],
   [

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -456,7 +456,7 @@ const _methodCollMap = new Map([
       hasNewData: true,
       confName: 'statusMessagesConf',
       type: 'public:updatable:array:objects',
-      fieldsOfUniqueIndex: ['timestamp', 'key'],
+      fieldsOfUniqueIndex: ['timestamp', 'key', '_type'],
       model: { ..._models.get(ALLOWED_COLLS.STATUS_MESSAGES) }
     }
   ],

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -287,7 +287,8 @@ const _models = new Map([
       priceSpot: 'DECIMAL(22,12)',
       fundBal: 'DECIMAL(22,12)',
       fundingAccrued: 'DECIMAL(22,12)',
-      fundingStep: 'DECIMAL(22,12)'
+      fundingStep: 'DECIMAL(22,12)',
+      _type: 'VARCHAR(255)'
     }
   ],
   [


### PR DESCRIPTION
This PR adds status messages report to sync mode. Basic changes:
  - adds `getStatusMessagesConf` method to the main service
  - adds `editStatusMessagesConf` method to the main service
  - adds `getStatusMessages` method to the main service
  - adds corresponding test coverage

Example of a request:
```js
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getStatusMessagesCsv",
    "params": {
    	"type": "deriv", // by default
    	"symbol": ["tBTCF0:USTF0", "tETHF0:USTF0"],  // ['ALL'] by default
    }
}
```

**Depends** on this PR: [bitfinexcom/bfx-report#149](https://github.com/bitfinexcom/bfx-report/pull/149)