### PR TITLE
Fix symbol pair splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,13 @@
       }
     },
     "test": {
-      "command": "standard && mocha './test/**/*.spec.js' --config .mocharc.json",
+      "command": "standard && mocha './workers/**/__test__/*.spec.js' './test/**/*.spec.js' --config .mocharc.json",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
+    "unit": {
+      "command": "mocha './workers/**/__test__/*.spec.js' --config .mocharc.json",
       "env": {
         "NODE_ENV": "test"
       }
@@ -114,6 +120,7 @@
     "startBackEnd": "better-npm-run start:back",
     "startExpress": "better-npm-run start:express",
     "startUI": "better-npm-run start:ui",
-    "start": "better-npm-run start:all"
+    "start": "better-npm-run start:all",
+    "unit": "better-npm-run unit"
   }
 }

--- a/workers/loc.api/sync/helpers/__test__/split-symbol-pairs.spec.js
+++ b/workers/loc.api/sync/helpers/__test__/split-symbol-pairs.spec.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const splitSymbolPairs = require('../split-symbol-pairs')
+
+describe('splitSymbolPairs helper', () => {
+  it('BTC:CNHT pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('BTC:CNHT')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'BTC')
+    assert.strictEqual(res[1], 'CNHT')
+  })
+
+  it('DUSK:USD pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('DUSK:USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'DUSK')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('EURUSD pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('EURUSD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'EUR')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('tXAUT:USD pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tXAUT:USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'XAUT')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('fBTCUSD pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('fBTCUSD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'BTC')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('tBTCF0:USD pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tBTCF0:USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'BTCF0')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('tBTCF0USD pair, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tBTCF0USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'BTCF0')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('tXAUTUSD pair, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tXAUTUSD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'XAUT')
+    assert.strictEqual(res[1], 'USD')
+  })
+
+  it('tEUR:USD pair, with separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tEUR:USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'EUR')
+    assert.strictEqual(res[1], 'USD')
+  })
+})

--- a/workers/loc.api/sync/helpers/split-symbol-pairs.js
+++ b/workers/loc.api/sync/helpers/split-symbol-pairs.js
@@ -18,5 +18,5 @@ module.exports = (symbol) => {
     return [str]
   }
 
-  return [str.slice(0, 3), str.slice(-3)]
+  return [str.slice(0, -3), str.slice(-3)]
 }


### PR DESCRIPTION
This PR fixes symbol pair splitting. The issue is when a pair is passed like `tXAUTUSD` instead of `tXAUT:USD` it will split to `['XAU', 'USD']` against expected `['XAUT', 'USD']`