### PR TITLE
Run vacuum command at startup

### DIFF
--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -213,6 +213,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _vacuum () {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.RUN,
+      sql: 'VACUUM'
+    })
+  }
+
   optimize () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -266,6 +273,7 @@ class BetterSqliteDAO extends DAO {
     await this._createTablesIfNotExists()
     await this._createIndexisIfNotExists()
     await this._createTriggerIfNotExists()
+    await this._vacuum()
     await this.setCurrDbVer(this.syncSchema.SUPPORTED_DB_VERSION)
   }
 


### PR DESCRIPTION
This PR runs the `VACUUM` command at the startup of the app. The database file might be larger than strictly necessary, running `VACUUM` to rebuild the database reclaims this space and reduces the size of the database file, check the doc https://sqlite.org/lang_vacuum.html