### PR TITLE
Add ability to not start migrations at first start

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "yargs": "^13.2.4",
-    "sqlite3": "4.0.3"
+    "sqlite3": "4.1.1"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -53,6 +53,11 @@ class DAO {
   /**
    * @abstract
    */
+  async isDBEmpty () {}
+
+  /**
+   * @abstract
+   */
   async getCurrDbVer () { throw new ImplementationError() }
 
   /**

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -238,6 +238,18 @@ class SqliteDAO extends DAO {
   /**
    * @override
    */
+  async isDBEmpty () {
+    const tablesNames = await this.getTablesNames()
+
+    return (
+      !Array.isArray(tablesNames) ||
+      tablesNames.length === 0
+    )
+  }
+
+  /**
+   * @override
+   */
   async getCurrDbVer () {
     const data = await this._get('PRAGMA user_version')
     const { user_version: version } = { ...data }

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -104,6 +104,12 @@ class DbMigrator {
    * @abstract
    */
   async migrateFromCurrToSupportedVer () {
+    const isDBEmpty = await this.dao.isDBEmpty()
+
+    if (isDBEmpty) {
+      return
+    }
+
     const supportedVer = this.getSupportedDbVer()
     const currVer = await this.dao.getCurrDbVer()
 


### PR DESCRIPTION
This PR adds an ability to not start migrations at the first start and bumps up `sqlite3` version to `4.1.1`