### PR TITLE
Enable api calls for public endpoints by default

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -1649,6 +1649,43 @@ module.exports = (
     ])
   })
 
+  it('it should be successfully performed by the getPublicTrades method, with not synced symbol', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getPublicTrades',
+        params: {
+          symbol: 'tEOSEUR',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'mts',
+      'amount',
+      'price'
+    ])
+  })
+
   it('it should be successfully performed by the getPublicTrades method, where the symbol is an array with length equal to one', async function () {
     this.timeout(5000)
 
@@ -1787,7 +1824,7 @@ module.exports = (
     ])
   })
 
-  it('it should be returned empty array by the getCandles method', async function () {
+  it('it should be returned from api_v2 by the getCandles method, with not synced symbol', async function () {
     this.timeout(5000)
 
     const res = await agent
@@ -1797,7 +1834,7 @@ module.exports = (
         auth,
         method: 'getCandles',
         params: {
-          symbol: 'tBTCUSD',
+          symbol: 'tEOSEUR',
           timeframe: '1h'
         },
         id: 5
@@ -1810,7 +1847,18 @@ module.exports = (
     assert.isObject(res.body.result)
     assert.isArray(res.body.result.res)
     assert.isBoolean(res.body.result.nextPage)
-    assert.lengthOf(res.body.result.res, 0)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'mts',
+      'open',
+      'close',
+      'high',
+      'low',
+      'volume'
+    ])
   })
 
   it('it should be successfully performed by the getOrderTrades method', async function () {

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -131,6 +131,12 @@ class DatePropNameError extends BaseError {
   }
 }
 
+class GetPublicDataError extends BaseError {
+  constructor (message = 'ERR_GETTING_PUBLIC_DATA_HAS_FAILED') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -153,5 +159,6 @@ module.exports = {
   SubAccountCreatingError,
   SubAccountRemovingError,
   SubAccountLedgersBalancesRecalcError,
-  DatePropNameError
+  DatePropNameError,
+  GetPublicDataError
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -3,7 +3,6 @@
 const checkParams = require('./check-params')
 const {
   checkParamsAuth,
-  emptyRes,
   tryParseJSON,
   collObjToArr,
   refreshObj,
@@ -23,7 +22,6 @@ const {
 module.exports = {
   checkParams,
   checkParamsAuth,
-  emptyRes,
   tryParseJSON,
   collObjToArr,
   refreshObj,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -19,10 +19,6 @@ const checkParamsAuth = (args) => {
   }
 }
 
-const emptyRes = () => {
-  return { res: [], nextPage: false }
-}
-
 const tryParseJSON = (
   jsonString,
   isNotObject
@@ -114,7 +110,6 @@ const mapObjBySchema = (obj, schema = {}) => {
 
 module.exports = {
   checkParamsAuth,
-  emptyRes,
   tryParseJSON,
   collObjToArr,
   refreshObj,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -775,27 +775,16 @@ class FrameworkReportService extends ReportService {
         }
       }
 
-      const confs = await this._publicСollsСonfAccessors
-        .getPublicСollsСonf(
-          'candlesConf',
-          argsWithParamsByDefault
+      return this._publicСollsСonfAccessors
+        .getPublicData(
+          (args) => super.getCandles(space, args),
+          argsWithParamsByDefault,
+          {
+            collName: '_getCandles',
+            confName: 'candlesConf',
+            datePropName: 'mts'
+          }
         )
-
-      if (isEmpty(confs)) {
-        return super.getCandles(space, args)
-      }
-
-      const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, argsWithParamsByDefault)
-
-      return this._dao.findInCollBy(
-        '_getCandles',
-        _args,
-        {
-          isPrepareResponse: true,
-          isPublic: true
-        }
-      )
     }, 'getCandles', cb)
   }
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -522,41 +522,6 @@ class FrameworkReportService extends ReportService {
   /**
    * @override
    */
-  getTickersHistory (space, args, cb) {
-    return this._responder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        return super.getTickersHistory(space, args)
-      }
-
-      checkParams(args, 'paramsSchemaForApi', ['symbol'])
-
-      const confs = await this._publicСollsСonfAccessors
-        .getPublicСollsСonf(
-          'tickersHistoryConf',
-          args
-        )
-
-      if (isEmpty(confs)) {
-        return super.getTickersHistory(space, args)
-      }
-
-      const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, args)
-
-      return this._dao.findInCollBy(
-        '_getTickersHistory',
-        _args,
-        {
-          isPrepareResponse: true,
-          isPublic: true
-        }
-      )
-    }, 'getTickersHistory', cb)
-  }
-
-  /**
-   * @override
-   */
   getPositionsHistory (space, args, cb) {
     return this._responder(async () => {
       if (!await this.isSyncModeWithDbData(space, args)) {
@@ -689,6 +654,30 @@ class FrameworkReportService extends ReportService {
         { isPrepareResponse: true }
       )
     }, 'getFundingTrades', cb)
+  }
+
+  /**
+   * @override
+   */
+  getTickersHistory (space, args, cb) {
+    return this._responder(async () => {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        return super.getTickersHistory(space, args)
+      }
+
+      checkParams(args, 'paramsSchemaForApi', ['symbol'])
+
+      return this._publicСollsСonfAccessors
+        .getPublicData(
+          (args) => super.getTickersHistory(space, args),
+          args,
+          {
+            collName: '_getTickersHistory',
+            confName: 'tickersHistoryConf',
+            datePropName: 'mtsUpdate'
+          }
+        )
+    }, 'getTickersHistory', cb)
   }
 
   /**

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -737,27 +737,16 @@ class FrameworkReportService extends ReportService {
         }
       }
 
-      const confs = await this._publicСollsСonfAccessors
-        .getPublicСollsСonf(
-          'statusMessagesConf',
-          preparedArgs
+      return this._publicСollsСonfAccessors
+        .getPublicData(
+          (args) => super.getStatusMessages(space, args),
+          preparedArgs,
+          {
+            collName: '_getStatusMessages',
+            confName: 'statusMessagesConf',
+            datePropName: 'timestamp'
+          }
         )
-
-      if (isEmpty(confs)) {
-        return super.getStatusMessages(space, args)
-      }
-
-      const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, preparedArgs)
-
-      return this._dao.findInCollBy(
-        '_getStatusMessages',
-        _args,
-        {
-          isPrepareResponse: true,
-          isPublic: true
-        }
-      )
     }, 'getStatusMessages', cb)
   }
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -691,27 +691,16 @@ class FrameworkReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForPublicTrades', ['symbol'])
 
-      const confs = await this._publicСollsСonfAccessors
-        .getPublicСollsСonf(
-          'publicTradesConf',
-          args
+      return this._publicСollsСonfAccessors
+        .getPublicData(
+          (args) => super.getPublicTrades(space, args),
+          args,
+          {
+            collName: '_getPublicTrades',
+            confName: 'publicTradesConf',
+            datePropName: 'mts'
+          }
         )
-
-      if (isEmpty(confs)) {
-        return super.getPublicTrades(space, args)
-      }
-
-      const _args = this._publicСollsСonfAccessors
-        .getArgs(confs, args)
-
-      return this._dao.findInCollBy(
-        '_getPublicTrades',
-        _args,
-        {
-          isPrepareResponse: true,
-          isPublic: true
-        }
-      )
     }, 'getPublicTrades', cb)
   }
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -26,7 +26,6 @@ const {
   checkParamsAuth,
   isEnotfoundError,
   isEaiAgainError,
-  emptyRes,
   collObjToArr,
   getAuthFromSubAccountAuth
 } = require('./helpers')
@@ -538,7 +537,7 @@ class FrameworkReportService extends ReportService {
         )
 
       if (isEmpty(confs)) {
-        return emptyRes()
+        return super.getTickersHistory(space, args)
       }
 
       const _args = this._publicСollsСonfAccessors
@@ -710,7 +709,7 @@ class FrameworkReportService extends ReportService {
         )
 
       if (isEmpty(confs)) {
-        return emptyRes()
+        return super.getPublicTrades(space, args)
       }
 
       const _args = this._publicСollsСonfAccessors
@@ -767,7 +766,7 @@ class FrameworkReportService extends ReportService {
         )
 
       if (isEmpty(confs)) {
-        return emptyRes()
+        return super.getStatusMessages(space, args)
       }
 
       const _args = this._publicСollsСonfAccessors
@@ -816,7 +815,7 @@ class FrameworkReportService extends ReportService {
         )
 
       if (isEmpty(confs)) {
-        return emptyRes()
+        return super.getCandles(space, args)
       }
 
       const _args = this._publicСollsСonfAccessors

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -377,19 +377,13 @@ class PublicСollsСonfAccessors {
 
   async getPublicData (
     method,
-    args,
+    incomingArgs,
     opts = {}
   ) {
     if (typeof method !== 'function') {
       throw new FindMethodError()
     }
 
-    const { params } = { ...args }
-    const {
-      limit = 10000,
-      notThrowError,
-      notCheckNextPage
-    } = { ...params }
     const {
       checkParamsFn,
       datePropName,
@@ -408,8 +402,19 @@ class PublicСollsСonfAccessors {
       throw new GetPublicDataError()
     }
     if (typeof checkParamsFn === 'function') {
-      checkParamsFn(args)
+      checkParamsFn(incomingArgs)
     }
+
+    const { params: incomingParams } = { ...incomingArgs }
+    const params = this.isCandlesConfs(confName)
+      ? incomingParams
+      : omit(incomingParams, ['timeframe'])
+    const args = { ...incomingArgs, params }
+    const {
+      limit = 10000,
+      notThrowError,
+      notCheckNextPage
+    } = { ...params }
 
     const confs = await this.getPublicСollsСonf(
       confName,


### PR DESCRIPTION
This PR enables api calls for public endpoints (public trades, tickers history, status messages, candles) by default  do the request against the api, unless the pair had been synced