### PR TITLE
Show completed movements on tax report

### DIFF
--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -38,6 +38,7 @@ class FullTaxReport {
       this.ALLOWED_COLLS.MOVEMENTS,
       {
         filter: {
+          $eq: { status: 'COMPLETED' },
           $gte: { mtsUpdated: start },
           $lte: { mtsUpdated: end },
           user_id: user._id


### PR DESCRIPTION
This PR fixes the full tax report to show completed movements

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/87