### PR TITLE
Remove duplicated movements with same mts

### DIFF
--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v9.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v9.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+
+class MigrationV9 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'DROP INDEX movements_id_mtsUpdated_user_id',
+
+      'DELETE FROM movements',
+
+      /*
+      * Remove statusMessages sync configs to allow UI
+      * sync that collection from scratch
+      */
+      `DELETE FROM publicСollsСonf
+        WHERE confName = 'statusMessagesConf'`,
+
+      `CREATE UNIQUE INDEX movements_id_user_id
+        ON movements(id, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      'DROP INDEX movements_id_user_id',
+
+      'DELETE FROM movements',
+
+      `CREATE UNIQUE INDEX movements_id_mtsUpdated_user_id
+        ON movements(id, mtsUpdated, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+}
+
+module.exports = MigrationV9

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -7,8 +7,7 @@
  * in the `workers/loc.api/sync/dao/db-migrations/sqlite-migrations` folder,
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
-
-const SUPPORTED_DB_VERSION = 8
+const SUPPORTED_DB_VERSION = 9
 
 const { cloneDeep, omit } = require('lodash')
 
@@ -621,7 +620,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdated', 'currency'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdated', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: { ...getModelsMap().get(TABLES_NAMES.MOVEMENTS) }
     }
   ],


### PR DESCRIPTION
This PR adds ability to remove duplicated movements with the same timestamps and refresh db row to the last state of api_v2

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/93