### PR TITLE
Optimize currency converter

### DIFF
--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -45,6 +45,8 @@ class CurrencyConverter {
       CANDLES: 'candles'
     }
     this.candlesTimeframe = '1D'
+    this.candlesSchema = this.syncSchema.getMethodCollMap()
+      .get(this.SYNC_API_METHODS.CANDLES)
 
     this.currenciesUpdatedAt = new Date()
     this.currencies = []
@@ -321,7 +323,8 @@ class CurrencyConverter {
 
     const symbol = this._getPairFromPair(reqSymb)
     const { res } = await getDataFromApi(
-      (space, args) => this.rService._getPublicTrades.bind(this.rService)(args),
+      (space, args) => this.rService._getPublicTrades
+        .bind(this.rService)(args),
       {
         params: {
           symbol,
@@ -345,9 +348,6 @@ class CurrencyConverter {
     reqSymb,
     end
   ) {
-    const candlesSchema = this.syncSchema.getMethodCollMap()
-      .get(this.SYNC_API_METHODS.CANDLES)
-
     if (
       !reqSymb ||
       !Number.isInteger(end)
@@ -357,13 +357,13 @@ class CurrencyConverter {
 
     const symbol = this._getPairFromPair(reqSymb)
     const candle = await this.dao.getElemInCollBy(
-      candlesSchema.name,
+      this.candlesSchema.name,
       {
-        [candlesSchema.symbolFieldName]: symbol,
+        [this.candlesSchema.symbolFieldName]: symbol,
         end,
-        _dateFieldName: [candlesSchema.dateFieldName]
+        _dateFieldName: [this.candlesSchema.dateFieldName]
       },
-      candlesSchema.sort
+      this.candlesSchema.sort
     )
     const { close } = { ...candle }
 
@@ -700,8 +700,7 @@ class CurrencyConverter {
       symbolFieldName,
       dateFieldName,
       timeframeFieldName
-    } = this.syncSchema.getMethodCollMap()
-      .get(this.SYNC_API_METHODS.CANDLES)
+    } = this.candlesSchema
     const symbFilter = (
       Array.isArray(symbol) &&
       symbol.length !== 0

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -414,25 +414,25 @@ class CurrencyConverter {
     const _getPrice = this._getPriceMethod(collName)
 
     if (isRequiredConvFromForex) {
-      const btcPriseIn = await _getPrice(
+      const btcPriceIn = await _getPrice(
         `tBTC${item[symbolFieldName]}`,
         end
       )
-      const btcPriseOut = await _getPrice(
+      const btcPriceOut = await _getPrice(
         `tBTC${convertTo}`,
         end
       )
 
       if (
-        !btcPriseIn ||
-        !btcPriseOut ||
-        !Number.isFinite(btcPriseIn) ||
-        !Number.isFinite(btcPriseOut)
+        !btcPriceIn ||
+        !btcPriceOut ||
+        !Number.isFinite(btcPriceIn) ||
+        !Number.isFinite(btcPriceOut)
       ) {
         return null
       }
 
-      return btcPriseOut / btcPriseIn
+      return btcPriceOut / btcPriceIn
     }
 
     const price = await _getPrice(
@@ -605,27 +605,27 @@ class CurrencyConverter {
     )
 
     if (_isForexSymb) {
-      const btcPriseIn = this._findCandlesPrice(
+      const btcPriceIn = this._findCandlesPrice(
         candles,
         `tBTC${firstSymb}`,
         end
       )
-      const btcPriseOut = this._findCandlesPrice(
+      const btcPriceOut = this._findCandlesPrice(
         candles,
         `tBTC${lastSymb}`,
         end
       )
 
       if (
-        !btcPriseIn ||
-        !btcPriseOut ||
-        !Number.isFinite(btcPriseIn) ||
-        !Number.isFinite(btcPriseOut)
+        !btcPriceIn ||
+        !btcPriceOut ||
+        !Number.isFinite(btcPriceIn) ||
+        !Number.isFinite(btcPriceOut)
       ) {
         return null
       }
 
-      return btcPriseOut / btcPriseIn
+      return btcPriceOut / btcPriceIn
     }
 
     return this._findCandlesPrice(
@@ -655,27 +655,27 @@ class CurrencyConverter {
     )
 
     if (_isForexSymb) {
-      const btcPriseIn = this._findPublicTradesPrice(
+      const btcPriceIn = this._findPublicTradesPrice(
         publicTrades,
         `tBTC${firstSymb}`,
         end
       )
-      const btcPriseOut = this._findPublicTradesPrice(
+      const btcPriceOut = this._findPublicTradesPrice(
         publicTrades,
         `tBTC${lastSymb}`,
         end
       )
 
       if (
-        !btcPriseIn ||
-        !btcPriseOut ||
-        !Number.isFinite(btcPriseIn) ||
-        !Number.isFinite(btcPriseOut)
+        !btcPriceIn ||
+        !btcPriceOut ||
+        !Number.isFinite(btcPriceIn) ||
+        !Number.isFinite(btcPriceOut)
       ) {
         return null
       }
 
-      return btcPriseOut / btcPriseIn
+      return btcPriceOut / btcPriceIn
     }
 
     return this._findPublicTradesPrice(


### PR DESCRIPTION
This PR optimizes the currency converter. Basic changes:
  - adds an ability to cache currencies endpoint response during 20min to avoid redundant calls to the db and api
  - avoids cloning candles sync schema