### PR TITLE
Fix performing loan report

### DIFF
--- a/workers/loc.api/sync/helpers/get-back-iterable.js
+++ b/workers/loc.api/sync/helpers/get-back-iterable.js
@@ -1,0 +1,19 @@
+'use strict'
+
+module.exports = (array) => {
+  return {
+    [Symbol.iterator] () {
+      return {
+        index: array.length,
+        next () {
+          this.index -= 1
+
+          return {
+            done: this.index < 0,
+            value: array[this.index]
+          }
+        }
+      }
+    }
+  }
+}

--- a/workers/loc.api/sync/helpers/index.js
+++ b/workers/loc.api/sync/helpers/index.js
@@ -12,6 +12,7 @@ const splitSymbolPairs = require('./split-symbol-pairs')
 const setMtsToStartingAndEndingFrames = require(
   './set-mts-to-starting-and-ending-frames'
 )
+const getBackIterable = require('./get-back-iterable')
 const {
   delay
 } = require('./utils')
@@ -27,5 +28,6 @@ module.exports = {
   checkCollPermission,
   splitSymbolPairs,
   delay,
-  setMtsToStartingAndEndingFrames
+  setMtsToStartingAndEndingFrames,
+  getBackIterable
 }

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -100,7 +100,7 @@ class PerformingLoan {
       return 0
     }
 
-    return (amount / balance) * 365 * 100
+    return (Math.pow(1 + amount / balance, 365) - 1) * 100
   }
 
   _calcDailyPercs (data) {

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -31,6 +31,8 @@ class PerformingLoan {
 
     this.tradesMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
+    this.ledgersModel = this.syncSchema.getModelsMap()
+      .get(this.ALLOWED_COLLS.LEDGERS)
   }
 
   async _getLedgers ({
@@ -40,7 +42,8 @@ class PerformingLoan {
     symbol,
     filter = {
       $eq: { _isMarginFundingPayment: 1 }
-    }
+    },
+    projection = this.ledgersModel
   }) {
     const user = await this.authenticator
       .verifyRequestUser({ auth })
@@ -51,8 +54,6 @@ class PerformingLoan {
     )
       ? { $in: { currency: symbol } }
       : {}
-    const ledgersModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.LEDGERS)
 
     return this.dao.getElemsInCollBy(
       this.ALLOWED_COLLS.LEDGERS,
@@ -65,11 +66,76 @@ class PerformingLoan {
           ...symbFilter
         },
         sort: [['mts', -1]],
-        projection: ledgersModel,
+        projection,
         exclude: ['user_id'],
         isExcludePrivate: true
       }
     )
+  }
+
+  _getFundingBalances ({
+    auth,
+    start,
+    end,
+    symbol,
+    filter = {
+      $eq: { wallet: 'funding' },
+      $isNotNull: ['balance']
+    }
+  }) {
+    return this._getLedgers({
+      auth,
+      start,
+      end,
+      symbol,
+      filter,
+      projection: ['mts', 'currency', 'balance']
+    })
+  }
+
+  _findMaxBalanceBetweenMts (
+    balances = [],
+    params = {}
+  ) {
+    const {
+      end = Date.now(),
+      start = 0,
+      symbol
+    } = { ...params }
+
+    if (
+      !Array.isArray(balances) ||
+      balances.length === 0 ||
+      !Number.isInteger(end) ||
+      !Number.isInteger(start)
+    ) {
+      return null
+    }
+
+    let maxBalance = null
+
+    for (const ledger of balances) {
+      const {
+        mts,
+        currency,
+        balance
+      } = { ...ledger }
+
+      if (mts < start) {
+        break
+      }
+      if (
+        mts > end ||
+        currency !== symbol
+      ) {
+        continue
+      }
+      if (balance > maxBalance) {
+        maxBalance = balance
+      }
+    }
+
+    return maxBalance
   }
 
   _calcPercsArr (percs) {
@@ -103,26 +169,37 @@ class PerformingLoan {
     return (Math.pow(1 + amount / balance, 365) - 1) * 100
   }
 
-  _calcDailyPercs (data) {
+  _calcDailyPercs (data, balances) {
     let prevMts = 0
 
     const percsGroupedByDays = data.reduce(
       (accum, ledger = {}) => {
-        const { amount, balance, mts } = { ...ledger }
+        const { amount, mts, currency } = { ...ledger }
+        const maxBalance = this._findMaxBalanceBetweenMts(
+          balances,
+          {
+            end: mts,
+            start: Number.isInteger(mts)
+              ? mts - 24 * 60 * 60 * 1000
+              : null,
+            symbol: currency
+          }
+        )
+        console.log('[maxBalance]:'.bgRed, maxBalance)
 
         if (
           accum.length !== 0 &&
           this._isSameDay(prevMts, mts)
         ) {
           accum[accum.length - 1].push(
-            this._calcPerc(amount, balance)
+            this._calcPerc(amount, maxBalance)
           )
           prevMts = mts
 
           return accum
         }
 
-        accum.push([this._calcPerc(amount, balance)])
+        accum.push([this._calcPerc(amount, maxBalance)])
         prevMts = mts
 
         return accum
@@ -135,7 +212,7 @@ class PerformingLoan {
     })
   }
 
-  _calcLedgers () {
+  _calcLedgers (balances) {
     return (data = []) => {
       const res = data.reduce((accum, ledger = {}) => {
         const { amountUsd } = { ...ledger }
@@ -151,7 +228,7 @@ class PerformingLoan {
             : amountUsd
         }
       }, {})
-      const dailyPercs = this._calcDailyPercs(data)
+      const dailyPercs = this._calcDailyPercs(data, balances)
 
       return {
         ...res,
@@ -237,6 +314,7 @@ class PerformingLoan {
     }
 
     const ledgers = await this._getLedgers(args)
+    const balances = await this._getFundingBalances(args)
 
     const {
       dateFieldName: ledgersDateFieldName,
@@ -249,7 +327,7 @@ class PerformingLoan {
       this.FOREX_SYMBS,
       ledgersDateFieldName,
       ledgersSymbolFieldName,
-      this._calcLedgers()
+      this._calcLedgers(balances)
     )
 
     const groupedData = await calcGroupedData(

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -180,12 +180,12 @@ class PerformingLoan {
           {
             end: mts,
             start: Number.isInteger(mts)
-              ? mts - 24 * 60 * 60 * 1000
+              /* Used 30h instead of 24h as might have overlaps */
+              ? mts - 30 * 60 * 60 * 1000
               : null,
             symbol: currency
           }
         )
-        console.log('[maxBalance]:'.bgRed, maxBalance)
 
         if (
           accum.length !== 0 &&


### PR DESCRIPTION
This PR fixes performing loan report, the issue is we should use the max balance of the last 30h for calculating record of founding earnings instead of using the balance. Basic changes:
  - improves percentage calculation to consider compound interest
  - uses the max balance of the last 30 hours