### PR TITLE
Fix csv export to increase limit if containing same mts

### DIFF
--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -3,7 +3,8 @@
 const {
   mixUserIdToArrData,
   convertDataType,
-  mapObjBySchema
+  mapObjBySchema,
+  isContainedSameMts
 } = require('./utils')
 const {
   serializeVal,
@@ -30,6 +31,7 @@ module.exports = {
   mixUserIdToArrData,
   convertDataType,
   mapObjBySchema,
+  isContainedSameMts,
   serializeVal,
   deserializeVal,
   getWhereQuery,

--- a/workers/loc.api/sync/dao/helpers/utils.js
+++ b/workers/loc.api/sync/dao/helpers/utils.js
@@ -93,8 +93,30 @@ const mapObjBySchema = (obj, schema = {}) => {
   }, {})
 }
 
+const isContainedSameMts = (
+  res,
+  dateFieldName,
+  limit
+) => {
+  if (!Array.isArray(res)) {
+    return false
+  }
+
+  return (
+    res.length >= 2 &&
+    (
+      !Number.isInteger(limit) ||
+      res.length === limit
+    ) &&
+    Number.isInteger(res[res.length - 1][dateFieldName]) &&
+    Number.isInteger(res[res.length - 2][dateFieldName]) &&
+    res[res.length - 1][dateFieldName] === res[res.length - 2][dateFieldName]
+  )
+}
+
 module.exports = {
   mixUserIdToArrData,
   convertDataType,
-  mapObjBySchema
+  mapObjBySchema,
+  isContainedSameMts
 }


### PR DESCRIPTION
This PR fixes csv export to increase the limit param if rows contain the same timestamp

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/87