### PR TITLE
Add staking payments

### DIFF
--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v7.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v7.js
@@ -14,7 +14,7 @@ class MigrationV7 extends AbstractMigration {
       `UPDATE ledgers SET _isStakingPayments = (
         SELECT 1 FROM (
           SELECT * FROM ledgers AS l
-          WHERE l.description LIKE '%Staking Payments%'
+          WHERE l.description COLLATE NOCASE LIKE '%Staking Payments%'
             AND l._id = ledgers._id
         )
       )`

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v7.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v7.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV7 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE ledgers ADD COLUMN _isStakingPayments INT',
+
+      `UPDATE ledgers SET _isStakingPayments = (
+        SELECT 1 FROM (
+          SELECT * FROM ledgers AS l
+          WHERE l.description LIKE '%Staking Payments%'
+            AND l._id = ledgers._id
+        )
+      )`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'ledgers',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          id: 'BIGINT',
+          currency: 'VARCHAR(255)',
+          mts: 'BIGINT',
+          amount: 'DECIMAL(22,12)',
+          amountUsd: 'DECIMAL(22,12)',
+          balance: 'DECIMAL(22,12)',
+          _nativeBalance: 'DECIMAL(22,12)',
+          balanceUsd: 'DECIMAL(22,12)',
+          _nativeBalanceUsd: 'DECIMAL(22,12)',
+          description: 'TEXT',
+          wallet: 'VARCHAR(255)',
+          _isMarginFundingPayment: 'INT',
+          _isAffiliateRebate: 'INT',
+          _isBalanceRecalced: 'INT',
+          subUserId: 'INT',
+          user_id: 'INT NOT NULL',
+          __constraints__: `CONSTRAINT #{tableName}_fk_user_id
+            FOREIGN KEY (user_id)
+            REFERENCES users(_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE`
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV7

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -58,7 +58,11 @@ module.exports = (
   const symbFilter = getSymbolFilter(symbol, symbolFieldName)
   const timeframeFilter = getTimeframeFilter(timeframe, timeframeFieldName)
   const fieldsFilters = getFieldsFilters(
-    ['isMarginFundingPayment', 'isAffiliateRebate'],
+    [
+      'isMarginFundingPayment',
+      'isAffiliateRebate',
+      'isStakingPayments'
+    ],
     params,
     model
   )

--- a/workers/loc.api/sync/dao/helpers/serialization.js
+++ b/workers/loc.api/sync/dao/helpers/serialization.js
@@ -28,7 +28,8 @@ const deserializeVal = (
     'noClose',
     'maker',
     '_isMarginFundingPayment',
-    '_isAffiliateRebate'
+    '_isAffiliateRebate',
+    '_isStakingPayments'
   ]
 ) => {
   if (

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -119,6 +119,10 @@ class ApiMiddlewareHandlerAfter {
             {
               fieldName: '_isAffiliateRebate',
               pattern: 'Affiliate Rebate'
+            },
+            {
+              fieldName: '_isStakingPayments',
+              pattern: 'Staking Payments' // TODO: need to check it out
             }
           ]
         ),

--- a/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.handler.after.js
@@ -122,7 +122,7 @@ class ApiMiddlewareHandlerAfter {
             },
             {
               fieldName: '_isStakingPayments',
-              pattern: 'Staking Payments' // TODO: need to check it out
+              pattern: 'Staking Payments'
             }
           ]
         ),

--- a/workers/loc.api/sync/data.inserter/helpers/get-flags-from-ledger-description.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-flags-from-ledger-description.js
@@ -15,9 +15,13 @@ module.exports = (
   return schemas.reduce((accum, schema) => {
     const {
       fieldName,
-      pattern
+      pattern,
+      isCaseSensitivity
     } = { ...schema }
-    const regExp = new RegExp(pattern, 'i')
+    const regExp = new RegExp(
+      pattern,
+      isCaseSensitivity ? '' : 'i'
+    )
 
     return {
       ...accum,

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -7,7 +7,7 @@
  * in the `workers/loc.api/sync/dao/db-migrations/sqlite-migrations` folder,
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
-const SUPPORTED_DB_VERSION = 6
+const SUPPORTED_DB_VERSION = 7
 
 const { cloneDeep, omit } = require('lodash')
 
@@ -106,6 +106,7 @@ const _models = new Map([
       wallet: 'VARCHAR(255)',
       _isMarginFundingPayment: 'INT',
       _isAffiliateRebate: 'INT',
+      _isStakingPayments: 'INT',
       _isBalanceRecalced: 'INT',
       subUserId: 'INT',
       user_id: 'INT NOT NULL',


### PR DESCRIPTION
This PR adds an ability to filter staking payments on ledgers to the sync mode using `"isStakingPayments": true` param in a request to the `getLedgers` method

**Depends** on these PRs:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/87
  - https://github.com/bitfinexcom/bfx-report/pull/176