### PR TITLE
Add timestamps into full tax and full snapshot reports

### DIFF
--- a/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
@@ -22,12 +22,11 @@ module.exports = (rService) => async (
   } = { ...jobData }
   const { params: _params } = { ..._args }
   const params = {
-    start: 0,
     end: Date.now(),
     ..._params
   }
   const args = { ..._args, params }
-  const { start, end } = params
+  const { end } = params
   const mtsCreated = Date.now()
 
   queue.emit('progress', 0)
@@ -115,7 +114,7 @@ module.exports = (rService) => async (
   } = { ...res }
 
   write(
-    [{ mtsCreated, start, end }, {}],
+    [{ mtsCreated, end }, {}],
     timestampsStringifier,
     formatSettings.timestamps,
     params

--- a/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
@@ -22,10 +22,13 @@ module.exports = (rService) => async (
   } = { ...jobData }
   const { params: _params } = { ..._args }
   const params = {
+    start: 0,
     end: Date.now(),
     ..._params
   }
   const args = { ..._args, params }
+  const { start, end } = params
+  const mtsCreated = Date.now()
 
   queue.emit('progress', 0)
 
@@ -44,6 +47,10 @@ module.exports = (rService) => async (
 
   wStream.setMaxListeners(20)
 
+  const timestampsStringifier = stringify({
+    header: true,
+    columns: columnsCsv.timestamps
+  })
   const posNameStringifier = stringify(
     { columns: ['name'] }
   )
@@ -81,6 +88,7 @@ module.exports = (rService) => async (
     columns: columnsCsv.walletsTickers
   })
 
+  timestampsStringifier.pipe(wStream)
   posNameStringifier.pipe(wStream)
   posStringifier.pipe(wStream)
   positionsTotalPlUsdStringifier.pipe(wStream)
@@ -106,6 +114,12 @@ module.exports = (rService) => async (
     walletsTotalBalanceUsd
   } = { ...res }
 
+  write(
+    [{ mtsCreated, start, end }, {}],
+    timestampsStringifier,
+    formatSettings.timestamps,
+    params
+  )
   write([{ name: 'POSITIONS' }], posNameStringifier)
   write(
     [...positionsSnapshot, {}],

--- a/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
@@ -22,10 +22,13 @@ module.exports = (rService) => async (
   } = { ...jobData }
   const { params: _params } = { ..._args }
   const params = {
+    start: 0,
     end: Date.now(),
     ..._params
   }
   const args = { ..._args, params }
+  const { start, end } = params
+  const mtsCreated = Date.now()
 
   queue.emit('progress', 0)
 
@@ -44,6 +47,10 @@ module.exports = (rService) => async (
 
   wStream.setMaxListeners(20)
 
+  const timestampsStringifier = stringify({
+    header: true,
+    columns: columnsCsv.timestamps
+  })
   const startingPositionsSnapshotNameStringifier = stringify(
     { columns: ['name'] }
   )
@@ -91,6 +98,7 @@ module.exports = (rService) => async (
     columns: columnsCsv.totalResult
   })
 
+  timestampsStringifier.pipe(wStream)
   startingPositionsSnapshotNameStringifier.pipe(wStream)
   startingPositionsSnapshotStringifier.pipe(wStream)
   endingPositionsSnapshotNameStringifier.pipe(wStream)
@@ -121,6 +129,12 @@ module.exports = (rService) => async (
     }
   } = { ...res }
 
+  write(
+    [{ mtsCreated, start, end }, {}],
+    timestampsStringifier,
+    formatSettings.timestamps,
+    params
+  )
   write(
     [{ name: 'STARTING POSITIONS SNAPSHOT' }],
     startingPositionsSnapshotNameStringifier

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -244,6 +244,11 @@ class CsvJobData extends BaseCsvJobData {
       fileNamesMap: [['getFullSnapshotReport', 'full-snapshot-report']],
       args: csvArgs,
       columnsCsv: {
+        timestamps: {
+          mtsCreated: 'CREATED',
+          start: 'FROM',
+          end: 'TO'
+        },
         positionsSnapshot: {
           id: '#',
           symbol: 'PAIR',
@@ -282,6 +287,11 @@ class CsvJobData extends BaseCsvJobData {
         }
       },
       formatSettings: {
+        timestamps: {
+          mtsCreated: 'date',
+          start: 'date',
+          end: 'date'
+        },
         positionsSnapshot: {
           mtsUpdate: 'date',
           mtsCreate: 'date',
@@ -333,6 +343,11 @@ class CsvJobData extends BaseCsvJobData {
       fileNamesMap: [['getFullTaxReport', 'full-tax-report']],
       args: csvArgs,
       columnsCsv: {
+        timestamps: {
+          mtsCreated: 'CREATED',
+          start: 'FROM',
+          end: 'TO'
+        },
         positionsSnapshot: {
           id: '#',
           symbol: 'PAIR',
@@ -371,6 +386,11 @@ class CsvJobData extends BaseCsvJobData {
         }
       },
       formatSettings: {
+        timestamps: {
+          mtsCreated: 'date',
+          start: 'date',
+          end: 'date'
+        },
         positionsSnapshot: {
           mtsUpdate: 'date',
           mtsCreate: 'date',

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -230,24 +230,38 @@ class CsvJobData extends BaseCsvJobData {
       uId,
       uInfo
     )
+    const { params } = { ...args }
+    const {
+      isStartSnapshot,
+      isEndSnapshot
+    } = { ...params }
+    const isBaseNameInName = isStartSnapshot || isEndSnapshot
+    const typeName = isStartSnapshot
+      ? 'START_SNAPSHOT'
+      : 'END_SNAPSHOT'
+    const fileName = isBaseNameInName
+      ? `full-tax-report_${typeName}`
+      : 'full-snapshot-report'
 
     const csvArgs = getCsvArgs(
       args,
       null,
-      { isOnMomentInName: true }
+      {
+        isOnMomentInName: !isBaseNameInName,
+        isBaseNameInName
+      }
     )
 
     const jobData = {
       userInfo,
       userId,
       name: 'getFullSnapshotReport',
-      fileNamesMap: [['getFullSnapshotReport', 'full-snapshot-report']],
+      fileNamesMap: [['getFullSnapshotReport', fileName]],
       args: csvArgs,
       columnsCsv: {
         timestamps: {
           mtsCreated: 'CREATED',
-          start: 'FROM',
-          end: 'TO'
+          end: 'SNAPSHOT AT'
         },
         positionsSnapshot: {
           id: '#',
@@ -289,7 +303,6 @@ class CsvJobData extends BaseCsvJobData {
       formatSettings: {
         timestamps: {
           mtsCreated: 'date',
-          start: 'date',
           end: 'date'
         },
         positionsSnapshot: {
@@ -319,6 +332,30 @@ class CsvJobData extends BaseCsvJobData {
     uId,
     uInfo
   ) {
+    const { params } = { ...args }
+    const {
+      start,
+      end,
+      isStartSnapshot,
+      isEndSnapshot
+    } = { ...params }
+
+    if (isStartSnapshot || isEndSnapshot) {
+      const mts = isStartSnapshot ? start : end
+
+      return this.getFullSnapshotReportCsvJobData(
+        {
+          ...args,
+          params: {
+            ...params,
+            end: mts
+          }
+        },
+        uId,
+        uInfo
+      )
+    }
+
     checkParams(args, 'paramsSchemaForFullTaxReportCsv')
 
     const {
@@ -333,14 +370,14 @@ class CsvJobData extends BaseCsvJobData {
     const csvArgs = getCsvArgs(
       args,
       null,
-      { isOnMomentInName: true }
+      { isBaseNameInName: true }
     )
 
     const jobData = {
       userInfo,
       userId,
       name: 'getFullTaxReport',
-      fileNamesMap: [['getFullTaxReport', 'full-tax-report']],
+      fileNamesMap: [['getFullTaxReport', 'full-tax-report_FULL_PERIOD']],
       args: csvArgs,
       columnsCsv: {
         timestamps: {


### PR DESCRIPTION
This PR adds timestamps into full tax and full snapshot reports, improves naming of csv files. To generate full tax and starting snapshot and ending snapshot reports need to do the following request:

```json
{
    "auth": {
    	"token": "123-321-abc"
    },
    "method": "getMultipleCsv",
    "params": {
    	"multiExport": [
    	    {
              "method": "getFullTaxReportCsv",
              "start": 1584662400000,
              "end": 1589932800000
            },
            {
              "method": "getFullTaxReportCsv",
              "start": 1584662400000,
	      "isStartSnapshot": true
            },
            {
              "method": "getFullTaxReportCsv",
	      "end": 1589932800000,
              "isEndSnapshot": true
            }
          ]
    }
}
```

CSV files would be generated with these names:

  - user_full-tax-report_FULL_PERIOD_Fri-May-22-2020-a122e10f-405f-47bd-a86c-17e19648c5c5.csv
  - user_full-tax-report_START_SNAPSHOT_Fri-May-22-2020-592d87e6-b883-4a0b-a4c3-9c17114ee03e.csv
  - user_full-tax-report_END_SNAPSHOT_Fri-May-22-2020-862563d5-2154-48c2-9416-c667a0669458.csv

**Depends** on these PRs:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/87
  - https://github.com/bitfinexcom/bfx-report/pull/178