### PR TITLE
Increases win/loss report performance

### DIFF
--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -267,7 +267,7 @@ class BalanceHistory {
         return accum + balance
       }
 
-      const prise = this._getCandlesClosePrice(
+      const price = this._getCandlesClosePrice(
         candles,
         mts,
         timeframe,
@@ -276,13 +276,13 @@ class BalanceHistory {
       )
 
       if (
-        !Number.isFinite(prise) ||
+        !Number.isFinite(price) ||
         !Number.isFinite(balance)
       ) {
         return accum
       }
 
-      return accum + balance * prise
+      return accum + balance * price
     }, 0)
 
     return { USD: resInUsd }

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -267,15 +267,13 @@ class BalanceHistory {
         return accum + balance
       }
 
-      const prise = {
-        ...this._getCandlesClosePrice(
-          candles,
-          mts,
-          timeframe,
-          `t${symb}USD`,
-          currenciesSynonymous
-        )
-      }
+      const prise = this._getCandlesClosePrice(
+        candles,
+        mts,
+        timeframe,
+        `t${symb}USD`,
+        currenciesSynonymous
+      )
 
       if (
         !Number.isFinite(prise) ||

--- a/workers/loc.api/sync/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/helpers/calc-grouped-data.js
@@ -24,6 +24,8 @@ const _getMaxLength = (data) => {
   )
 }
 
+// Applies Object.assign instead of spread operator
+// to increase performance
 const _mergeData = (data) => {
   if (
     !data ||
@@ -40,7 +42,7 @@ const _mergeData = (data) => {
 
   for (let i = 0; maxLength > i; i += 1) {
     dataKeys.forEach(key => {
-      const { mts, vals } = { ..._data[key][i] }
+      const { mts, vals } = Object.assign({}, _data[key][i])
       const firstItem = res[0]
       const lastItem = res[res.length - 1]
 
@@ -58,7 +60,7 @@ const _mergeData = (data) => {
       ) {
         res.unshift({
           mts,
-          [key]: { ...vals }
+          [key]: Object.assign({}, vals)
         })
 
         return
@@ -69,7 +71,7 @@ const _mergeData = (data) => {
       ) {
         res.push({
           mts,
-          [key]: { ...vals }
+          [key]: Object.assign({}, vals)
         })
 
         return
@@ -77,10 +79,9 @@ const _mergeData = (data) => {
 
       for (const [index, item] of iterator.entries()) {
         if (mts === item.mts) {
-          res[index] = {
-            ...item,
-            [key]: { ...vals }
-          }
+          res[index] = Object.assign({}, item, {
+            [key]: Object.assign({}, vals)
+          })
 
           return
         }
@@ -91,7 +92,7 @@ const _mergeData = (data) => {
         ) {
           res.splice(index + 1, 0, {
             mts,
-            [key]: { ...vals }
+            [key]: Object.assign({}, vals)
           })
 
           return
@@ -124,6 +125,8 @@ const _calcDataItem = (item = []) => {
   }, {})
 }
 
+// Applies Object.assign instead of spread operator
+// to increase performance
 const _getReducer = (
   isSubCalc,
   isReverse,
@@ -141,10 +144,12 @@ const _getReducer = (
       return accum
     }
 
-    const data = {
-      mts: item.mts,
-      ...(isSubCalc ? { vals: { ...res } } : res)
-    }
+    const data = isSubCalc
+      ? {
+        mts: item.mts,
+        vals: Object.assign({}, res)
+      }
+      : Object.assign({ mts: item.mts }, res)
 
     if (isReverse) {
       accum.unshift(data)

--- a/workers/loc.api/sync/helpers/get-back-iterable.js
+++ b/workers/loc.api/sync/helpers/get-back-iterable.js
@@ -2,7 +2,7 @@
 
 module.exports = (array) => {
   return {
-    [Symbol.iterator] () {
+    [Symbol.iterator] (areEntriesReturned) {
       return {
         index: array.length,
         next () {
@@ -10,9 +10,18 @@ module.exports = (array) => {
 
           return {
             done: this.index < 0,
-            value: array[this.index]
+            value: areEntriesReturned
+              ? [this.index, array[this.index]]
+              : array[this.index]
           }
         }
+      }
+    },
+    entries () {
+      const iterator = this[Symbol.iterator](true)
+
+      return {
+        [Symbol.iterator] () { return iterator }
       }
     }
   }

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -516,14 +516,23 @@ class PositionsSnapshot {
       tickers: []
     }
 
-    const positionsHistory = await this._getPositionsHistory(
+    const positionsHistoryPromise = this._getPositionsHistory(
       user,
       end
     )
-    const activePositions = await this._getActivePositions(
+    const activePositionsPromise = this._getActivePositions(
       auth,
       end
     )
+
+    const [
+      positionsHistory,
+      activePositions
+    ] = await Promise.all([
+      positionsHistoryPromise,
+      activePositionsPromise
+    ])
+
     const positions = this._mergePositions(
       positionsHistory,
       activePositions


### PR DESCRIPTION
This PR increases the win/loss report performance. Basic changes:
  - Increases grouped data calc performance avoiding redundant data ordering, it related to the fact that in this place we can have plenty of data of big users
  - Increases positions snapshot performance
  - Increases balance history performance
  - Increases win/loss performance
  - Fixes getting candles close price