### PR TITLE
Fix name typo for performing loan csv method

### DIFF
--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -467,7 +467,7 @@ class CsvJobData extends BaseCsvJobData {
     return jobData
   }
 
-  async getPerformingLoanCsvCsvJobData (
+  async getPerformingLoanCsvJobData (
     args,
     uId,
     uInfo

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -980,7 +980,7 @@ class FrameworkReportService extends ReportService {
   getPerformingLoanCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(
-        'getPerformingLoanCsvCsvJobData',
+        'getPerformingLoanCsvJobData',
         args
       )
     }, 'getPerformingLoanCsv', cb)


### PR DESCRIPTION
This PR fixes name typo for the `getPerformingLoanCsv` method to generate csv in the `getMultipleCsv` method