### PR TITLE
Improve performing loan report

### DIFF
--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -511,7 +511,9 @@ describe('Additional sync mode API with SQLite', () => {
       assert.isObject(resItem)
       assert.containsAllKeys(resItem, [
         'mts',
-        'USD'
+        'USD',
+        'cumulative',
+        'perc'
       ])
     }
   })

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -495,6 +495,8 @@ class CsvJobData extends BaseCsvJobData {
       propNameForPagination: null,
       columnsCsv: {
         USD: 'USD',
+        cumulative: 'CUMULATIVE USD',
+        perc: 'PERCENT FOR YEAR',
         mts: 'DATE'
       },
       formatSettings: {

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -112,6 +112,9 @@ class PerformingLoan {
           accum[accum.length - 1].push(
             this._calcPerc(amount, balance)
           )
+          prevMts = mts
+
+          return accum
         }
 
         accum.push([this._calcPerc(amount, balance)])

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -175,7 +175,7 @@ class PerformingLoan {
   }
 
   _getLedgersByTimeframe () {
-    let _cumulative = 0
+    let cumulative = 0
 
     return ({ ledgersGroupedByTimeframe = {}, mts }) => {
       const ledgersArr = Object.entries(ledgersGroupedByTimeframe)
@@ -196,8 +196,7 @@ class PerformingLoan {
         }
       }, {})
       const perc = this._calcAmountPerc(ledgersGroupedByTimeframe)
-      const cumulative = _cumulative
-      _cumulative = this._calcPrevAmount(res, cumulative)
+      cumulative = this._calcPrevAmount(res, cumulative)
 
       return {
         cumulative,


### PR DESCRIPTION
This PR improves the performing loan report. Basic changes:
  - adds `cumulative` variable to each response as the acum of the past and current values on the queried period
  - adds `perc` variable to each response as a percent for the year:
    `( amount / balance * 365 * 100 )`
  - improves corresponding test coverage
  - adds the fields to the performing loan report csv