### PR TITLE
Add ability to disable user password protection

### DIFF
--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -38,7 +38,15 @@ class Authenticator {
 
   async signUp (args, params) {
     const { auth } = { ...args }
-    const { apiKey, apiSecret, password } = { ...auth }
+    const {
+      apiKey,
+      apiSecret,
+      password: userPwd,
+      isNotProtected
+    } = { ...auth }
+    const password = isNotProtected
+      ? this.crypto.getSecretKey()
+      : userPwd
     const {
       active = true,
       isDataFromDb = true,
@@ -305,10 +313,16 @@ class Authenticator {
     const { auth } = { ...args }
     const {
       email,
-      password,
+      password: userPwd,
       isSubAccount = false,
       token
     } = { ...auth }
+    const password = (
+      userPwd &&
+      typeof userPwd === 'string'
+    )
+      ? userPwd
+      : this.crypto.getSecretKey()
     const {
       projection,
       isFilledSubUsers,

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v10.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v10.js
@@ -12,7 +12,6 @@ class MigrationV10 extends AbstractMigration {
       'DROP INDEX trades_id_mtsCreate_orderID_fee_user_id',
       'DROP INDEX fundingTrades_id_mtsCreate_offerID_user_id',
       'DROP INDEX publicTrades_id_mts__symbol',
-      'DROP INDEX statusMessages_timestamp_key__type',
       'DROP INDEX orders_id_mtsUpdate_user_id',
       'DROP INDEX fundingOfferHistory_id_mtsUpdate_user_id',
       'DROP INDEX fundingLoanHistory_id_mtsUpdate_user_id',
@@ -24,7 +23,6 @@ class MigrationV10 extends AbstractMigration {
       'DELETE FROM trades',
       'DELETE FROM fundingTrades',
       'DELETE FROM publicTrades',
-      'DELETE FROM statusMessages',
       'DELETE FROM orders',
       'DELETE FROM fundingOfferHistory',
       'DELETE FROM fundingLoanHistory',
@@ -40,8 +38,6 @@ class MigrationV10 extends AbstractMigration {
         ON fundingTrades(id, user_id)`,
       `CREATE UNIQUE INDEX publicTrades_id__symbol
         ON publicTrades(id, _symbol)`,
-      `CREATE UNIQUE INDEX statusMessages_key__type
-        ON statusMessages(key, _type)`,
       `CREATE UNIQUE INDEX orders_id_user_id
         ON orders(id, user_id)`,
       `CREATE UNIQUE INDEX fundingOfferHistory_id_user_id
@@ -68,7 +64,6 @@ class MigrationV10 extends AbstractMigration {
       'DROP INDEX trades_id_symbol_user_id',
       'DROP INDEX fundingTrades_id_user_id',
       'DROP INDEX publicTrades_id__symbol',
-      'DROP INDEX statusMessages_key__type',
       'DROP INDEX orders_id_user_id',
       'DROP INDEX fundingOfferHistory_id_user_id',
       'DROP INDEX fundingLoanHistory_id_user_id',
@@ -80,7 +75,6 @@ class MigrationV10 extends AbstractMigration {
       'DELETE FROM trades',
       'DELETE FROM fundingTrades',
       'DELETE FROM publicTrades',
-      'DELETE FROM statusMessages',
       'DELETE FROM orders',
       'DELETE FROM fundingOfferHistory',
       'DELETE FROM fundingLoanHistory',
@@ -96,8 +90,6 @@ class MigrationV10 extends AbstractMigration {
         ON fundingTrades(id, mtsCreate, offerID, user_id)`,
       `CREATE UNIQUE INDEX publicTrades_id_mts__symbol
         ON publicTrades(id, mts, _symbol)`,
-      `CREATE UNIQUE INDEX statusMessages_timestamp_key__type
-        ON statusMessages(timestamp, key, _type)`,
       `CREATE UNIQUE INDEX orders_id_mtsUpdate_user_id
         ON orders(id, mtsUpdate, user_id)`,
       `CREATE UNIQUE INDEX fundingOfferHistory_id_mtsUpdate_user_id

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v10.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v10.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+
+class MigrationV10 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'DROP INDEX ledgers_id_mts_user_id',
+      'DROP INDEX trades_id_mtsCreate_orderID_fee_user_id',
+      'DROP INDEX fundingTrades_id_mtsCreate_offerID_user_id',
+      'DROP INDEX publicTrades_id_mts__symbol',
+      'DROP INDEX statusMessages_timestamp_key__type',
+      'DROP INDEX orders_id_mtsUpdate_user_id',
+      'DROP INDEX fundingOfferHistory_id_mtsUpdate_user_id',
+      'DROP INDEX fundingLoanHistory_id_mtsUpdate_user_id',
+      'DROP INDEX fundingCreditHistory_id_mtsUpdate_user_id',
+      'DROP INDEX positionsHistory_id_mtsUpdate_user_id',
+      'DROP INDEX logins_id_time_user_id',
+
+      'DELETE FROM ledgers',
+      'DELETE FROM trades',
+      'DELETE FROM fundingTrades',
+      'DELETE FROM publicTrades',
+      'DELETE FROM statusMessages',
+      'DELETE FROM orders',
+      'DELETE FROM fundingOfferHistory',
+      'DELETE FROM fundingLoanHistory',
+      'DELETE FROM fundingCreditHistory',
+      'DELETE FROM positionsHistory',
+      'DELETE FROM logins',
+
+      `CREATE UNIQUE INDEX ledgers_id_user_id
+        ON ledgers(id, user_id)`,
+      `CREATE UNIQUE INDEX trades_id_symbol_user_id
+        ON trades(id, symbol, user_id)`,
+      `CREATE UNIQUE INDEX fundingTrades_id_user_id
+        ON fundingTrades(id, user_id)`,
+      `CREATE UNIQUE INDEX publicTrades_id__symbol
+        ON publicTrades(id, _symbol)`,
+      `CREATE UNIQUE INDEX statusMessages_key__type
+        ON statusMessages(key, _type)`,
+      `CREATE UNIQUE INDEX orders_id_user_id
+        ON orders(id, user_id)`,
+      `CREATE UNIQUE INDEX fundingOfferHistory_id_user_id
+        ON fundingOfferHistory(id, user_id)`,
+      `CREATE UNIQUE INDEX fundingLoanHistory_id_user_id
+        ON fundingLoanHistory(id, user_id)`,
+      `CREATE UNIQUE INDEX fundingCreditHistory_id_user_id
+        ON fundingCreditHistory(id, user_id)`,
+      `CREATE UNIQUE INDEX positionsHistory_id_user_id
+        ON positionsHistory(id, user_id)`,
+      `CREATE UNIQUE INDEX logins_id_user_id
+        ON logins(id, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      'DROP INDEX ledgers_id_user_id',
+      'DROP INDEX trades_id_symbol_user_id',
+      'DROP INDEX fundingTrades_id_user_id',
+      'DROP INDEX publicTrades_id__symbol',
+      'DROP INDEX statusMessages_key__type',
+      'DROP INDEX orders_id_user_id',
+      'DROP INDEX fundingOfferHistory_id_user_id',
+      'DROP INDEX fundingLoanHistory_id_user_id',
+      'DROP INDEX fundingCreditHistory_id_user_id',
+      'DROP INDEX positionsHistory_id_user_id',
+      'DROP INDEX logins_id_user_id',
+
+      'DELETE FROM ledgers',
+      'DELETE FROM trades',
+      'DELETE FROM fundingTrades',
+      'DELETE FROM publicTrades',
+      'DELETE FROM statusMessages',
+      'DELETE FROM orders',
+      'DELETE FROM fundingOfferHistory',
+      'DELETE FROM fundingLoanHistory',
+      'DELETE FROM fundingCreditHistory',
+      'DELETE FROM positionsHistory',
+      'DELETE FROM logins',
+
+      `CREATE UNIQUE INDEX ledgers_id_mts_user_id
+        ON ledgers(id, mts, user_id)`,
+      `CREATE UNIQUE INDEX trades_id_mtsCreate_orderID_fee_user_id
+        ON trades(id, mtsCreate, orderID, fee, user_id)`,
+      `CREATE UNIQUE INDEX fundingTrades_id_mtsCreate_offerID_user_id
+        ON fundingTrades(id, mtsCreate, offerID, user_id)`,
+      `CREATE UNIQUE INDEX publicTrades_id_mts__symbol
+        ON publicTrades(id, mts, _symbol)`,
+      `CREATE UNIQUE INDEX statusMessages_timestamp_key__type
+        ON statusMessages(timestamp, key, _type)`,
+      `CREATE UNIQUE INDEX orders_id_mtsUpdate_user_id
+        ON orders(id, mtsUpdate, user_id)`,
+      `CREATE UNIQUE INDEX fundingOfferHistory_id_mtsUpdate_user_id
+        ON fundingOfferHistory(id, mtsUpdate, user_id)`,
+      `CREATE UNIQUE INDEX fundingLoanHistory_id_mtsUpdate_user_id
+        ON fundingLoanHistory(id, mtsUpdate, user_id)`,
+      `CREATE UNIQUE INDEX fundingCreditHistory_id_mtsUpdate_user_id
+        ON fundingCreditHistory(id, mtsUpdate, user_id)`,
+      `CREATE UNIQUE INDEX positionsHistory_id_mtsUpdate_user_id
+        ON positionsHistory(id, mtsUpdate, user_id)`,
+      `CREATE UNIQUE INDEX logins_id_time_user_id
+        ON logins(id, time, user_id)`
+    ]
+
+    this.addSql(sqlArr)
+  }
+}
+
+module.exports = MigrationV10

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -592,7 +592,7 @@ const _methodCollMap = new Map([
       confName: 'statusMessagesConf',
       type: 'public:updatable:array:objects',
       fieldsOfIndex: ['timestamp', 'key'],
-      fieldsOfUniqueIndex: ['key', '_type'],
+      fieldsOfUniqueIndex: ['timestamp', 'key', '_type'],
       model: _getModelOf(TABLES_NAMES.STATUS_MESSAGES)
     }
   ],

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -7,7 +7,7 @@
  * in the `workers/loc.api/sync/dao/db-migrations/sqlite-migrations` folder,
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
-const SUPPORTED_DB_VERSION = 9
+const SUPPORTED_DB_VERSION = 10
 
 const { cloneDeep, omit } = require('lodash')
 
@@ -518,7 +518,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mts', 'currency'],
-      fieldsOfUniqueIndex: ['id', 'mts', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.LEDGERS)
     }
   ],
@@ -534,7 +534,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsCreate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsCreate', 'orderID', 'fee', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'symbol', 'user_id'],
       model: _getModelOf(TABLES_NAMES.TRADES)
     }
   ],
@@ -550,7 +550,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsCreate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsCreate', 'offerID', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.FUNDING_TRADES)
     }
   ],
@@ -567,7 +567,7 @@ const _methodCollMap = new Map([
       confName: 'publicTradesConf',
       type: 'public:insertable:array:objects',
       fieldsOfIndex: ['mts', '_symbol'],
-      fieldsOfUniqueIndex: ['id', 'mts', '_symbol'],
+      fieldsOfUniqueIndex: ['id', '_symbol'],
       model: _getModelOf(TABLES_NAMES.PUBLIC_TRADES)
     }
   ],
@@ -592,7 +592,7 @@ const _methodCollMap = new Map([
       confName: 'statusMessagesConf',
       type: 'public:updatable:array:objects',
       fieldsOfIndex: ['timestamp', 'key'],
-      fieldsOfUniqueIndex: ['timestamp', 'key', '_type'],
+      fieldsOfUniqueIndex: ['key', '_type'],
       model: _getModelOf(TABLES_NAMES.STATUS_MESSAGES)
     }
   ],
@@ -608,7 +608,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.ORDERS)
     }
   ],
@@ -640,7 +640,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
     }
   ],
@@ -656,7 +656,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
     }
   ],
@@ -672,7 +672,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
     }
   ],
@@ -688,7 +688,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
-      fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
     }
   ],
@@ -704,7 +704,7 @@ const _methodCollMap = new Map([
       start: 0,
       type: 'insertable:array:objects',
       fieldsOfIndex: ['time'],
-      fieldsOfUniqueIndex: ['id', 'time', 'user_id'],
+      fieldsOfUniqueIndex: ['id', 'user_id'],
       model: _getModelOf(TABLES_NAMES.LOGINS)
     }
   ],

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -44,6 +44,10 @@ const getModelsMap = (params = {}) => {
   return _cloneSchema(models, omittedFields)
 }
 
+const _getModelOf = (tableName) => {
+  return { ...getModelsMap().get(tableName) }
+}
+
 const _models = new Map([
   [
     TABLES_NAMES.USERS,
@@ -515,7 +519,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mts', 'currency'],
       fieldsOfUniqueIndex: ['id', 'mts', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.LEDGERS) }
+      model: _getModelOf(TABLES_NAMES.LEDGERS)
     }
   ],
   [
@@ -531,7 +535,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsCreate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsCreate', 'orderID', 'fee', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.TRADES) }
+      model: _getModelOf(TABLES_NAMES.TRADES)
     }
   ],
   [
@@ -547,7 +551,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsCreate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsCreate', 'offerID', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.FUNDING_TRADES) }
+      model: _getModelOf(TABLES_NAMES.FUNDING_TRADES)
     }
   ],
   [
@@ -564,7 +568,7 @@ const _methodCollMap = new Map([
       type: 'public:insertable:array:objects',
       fieldsOfIndex: ['mts', '_symbol'],
       fieldsOfUniqueIndex: ['id', 'mts', '_symbol'],
-      model: { ...getModelsMap().get(TABLES_NAMES.PUBLIC_TRADES) }
+      model: _getModelOf(TABLES_NAMES.PUBLIC_TRADES)
     }
   ],
   [
@@ -589,7 +593,7 @@ const _methodCollMap = new Map([
       type: 'public:updatable:array:objects',
       fieldsOfIndex: ['timestamp', 'key'],
       fieldsOfUniqueIndex: ['timestamp', 'key', '_type'],
-      model: { ...getModelsMap().get(TABLES_NAMES.STATUS_MESSAGES) }
+      model: _getModelOf(TABLES_NAMES.STATUS_MESSAGES)
     }
   ],
   [
@@ -605,7 +609,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.ORDERS) }
+      model: _getModelOf(TABLES_NAMES.ORDERS)
     }
   ],
   [
@@ -621,7 +625,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdated', 'currency'],
       fieldsOfUniqueIndex: ['id', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.MOVEMENTS) }
+      model: _getModelOf(TABLES_NAMES.MOVEMENTS)
     }
   ],
   [
@@ -637,7 +641,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.FUNDING_OFFER_HISTORY) }
+      model: _getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
     }
   ],
   [
@@ -653,7 +657,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.FUNDING_LOAN_HISTORY) }
+      model: _getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
     }
   ],
   [
@@ -669,7 +673,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.FUNDING_CREDIT_HISTORY) }
+      model: _getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
     }
   ],
   [
@@ -685,7 +689,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsUpdate', 'symbol'],
       fieldsOfUniqueIndex: ['id', 'mtsUpdate', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.POSITIONS_HISTORY) }
+      model: _getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
     }
   ],
   [
@@ -701,7 +705,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['time'],
       fieldsOfUniqueIndex: ['id', 'time', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.LOGINS) }
+      model: _getModelOf(TABLES_NAMES.LOGINS)
     }
   ],
   [
@@ -717,7 +721,7 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfIndex: ['mtsCreate'],
       fieldsOfUniqueIndex: ['mtsCreate', 'log', 'user_id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.CHANGE_LOGS) }
+      model: _getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }
   ],
   [
@@ -734,7 +738,7 @@ const _methodCollMap = new Map([
       type: 'public:insertable:array:objects',
       fieldsOfIndex: null,
       fieldsOfUniqueIndex: ['mtsUpdate', 'symbol'],
-      model: { ...getModelsMap().get(TABLES_NAMES.TICKERS_HISTORY) }
+      model: _getModelOf(TABLES_NAMES.TICKERS_HISTORY)
     }
   ],
   [
@@ -749,7 +753,7 @@ const _methodCollMap = new Map([
         sort: [['mts', -1], ['id', -1]]
       },
       type: 'hidden:insertable:array:objects',
-      model: { ...getModelsMap().get(TABLES_NAMES.LEDGERS) },
+      model: _getModelOf(TABLES_NAMES.LEDGERS),
       dataStructureConverter: (accum, {
         wallet: type,
         currency,
@@ -779,7 +783,7 @@ const _methodCollMap = new Map([
       sort: [['pairs', 1]],
       hasNewData: true,
       type: 'public:updatable:array',
-      model: { ...getModelsMap().get(TABLES_NAMES.SYMBOLS) }
+      model: _getModelOf(TABLES_NAMES.SYMBOLS)
     }
   ],
   [
@@ -791,7 +795,7 @@ const _methodCollMap = new Map([
       sort: [['pairs', 1]],
       hasNewData: true,
       type: 'public:updatable:array',
-      model: { ...getModelsMap().get(TABLES_NAMES.INACTIVE_SYMBOLS) }
+      model: _getModelOf(TABLES_NAMES.INACTIVE_SYMBOLS)
     }
   ],
   [
@@ -803,7 +807,7 @@ const _methodCollMap = new Map([
       sort: [['pairs', 1]],
       hasNewData: true,
       type: 'public:updatable:array',
-      model: { ...getModelsMap().get(TABLES_NAMES.FUTURES) }
+      model: _getModelOf(TABLES_NAMES.FUTURES)
     }
   ],
   [
@@ -816,7 +820,7 @@ const _methodCollMap = new Map([
       hasNewData: true,
       type: 'public:updatable:array:objects',
       fieldsOfUniqueIndex: ['id'],
-      model: { ...getModelsMap().get(TABLES_NAMES.CURRENCIES) }
+      model: _getModelOf(TABLES_NAMES.CURRENCIES)
     }
   ],
   [
@@ -834,7 +838,7 @@ const _methodCollMap = new Map([
       type: 'public:insertable:array:objects',
       fieldsOfIndex: ['mts', '_symbol'],
       fieldsOfUniqueIndex: ['_symbol', '_timeframe', 'mts'],
-      model: { ...getModelsMap().get(TABLES_NAMES.CANDLES) }
+      model: _getModelOf(TABLES_NAMES.CANDLES)
     }
   ]
 ])

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -118,9 +118,7 @@ class SubAccount {
         const isAuthCheckedInDb = (
           (
             email &&
-            typeof email === 'string' &&
-            password &&
-            typeof password === 'string'
+            typeof email === 'string'
           ) ||
           (
             token &&


### PR DESCRIPTION
This PR adds the ability to disable user password protection. To use this feature need:
  - send a `signUp` request with `"isNotProtected": true` flag:

```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---",
        "isNotProtected": true
    },
    "method": "signUp"
}
```

  - use the `signIn` method without a password:

```json
{
    "auth": {
        "email": "some@email.com",
        "isSubAccount": false
    },
    "method": "signIn"
}
```

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/96