### PR TITLE
Add performing loan report

### DIFF
--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -484,6 +484,38 @@ describe('Additional sync mode API with SQLite', () => {
     }
   })
 
+  it('it should be successfully performed by the getPerformingLoan method', async function () {
+    this.timeout(10000)
+
+    const paramsArr = getParamsArrToTestTimeframeGrouping({ start, end })
+
+    for (const params of paramsArr) {
+      const res = await agent
+        .post(`${basePath}/get-data`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getPerformingLoan',
+          params,
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isArray(res.body.result)
+
+      const resItem = res.body.result[0]
+
+      assert.isObject(resItem)
+      assert.containsAllKeys(resItem, [
+        'mts',
+        'USD'
+      ])
+    }
+  })
+
   it('it should be successfully performed by the getMultipleCsv method', async function () {
     this.timeout(60000)
 

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -731,4 +731,30 @@ describe('Additional sync mode API with SQLite', () => {
 
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
+
+  it('it should be successfully performed by the getPerformingLoanCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getPerformingLoanCsv',
+        params: {
+          end,
+          start,
+          timeframe: 'day',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
 })

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -48,6 +48,7 @@ const FullSnapshotReport = require('../sync/full.snapshot.report')
 const Trades = require('../sync/trades')
 const TradedVolume = require('../sync/traded.volume')
 const FeesReport = require('../sync/fees.report')
+const PerformingLoan = require('../sync/performing.loan')
 const CurrencyConverter = require('../sync/currency.converter')
 const CsvJobData = require('../generate-csv/csv.job.data')
 const {
@@ -90,7 +91,8 @@ module.exports = ({
           ['_fullSnapshotReport', TYPES.FullSnapshotReport],
           ['_fullTaxReport', TYPES.FullTaxReport],
           ['_tradedVolume', TYPES.TradedVolume],
-          ['_feesReport', TYPES.FeesReport]
+          ['_feesReport', TYPES.FeesReport],
+          ['_performingLoan', TYPES.PerformingLoan]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)
@@ -204,6 +206,8 @@ module.exports = ({
       .to(TradedVolume)
     bind(TYPES.FeesReport)
       .to(FeesReport)
+    bind(TYPES.PerformingLoan)
+      .to(PerformingLoan)
     bind(TYPES.FullSnapshotReportCsvWriter)
       .toConstantValue(
         bindDepsToFn(

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -39,5 +39,6 @@ module.exports = {
   SqliteDbMigrator: Symbol.for('SqliteDbMigrator'),
   Trades: Symbol.for('Trades'),
   TradedVolume: Symbol.for('TradedVolume'),
-  FeesReport: Symbol.for('FeesReport')
+  FeesReport: Symbol.for('FeesReport'),
+  PerformingLoan: Symbol.for('PerformingLoan')
 }

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -466,6 +466,44 @@ class CsvJobData extends BaseCsvJobData {
 
     return jobData
   }
+
+  async getPerformingLoanCsvCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForPerformingLoanCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getPerformingLoan',
+      fileNamesMap: [['getPerformingLoan', 'performing-loan']],
+      args: csvArgs,
+      propNameForPagination: null,
+      columnsCsv: {
+        USD: 'USD',
+        mts: 'DATE'
+      },
+      formatSettings: {
+        mts: 'date'
+      }
+    }
+
+    return jobData
+  }
 }
 
 decorate(inject(TYPES.RService), CsvJobData, 0)

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -191,6 +191,29 @@ const paramsSchemaForFeesReportApi = {
   }
 }
 
+const paramsSchemaForPerformingLoanApi = {
+  type: 'object',
+  properties: {
+    timeframe: {
+      type: 'string',
+      enum: [
+        'day',
+        'month',
+        'year'
+      ]
+    },
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    },
+    symbol: {
+      type: ['string', 'array']
+    }
+  }
+}
+
 const {
   timezone,
   dateFormat
@@ -282,6 +305,7 @@ module.exports = {
   paramsSchemaForFullTaxReportApi,
   paramsSchemaForTradedVolumeApi,
   paramsSchemaForFeesReportApi,
+  paramsSchemaForPerformingLoanApi,
   paramsSchemaForRiskCsv,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -295,6 +295,15 @@ const paramsSchemaForFeesReportCsv = {
   }
 }
 
+const paramsSchemaForPerformingLoanCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForPerformingLoanApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 module.exports = {
   paramsSchemaForCandlesApi,
   paramsSchemaForRiskApi,
@@ -313,5 +322,6 @@ module.exports = {
   paramsSchemaForFullSnapshotReportCsv,
   paramsSchemaForFullTaxReportCsv,
   paramsSchemaForTradedVolumeCsv,
-  paramsSchemaForFeesReportCsv
+  paramsSchemaForFeesReportCsv,
+  paramsSchemaForPerformingLoanCsv
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -883,11 +883,22 @@ class FrameworkReportService extends ReportService {
       if (!await this.isSyncModeWithDbData(space, args)) {
         throw new DuringSyncMethodAccessError()
       }
-
       checkParams(args, 'paramsSchemaForFeesReportApi')
 
       return this._feesReport.getFeesReport(args)
     }, 'getFeesReport', cb)
+  }
+
+  getPerformingLoan (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        throw new DuringSyncMethodAccessError()
+      }
+
+      checkParams(args, 'paramsSchemaForPerformingLoanApi')
+
+      return this._performingLoan.getPerformingLoan(args)
+    }, 'getPerformingLoan', cb)
   }
 
   /**

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -975,6 +975,15 @@ class FrameworkReportService extends ReportService {
       )
     }, 'getFeesReportCsv', cb)
   }
+
+  getPerformingLoanCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getPerformingLoanCsvCsvJobData',
+        args
+      )
+    }, 'getPerformingLoanCsv', cb)
+  }
 }
 
 module.exports = FrameworkReportService

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -883,6 +883,7 @@ class FrameworkReportService extends ReportService {
       if (!await this.isSyncModeWithDbData(space, args)) {
         throw new DuringSyncMethodAccessError()
       }
+
       checkParams(args, 'paramsSchemaForFeesReportApi')
 
       return this._feesReport.getFeesReport(args)

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+const {
+  calcGroupedData,
+  groupByTimeframe
+} = require('../helpers')
+
+class PerformingLoan {
+  constructor (
+    dao,
+    ALLOWED_COLLS,
+    syncSchema,
+    FOREX_SYMBS
+  ) {
+    this.dao = dao
+    this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.syncSchema = syncSchema
+    this.FOREX_SYMBS = FOREX_SYMBS
+
+    this.tradesMethodColl = this.syncSchema.getMethodCollMap()
+      .get('_getLedgers')
+  }
+
+  async _getLedgers ({
+    auth,
+    start,
+    end,
+    symbol
+  }) {
+    const user = await this.dao.checkAuthInDb({ auth })
+
+    const symbFilter = (
+      Array.isArray(symbol) &&
+      symbol.length !== 0
+    )
+      ? { $in: { currency: symbol } }
+      : {}
+    const ledgersModel = this.syncSchema.getModelsMap()
+      .get(this.ALLOWED_COLLS.LEDGERS)
+
+    return this.dao.getElemsInCollBy(
+      this.ALLOWED_COLLS.LEDGERS,
+      {
+        filter: {
+          user_id: user._id,
+          $lte: { mts: end },
+          $gte: { mts: start },
+          $eq: { _isMarginFundingPayment: 1 },
+          ...symbFilter
+        },
+        sort: [['mts', -1]],
+        projection: ledgersModel,
+        exclude: ['user_id'],
+        isExcludePrivate: true
+      }
+    )
+  }
+
+  _calcLedgers () {
+    return (data = []) => data.reduce((accum, trade = {}) => {
+      const { amountUsd } = { ...trade }
+
+      if (!Number.isFinite(amountUsd)) {
+        return { ...accum }
+      }
+
+      return {
+        ...accum,
+        USD: Number.isFinite(accum.USD)
+          ? accum.USD + amountUsd
+          : amountUsd
+      }
+    }, {})
+  }
+
+  _getLedgersByTimeframe () {
+    return ({ ledgersGroupedByTimeframe = {} }) => {
+      const ledgersArr = Object.entries(ledgersGroupedByTimeframe)
+      const res = ledgersArr.reduce((
+        accum,
+        [symb, amount]
+      ) => {
+        if (
+          symb !== 'USD' ||
+          !Number.isFinite(amount)
+        ) {
+          return { ...accum }
+        }
+
+        return {
+          ...accum,
+          [symb]: amount
+        }
+      }, {})
+
+      return res
+    }
+  }
+
+  async getPerformingLoan (
+    {
+      auth = {},
+      params = {}
+    } = {}
+  ) {
+    const {
+      start = 0,
+      end = Date.now(),
+      timeframe = 'day',
+      symbol: symbs
+    } = { ...params }
+    const _symbol = Array.isArray(symbs)
+      ? symbs
+      : [symbs]
+    const symbol = _symbol.filter((s) => (
+      s && typeof s === 'string'
+    ))
+    const args = {
+      auth,
+      start,
+      end,
+      symbol
+    }
+
+    const ledgers = await this._getLedgers(args)
+
+    const {
+      dateFieldName: ledgersDateFieldName,
+      symbolFieldName: ledgersSymbolFieldName
+    } = this.tradesMethodColl
+
+    const ledgersGroupedByTimeframe = await groupByTimeframe(
+      ledgers,
+      timeframe,
+      this.FOREX_SYMBS,
+      ledgersDateFieldName,
+      ledgersSymbolFieldName,
+      this._calcLedgers()
+    )
+
+    const groupedData = await calcGroupedData(
+      { ledgersGroupedByTimeframe },
+      false,
+      this._getLedgersByTimeframe(),
+      true
+    )
+
+    return groupedData
+  }
+}
+
+decorate(injectable(), PerformingLoan)
+decorate(inject(TYPES.DAO), PerformingLoan, 0)
+decorate(inject(TYPES.ALLOWED_COLLS), PerformingLoan, 1)
+decorate(inject(TYPES.SyncSchema), PerformingLoan, 2)
+decorate(inject(TYPES.FOREX_SYMBS), PerformingLoan, 3)
+
+module.exports = PerformingLoan


### PR DESCRIPTION
This PR adds performing loan report in USD equivalent. Basic changes:
  - adds `getPerformingLoan` method to the grenache service
  - adds `getPerformingLoanCsv` method to the grenache service
  - adds corresponding test coverage

Request example to the `getPerformingLoan` method:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getPerformingLoan",
    "params": {
    	"start": 1557192620000,
    	"end": 1574386215000,
    	"timeframe": "day",
    	"symbol": ["BTC", "EOS"]
    }
}
```

Response example:
```json
{
    "result": [
        {
            "mts": 1575676800000,
            "USD": 123
        },
        {
            "mts": 1575590400000,
            "USD": 321
        },
        {
            "mts": 1575417600000,
            "USD": 213
        }
    ],
    "id": null
}
```