### PR TITLE
Add password recovery

### DIFF
--- a/test/5-recover-password.spec.js
+++ b/test/5-recover-password.spec.js
@@ -1,0 +1,413 @@
+'use strict'
+
+const path = require('path')
+const { assert } = require('chai')
+const request = require('supertest')
+
+const {
+  stopEnvironment
+} = require('bfx-report/test/helpers/helpers.boot')
+const {
+  rmDB,
+  rmAllFiles
+} = require('bfx-report/test/helpers/helpers.core')
+
+const {
+  startEnvironment
+} = require('./helpers/helpers.boot')
+const {
+  connToSQLite,
+  closeSQLite,
+  getRServiceProxy
+} = require('./helpers/helpers.core')
+const {
+  createMockRESTv2SrvWithDate,
+  getMockData
+} = require('./helpers/helpers.mock-rest-v2')
+const _mockData = require('./helpers/mock-data')
+
+process.env.NODE_CONFIG_DIR = path.join(__dirname, 'config')
+const { app } = require('bfx-report-express')
+const agent = request.agent(app)
+
+const {
+  signUpTestCase
+} = require('./test-cases')
+
+let wrkReportServiceApi = null
+let mockRESTv2Srv = null
+let db = null
+
+const basePath = '/api'
+const tempDirPath = path.join(__dirname, '..', 'workers/loc.api/queue/temp')
+const dbDirPath = path.join(__dirname, '..', 'db')
+const date = new Date()
+const end = date.getTime()
+const start = (new Date()).setDate(date.getDate() - 90)
+
+const subUserApiKeys = {
+  apiKey: 'subUserApiKey',
+  apiSecret: 'subUserApiSecret'
+}
+const masterUserApiKeys = {
+  apiKey: 'masterUserApiKey',
+  apiSecret: 'masterUserApiSecret'
+}
+const subUserEmail = 'sub-user@email.fake'
+const masterUserEmail = 'master-user@email.fake'
+const password = '123Qwerty'
+const newPassword = 'Qwerty321'
+
+const masterUserMockData = new Map([
+  [
+    'user_info',
+    [
+      111,
+      masterUserEmail,
+      'masterUserName',
+      null,
+      null,
+      null,
+      null,
+      'Kyiv'
+    ]
+  ]
+])
+const _getMockData = (methodName) => {
+  return getMockData(
+    methodName,
+    new Map([..._mockData, ...masterUserMockData])
+  )
+}
+
+describe('Recover password', () => {
+  before(async function () {
+    this.timeout(20000)
+
+    mockRESTv2Srv = createMockRESTv2SrvWithDate(
+      start,
+      end,
+      10,
+      undefined,
+      { _getMockData }
+    )
+
+    await rmAllFiles(tempDirPath, ['README.md'])
+    await rmDB(dbDirPath)
+    const env = await startEnvironment(false, false, 1, {
+      dbDriver: 'sqlite'
+    })
+
+    wrkReportServiceApi = env.wrksReportServiceApi[0]
+
+    const rService = wrkReportServiceApi.grc_bfx.api
+    const rServiceProxy = getRServiceProxy(rService, {
+      _checkAuthInApi (targetMethod, context, argsList) {
+        const args = argsList[0]
+        const { auth } = { ...args }
+        const { apiKey, apiSecret } = { ...auth }
+
+        if (
+          apiKey === subUserApiKeys.apiKey &&
+          apiSecret === subUserApiKeys.apiSecret
+        ) {
+          return {
+            email: subUserEmail,
+            timezone: 'Kyiv',
+            username: 'subUserName',
+            id: 222
+          }
+        }
+
+        return Reflect.apply(...arguments)
+      }
+    })
+
+    rService._authenticator.rService = rServiceProxy
+
+    db = await connToSQLite()
+  })
+
+  after(async function () {
+    this.timeout(5000)
+
+    await stopEnvironment()
+    await closeSQLite(db)
+    await rmDB(dbDirPath)
+    await rmAllFiles(tempDirPath, ['README.md'])
+
+    try {
+      await mockRESTv2Srv.close()
+    } catch (err) { }
+  })
+
+  describe('Recover password for master user', () => {
+    const masterUserAuth = { token: '' }
+
+    signUpTestCase(
+      agent,
+      {
+        basePath,
+        auth: {
+          email: masterUserEmail,
+          password,
+          isSubAccount: false
+        },
+        apiKeys: masterUserApiKeys
+      },
+      (token) => {
+        masterUserAuth.token = token
+      }
+    )
+
+    it('it should be successfully performed by the signIn method', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password,
+            isSubAccount: false
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isNotOk(res.body.result.isSubAccount)
+      assert.strictEqual(res.body.result.token, masterUserAuth.token)
+    })
+
+    it('it should be successfully performed by the recoverPassword method', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            ...masterUserApiKeys,
+            newPassword,
+            isSubAccount: false
+          },
+          method: 'recoverPassword',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isNotOk(res.body.result.isSubAccount)
+      assert.strictEqual(res.body.result.token, masterUserAuth.token)
+    })
+
+    it('it should not be successfully performed by the signIn method with old pwd', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password,
+            isSubAccount: false
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(401)
+
+      assert.isObject(res.body)
+      assert.isObject(res.body.error)
+      assert.propertyVal(res.body.error, 'code', 401)
+      assert.propertyVal(res.body.error, 'message', 'Unauthorized')
+      assert.propertyVal(res.body, 'id', 5)
+    })
+
+    it('it should be successfully performed by the signIn method with new pwd', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password: newPassword,
+            isSubAccount: false
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isNotOk(res.body.result.isSubAccount)
+      assert.strictEqual(res.body.result.token, masterUserAuth.token)
+    })
+  })
+
+  describe('Recover password for sub-account', () => {
+    const masterUserAuth = { token: '' }
+    const subAccountAuth = { token: '' }
+
+    it('it should be successfully performed by the signIn method for master user', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password: newPassword,
+            isSubAccount: false
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isNotOk(res.body.result.isSubAccount)
+      assert.isString(res.body.result.token)
+
+      masterUserAuth.token = res.body.result.token
+    })
+
+    it('it should be successfully performed by the createSubAccount method', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: masterUserAuth,
+          method: 'createSubAccount',
+          params: {
+            subAccountApiKeys: [subUserApiKeys]
+          },
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isOk(res.body.result.isSubAccount)
+      assert.isString(res.body.result.token)
+
+      subAccountAuth.token = res.body.result.token
+    })
+
+    it('it should be successfully performed by the recoverPassword method', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            ...masterUserApiKeys,
+            newPassword: password,
+            isSubAccount: true
+          },
+          params: {
+            subAccountApiKeys: [subUserApiKeys]
+          },
+          method: 'recoverPassword',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isOk(res.body.result.isSubAccount)
+      assert.strictEqual(res.body.result.token, subAccountAuth.token)
+    })
+
+    it('it should not be successfully performed by the signIn method with old pwd', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password: newPassword,
+            isSubAccount: true
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(401)
+
+      assert.isObject(res.body)
+      assert.isObject(res.body.error)
+      assert.propertyVal(res.body.error, 'code', 401)
+      assert.propertyVal(res.body.error, 'message', 'Unauthorized')
+      assert.propertyVal(res.body, 'id', 5)
+    })
+
+    it('it should be successfully performed by the signIn method with new pwd', async function () {
+      this.timeout(5000)
+
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth: {
+            email: masterUserEmail,
+            password,
+            isSubAccount: true
+          },
+          method: 'signIn',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isObject(res.body.result)
+      assert.strictEqual(res.body.result.email, masterUserEmail)
+      assert.isBoolean(res.body.result.isSubAccount)
+      assert.isOk(res.body.result.isSubAccount)
+      assert.strictEqual(res.body.result.token, subAccountAuth.token)
+    })
+  })
+})

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -95,6 +95,19 @@ class FrameworkReportService extends ReportService {
     }, 'signOut', cb)
   }
 
+  recoverPassword (space, args, cb) {
+    return this._responder(() => {
+      const { auth } = { ...args }
+      const { isSubAccount } = { ...auth }
+
+      if (isSubAccount) {
+        return this._subAccount.recoverPassword(args)
+      }
+
+      return this._authenticator.recoverPassword(args)
+    }, 'recoverPassword', cb)
+  }
+
   verifyUser (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.verifyUser(

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -320,8 +320,8 @@ class Authenticator {
       apiKey,
       apiSecret,
       newPassword,
-      isSubAccount,
-      isNotProtected
+      isSubAccount = false,
+      isNotProtected = false
     } = { ...auth }
     const password = isNotProtected
       ? this.crypto.getSecretKey()
@@ -329,7 +329,9 @@ class Authenticator {
     const {
       active = true,
       isDataFromDb = true,
-      isReturnedUser
+      isReturnedUser = false,
+      isNotInTrans = false,
+      isSubUser = false
     } = { ...params }
 
     if (
@@ -338,7 +340,8 @@ class Authenticator {
       !apiSecret ||
       typeof apiSecret !== 'string' ||
       !password ||
-      typeof password !== 'string'
+      typeof password !== 'string' ||
+      (isSubAccount && isSubUser)
     ) {
       throw new AuthError()
     }
@@ -361,9 +364,12 @@ class Authenticator {
       {
         email,
         isSubAccount,
-        isSubUser: false
+        isSubUser
       },
-      { isFilledSubUsers: true }
+      {
+        isFilledSubUsers: true,
+        isNotInTrans
+      }
     )
 
     if (
@@ -386,7 +392,8 @@ class Authenticator {
 
     const username = this.generateSubUserName(
       { username: uName },
-      isSubAccount
+      isSubAccount,
+      isSubUser
     )
     const freshUserData = {
       id,
@@ -425,6 +432,10 @@ class Authenticator {
     const returnedUser = isReturnedUser
       ? refreshedUser
       : {}
+
+    if (isSubUser) {
+      return returnedUser
+    }
 
     const existedToken = this.getUserSessionByEmail(
       { email, isSubAccount }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -314,6 +314,138 @@ class Authenticator {
     return true
   }
 
+  async recoverPassword (args, params) {
+    const { auth } = { ...args }
+    const {
+      apiKey,
+      apiSecret,
+      newPassword,
+      isSubAccount,
+      isNotProtected
+    } = { ...auth }
+    const password = isNotProtected
+      ? this.crypto.getSecretKey()
+      : newPassword
+    const {
+      active = true,
+      isDataFromDb = true,
+      isReturnedUser
+    } = { ...params }
+
+    if (
+      !apiKey ||
+      typeof apiKey !== 'string' ||
+      !apiSecret ||
+      typeof apiSecret !== 'string' ||
+      !password ||
+      typeof password !== 'string'
+    ) {
+      throw new AuthError()
+    }
+
+    const {
+      id,
+      email,
+      timezone,
+      username: uName
+    } = await this.rService._checkAuthInApi(args)
+
+    if (
+      !email ||
+      typeof email !== 'string'
+    ) {
+      throw new AuthError()
+    }
+
+    const userFromDb = await this.getUser(
+      {
+        email,
+        isSubAccount,
+        isSubUser: false,
+        isFilledSubUsers: true
+      }
+    )
+
+    if (
+      !userFromDb ||
+      typeof userFromDb !== 'object' ||
+      !Number.isInteger(userFromDb._id)
+    ) {
+      throw new AuthError()
+    }
+
+    const [
+      encryptedApiKey,
+      encryptedApiSecret,
+      passwordHash
+    ] = await Promise.all([
+      this.crypto.encrypt(apiKey, password),
+      this.crypto.encrypt(apiSecret, password),
+      this.crypto.hashPassword(password)
+    ])
+
+    const username = this.generateSubUserName(
+      { username: uName },
+      isSubAccount
+    )
+    const freshUserData = {
+      id,
+      timezone,
+      username,
+      email,
+      apiKey: encryptedApiKey,
+      apiSecret: encryptedApiSecret,
+      passwordHash,
+      active: active === null
+        ? userFromDb.active
+        : active,
+      isDataFromDb: isDataFromDb === null
+        ? userFromDb.isDataFromDb
+        : isDataFromDb
+    }
+
+    const res = await this.dao.updateCollBy(
+      this.TABLES_NAMES.USERS,
+      { _id: userFromDb._id, email },
+      {
+        ...freshUserData,
+        active: serializeVal(freshUserData.active),
+        isDataFromDb: serializeVal(freshUserData.isDataFromDb)
+      }
+    )
+
+    if (res && res.changes < 1) {
+      throw new AuthError()
+    }
+
+    const refreshedUser = {
+      ...userFromDb,
+      ...freshUserData
+    }
+    const returnedUser = isReturnedUser
+      ? refreshedUser
+      : {}
+
+    const existedToken = this.getUserSessionByEmail(
+      { email, isSubAccount }
+    ).token
+    const createdToken = (
+      existedToken &&
+      typeof existedToken === 'string'
+    )
+      ? existedToken
+      : uuidv4()
+
+    this.setUserSession({ ...refreshedUser, token: createdToken })
+
+    return {
+      ...returnedUser,
+      email,
+      isSubAccount,
+      token: createdToken
+    }
+  }
+
   async verifyUser (args, params) {
     const { auth } = { ...args }
     const {

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -361,9 +361,9 @@ class Authenticator {
       {
         email,
         isSubAccount,
-        isSubUser: false,
-        isFilledSubUsers: true
-      }
+        isSubUser: false
+      },
+      { isFilledSubUsers: true }
     )
 
     if (

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -198,6 +198,22 @@ class SubAccount {
       }
     })
   }
+
+  // TODO:
+  async recoverPassword (args) {
+    const { auth, params } = { ...args }
+    const {
+      apiKey,
+      apiSecret,
+      newPassword,
+      isSubAccount,
+      isNotProtected
+    } = { ...auth }
+    const {
+      subAccountPassword,
+      subAccountApiKeys
+    } = { ...params }
+  }
 }
 
 decorate(injectable(), SubAccount)


### PR DESCRIPTION
This PR adds a password recovery feature for users and sub-accounts. Basic changes:
  - adds `recoverPassword` method to the main service
  - adds corresponding test coverage

To recover password need to do the following request:
  - for simple user:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---",
        "newPassword": "123Qwerty",
        "isSubAccount": false
    },
    "method": "recoverPassword"
}
```
response
```json
{
    "result": {
        "email": "user@email.com",
        "isSubAccount": false,
        "token": "someToken"
    },
    "id": null
}
```

  - for sub-account:
```json
{
    "auth": {
        "apiKey": "masterUserApiKey",
        "apiSecret": "masterUserApiSecret",
        "newPassword": "Qwerty123",
        "isSubAccount": true
    },
    "method": "recoverPassword",
    "params": {
    	"subAccountApiKeys": [
    	    {
    	        "apiKey": "subUserApiKey",
                "apiSecret": "subUserApiSecret"
    	    }
    	]
    }
}
```
response
```json
{
    "result": {
        "email": "user@email.com",
        "isSubAccount": true,
        "token": "someToken"
    },
    "id": null
}
```