### PR TITLE
Avoid throwing error to not deny access during sync

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -16,6 +16,9 @@ const TABLES_NAMES = require('../sync/schema/tables-names')
 const ALLOWED_COLLS = require('../sync/schema/allowed.colls')
 const SYNC_API_METHODS = require('../sync/schema/sync.api.methods')
 const SYNC_QUEUE_STATES = require('../sync/sync.queue/sync.queue.states')
+const CHECKER_NAMES = require(
+  '../sync/data.consistency.checker/checker.names'
+)
 const WSTransport = require('../ws-transport')
 const WSEventEmitter = require(
   '../ws-transport/ws.event.emitter'
@@ -27,6 +30,7 @@ const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
 const SyncCollsManager = require('../sync/sync.colls.manager')
+const DataConsistencyChecker = require('../sync/data.consistency.checker')
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -100,6 +104,7 @@ module.exports = ({
           ['_ALLOWED_COLLS', TYPES.ALLOWED_COLLS],
           ['_SYNC_API_METHODS', TYPES.SYNC_API_METHODS],
           ['_SYNC_QUEUE_STATES', TYPES.SYNC_QUEUE_STATES],
+          ['_CHECKER_NAMES', TYPES.CHECKER_NAMES],
           ['_prepareResponse', TYPES.PrepareResponse],
           ['_subAccount', TYPES.SubAccount],
           ['_progress', TYPES.Progress],
@@ -120,7 +125,8 @@ module.exports = ({
           ['_orderTrades', TYPES.OrderTrades],
           ['_authenticator', TYPES.Authenticator],
           ['_privResponder', TYPES.PrivResponder],
-          ['_syncCollsManager', TYPES.SyncCollsManager]
+          ['_syncCollsManager', TYPES.SyncCollsManager],
+          ['_dataConsistencyChecker', TYPES.DataConsistencyChecker]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)
@@ -142,6 +148,7 @@ module.exports = ({
     bind(TYPES.ALLOWED_COLLS).toConstantValue(ALLOWED_COLLS)
     bind(TYPES.SYNC_API_METHODS).toConstantValue(SYNC_API_METHODS)
     bind(TYPES.SYNC_QUEUE_STATES).toConstantValue(SYNC_QUEUE_STATES)
+    bind(TYPES.CHECKER_NAMES).toConstantValue(CHECKER_NAMES)
     bind(TYPES.GRC_BFX_OPTS).toConstantValue(grcBfxOpts)
     bind(TYPES.FOREX_SYMBS).toConstantValue(FOREX_SYMBS)
     bind(TYPES.WSTransport)
@@ -246,6 +253,9 @@ module.exports = ({
       .inSingletonScope()
     bind(TYPES.SyncCollsManager)
       .to(SyncCollsManager)
+      .inSingletonScope()
+    bind(TYPES.DataConsistencyChecker)
+      .to(DataConsistencyChecker)
       .inSingletonScope()
     bind(TYPES.Sync)
       .to(Sync)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -30,7 +30,12 @@ const Sync = require('../sync')
 const SyncInterrupter = require('../sync/sync.interrupter')
 const SyncQueue = require('../sync/sync.queue')
 const SyncCollsManager = require('../sync/sync.colls.manager')
-const DataConsistencyChecker = require('../sync/data.consistency.checker')
+const Checkers = require(
+  '../sync/data.consistency.checker/checkers'
+)
+const DataConsistencyChecker = require(
+  '../sync/data.consistency.checker'
+)
 const {
   redirectRequestsToApi,
   FOREX_SYMBS
@@ -253,6 +258,9 @@ module.exports = ({
       .inSingletonScope()
     bind(TYPES.SyncCollsManager)
       .to(SyncCollsManager)
+      .inSingletonScope()
+    bind(TYPES.Checkers)
+      .to(Checkers)
       .inSingletonScope()
     bind(TYPES.DataConsistencyChecker)
       .to(DataConsistencyChecker)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -8,6 +8,7 @@ module.exports = {
   ALLOWED_COLLS: Symbol.for('ALLOWED_COLLS'),
   SYNC_API_METHODS: Symbol.for('SYNC_API_METHODS'),
   SYNC_QUEUE_STATES: Symbol.for('SYNC_QUEUE_STATES'),
+  CHECKER_NAMES: Symbol.for('CHECKER_NAMES'),
   FrameworkRServiceDepsSchema: Symbol.for('FrameworkRServiceDepsSchema'),
   GRC_BFX_OPTS: Symbol.for('GRC_BFX_OPTS'),
   ApiMiddlewareHandlerAfter: Symbol.for('ApiMiddlewareHandlerAfter'),
@@ -55,5 +56,6 @@ module.exports = {
   Authenticator: Symbol.for('Authenticator'),
   PrivResponder: Symbol.for('PrivResponder'),
   SyncInterrupter: Symbol.for('SyncInterrupter'),
-  SyncCollsManager: Symbol.for('SyncCollsManager')
+  SyncCollsManager: Symbol.for('SyncCollsManager'),
+  DataConsistencyChecker: Symbol.for('DataConsistencyChecker')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -57,5 +57,6 @@ module.exports = {
   PrivResponder: Symbol.for('PrivResponder'),
   SyncInterrupter: Symbol.for('SyncInterrupter'),
   SyncCollsManager: Symbol.for('SyncCollsManager'),
+  Checkers: Symbol.for('Checkers'),
   DataConsistencyChecker: Symbol.for('DataConsistencyChecker')
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -153,6 +153,12 @@ class SyncedPositionsSnapshotParamsError extends BaseError {
   }
 }
 
+class DataConsistencyCheckerFindingError extends BaseError {
+  constructor (message = 'ERR_DATA_CONSISTENCY_CHECKER_HAS_NOT_BEEN_FOUND') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -178,5 +184,6 @@ module.exports = {
   SubAccountLedgersBalancesRecalcError,
   DatePropNameError,
   GetPublicDataError,
-  SyncedPositionsSnapshotParamsError
+  SyncedPositionsSnapshotParamsError,
+  DataConsistencyCheckerFindingError
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -159,6 +159,12 @@ class DataConsistencyCheckerFindingError extends BaseError {
   }
 }
 
+class DataConsistencyError extends BaseError {
+  constructor (message = 'ERR_COLLECTIONS_DATA_IS_NOT_CONSISTENT') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -185,5 +191,6 @@ module.exports = {
   DatePropNameError,
   GetPublicDataError,
   SyncedPositionsSnapshotParamsError,
-  DataConsistencyCheckerFindingError
+  DataConsistencyCheckerFindingError,
+  DataConsistencyError
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1147,9 +1147,8 @@ class FrameworkReportService extends ReportService {
    */
   getWallets (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.WALLETS, args)
 
       checkParams(args, 'paramsSchemaForWallets')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1213,9 +1213,8 @@ class FrameworkReportService extends ReportService {
 
   getTradedVolume (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.TRADED_VOLUME, args)
 
       checkParams(args, 'paramsSchemaForTradedVolumeApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1224,9 +1224,8 @@ class FrameworkReportService extends ReportService {
 
   getFeesReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FEES_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFeesReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1180,9 +1180,8 @@ class FrameworkReportService extends ReportService {
 
   getPositionsSnapshot (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.POSITIONS_SNAPSHOT, args)
 
       checkParams(args, 'paramsSchemaForPositionsSnapshotApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1202,9 +1202,8 @@ class FrameworkReportService extends ReportService {
 
   getFullTaxReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FULL_TAX_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFullTaxReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1158,9 +1158,8 @@ class FrameworkReportService extends ReportService {
 
   getBalanceHistory (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.BALANCE_HISTORY, args)
 
       checkParams(args, 'paramsSchemaForBalanceHistoryApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1191,9 +1191,8 @@ class FrameworkReportService extends ReportService {
 
   getFullSnapshotReport (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.FULL_SNAPSHOT_REPORT, args)
 
       checkParams(args, 'paramsSchemaForFullSnapshotReportApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1169,9 +1169,8 @@ class FrameworkReportService extends ReportService {
 
   getWinLoss (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.WIN_LOSS, args)
 
       checkParams(args, 'paramsSchemaForWinLossApi')
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -15,8 +15,7 @@ const {
 
 const ReportService = require('./service.report')
 const {
-  ServerAvailabilityError,
-  DuringSyncMethodAccessError
+  ServerAvailabilityError
 } = require('./errors')
 const {
   checkParams,
@@ -1235,9 +1234,8 @@ class FrameworkReportService extends ReportService {
 
   getPerformingLoan (space, args, cb) {
     return this._privResponder(async () => {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        throw new DuringSyncMethodAccessError()
-      }
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.PERFORMING_LOAN, args)
 
       checkParams(args, 'paramsSchemaForPerformingLoanApi')
 

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
@@ -10,6 +10,7 @@ const getInsertableArrayObjectsFilter = require(
 const getStatusMessagesFilter = require(
   '../get-status-messages-filter'
 )
+const TABLES_NAMES = require('../../../schema/tables-names')
 
 module.exports = (args, methodColl, opts) => {
   const { auth, params } = { ...args }
@@ -31,10 +32,16 @@ module.exports = (args, methodColl, opts) => {
   }
 
   if (!isPublic) {
-    const { _id } = { ...auth }
+    const { _id, isSubAccount } = { ...auth }
 
     if (!Number.isInteger(_id)) {
       throw new AuthError()
+    }
+    if (
+      methodColl.name === TABLES_NAMES.LEDGERS &&
+      isSubAccount
+    ) {
+      filter._isBalanceRecalced = 1
     }
 
     filter.user_id = _id

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -4,5 +4,6 @@ module.exports = {
   WALLETS: 'getWallets',
   BALANCE_HISTORY: 'getBalanceHistory',
   WIN_LOSS: 'getWinLoss',
-  POSITIONS_SNAPSHOT: 'getPositionsSnapshot'
+  POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
+  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  WALLETS: 'getWallets'
+}

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
-  WALLETS: 'getWallets'
+  WALLETS: 'getWallets',
+  BALANCE_HISTORY: 'getBalanceHistory'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -6,5 +6,6 @@ module.exports = {
   WIN_LOSS: 'getWinLoss',
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
-  FULL_TAX_REPORT: 'getFullTaxReport'
+  FULL_TAX_REPORT: 'getFullTaxReport',
+  TRADED_VOLUME: 'getTradedVolume'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -5,5 +5,6 @@ module.exports = {
   BALANCE_HISTORY: 'getBalanceHistory',
   WIN_LOSS: 'getWinLoss',
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
-  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport'
+  FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
+  FULL_TAX_REPORT: 'getFullTaxReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -8,5 +8,6 @@ module.exports = {
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
   FULL_TAX_REPORT: 'getFullTaxReport',
   TRADED_VOLUME: 'getTradedVolume',
-  FEES_REPORT: 'getFeesReport'
+  FEES_REPORT: 'getFeesReport',
+  PERFORMING_LOAN: 'getPerformingLoan'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -3,5 +3,6 @@
 module.exports = {
   WALLETS: 'getWallets',
   BALANCE_HISTORY: 'getBalanceHistory',
-  WIN_LOSS: 'getWinLoss'
+  WIN_LOSS: 'getWinLoss',
+  POSITIONS_SNAPSHOT: 'getPositionsSnapshot'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -7,5 +7,6 @@ module.exports = {
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
   FULL_TAX_REPORT: 'getFullTaxReport',
-  TRADED_VOLUME: 'getTradedVolume'
+  TRADED_VOLUME: 'getTradedVolume',
+  FEES_REPORT: 'getFeesReport'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   WALLETS: 'getWallets',
-  BALANCE_HISTORY: 'getBalanceHistory'
+  BALANCE_HISTORY: 'getBalanceHistory',
+  WIN_LOSS: 'getWinLoss'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -18,8 +18,18 @@ class Checkers {
     this.syncCollsManager = syncCollsManager
   }
 
-  // TODO:
-  [CHECKER_NAMES.WALLETS] (auth) {}
+  [CHECKER_NAMES.WALLETS] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+const CHECKER_NAMES = require('./checker.names')
+
+class Checkers {
+  constructor (
+    SYNC_API_METHODS,
+    syncCollsManager
+  ) {
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.syncCollsManager = syncCollsManager
+  }
+
+  // TODO:
+  [CHECKER_NAMES.WALLETS] (auth) {}
+}
+
+decorate(injectable(), Checkers)
+decorate(inject(TYPES.SYNC_API_METHODS), Checkers, 0)
+decorate(inject(TYPES.SyncCollsManager), Checkers, 1)
+
+module.exports = Checkers

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -72,6 +72,21 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FULL_SNAPSHOT_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -116,6 +116,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FEES_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.TRADES,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -30,6 +30,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.BALANCE_HISTORY] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -87,6 +87,22 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.FULL_TAX_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.MOVEMENTS,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -58,6 +58,20 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.POSITIONS_SNAPSHOT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -129,6 +129,38 @@ class Checkers {
         }
       })
   }
+
+  async [CHECKER_NAMES.PERFORMING_LOAN] (auth) {
+    const {
+      _id: userId,
+      subUsers,
+      isSubAccount
+    } = { ...auth }
+
+    if (!isSubAccount) {
+      return this.syncCollsManager
+        .hasCollBeenSyncedAtLeastOnce({
+          userId,
+          collName: this.SYNC_API_METHODS.LEDGERS
+        })
+    }
+
+    for (const subUser of subUsers) {
+      const { _id: subUserId } = { ...subUser }
+      const isValid = await this.syncCollsManager
+        .hasCollBeenSyncedAtLeastOnce({
+          userId,
+          subUserId,
+          collName: this.SYNC_API_METHODS.LEDGERS
+        })
+
+      if (!isValid) {
+        return false
+      }
+    }
+
+    return true
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -43,6 +43,21 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.WIN_LOSS] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.MOVEMENTS,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -103,6 +103,19 @@ class Checkers {
         }
       })
   }
+
+  [CHECKER_NAMES.TRADED_VOLUME] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.TRADES,
+            this.SYNC_API_METHODS.CANDLES
+          ]
+        }
+      })
+  }
 }
 
 decorate(injectable(), Checkers)

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const TYPES = require('../../di/types')
+
+class DataConsistencyChecker {
+  constructor (
+    SYNC_API_METHODS,
+    syncCollsManager
+  ) {
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.syncCollsManager = syncCollsManager
+  }
+
+  // TODO:
+  async check (checkerName, args) {}
+}
+
+decorate(injectable(), DataConsistencyChecker)
+decorate(inject(TYPES.SYNC_API_METHODS), DataConsistencyChecker, 0)
+decorate(inject(TYPES.SyncCollsManager), DataConsistencyChecker, 1)
+
+module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -7,7 +7,8 @@ const {
 } = require('inversify')
 
 const {
-  DataConsistencyCheckerFindingError
+  DataConsistencyCheckerFindingError,
+  DataConsistencyError
 } = require('../../errors')
 
 const TYPES = require('../../di/types')
@@ -19,7 +20,6 @@ class DataConsistencyChecker {
     this.checkers = checkers
   }
 
-  // TODO:
   async check (checkerName, args) {
     if (
       !checkerName ||
@@ -39,7 +39,7 @@ class DataConsistencyChecker {
     const isValid = await check(auth)
 
     if (!isValid) {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyError()
     }
   }
 }

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -10,19 +10,37 @@ const TYPES = require('../../di/types')
 
 class DataConsistencyChecker {
   constructor (
-    SYNC_API_METHODS,
-    syncCollsManager
+    checkers
   ) {
-    this.SYNC_API_METHODS = SYNC_API_METHODS
-    this.syncCollsManager = syncCollsManager
+    this.checkers = checkers
   }
 
   // TODO:
-  async check (checkerName, args) {}
+  async check (checkerName, args) {
+    if (
+      !checkerName ||
+      typeof checkerName !== 'string'
+    ) {
+      throw new Error('ERR_') // TODO:
+    }
+
+    const checker = this.checkers[checkerName]
+
+    if (typeof checker !== 'function') {
+      throw new Error('ERR_') // TODO:
+    }
+
+    const { auth } = { ...args }
+    const check = checker.bind(this.checkers)
+    const isValid = await check(auth)
+
+    if (!isValid) {
+      throw new Error('ERR_') // TODO:
+    }
+  }
 }
 
 decorate(injectable(), DataConsistencyChecker)
-decorate(inject(TYPES.SYNC_API_METHODS), DataConsistencyChecker, 0)
-decorate(inject(TYPES.SyncCollsManager), DataConsistencyChecker, 1)
+decorate(inject(TYPES.Checkers), DataConsistencyChecker, 0)
 
 module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -6,6 +6,10 @@ const {
   inject
 } = require('inversify')
 
+const {
+  DataConsistencyCheckerFindingError
+} = require('../../errors')
+
 const TYPES = require('../../di/types')
 
 class DataConsistencyChecker {
@@ -21,13 +25,13 @@ class DataConsistencyChecker {
       !checkerName ||
       typeof checkerName !== 'string'
     ) {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyCheckerFindingError()
     }
 
     const checker = this.checkers[checkerName]
 
     if (typeof checker !== 'function') {
-      throw new Error('ERR_') // TODO:
+      throw new DataConsistencyCheckerFindingError()
     }
 
     const { auth } = { ...args }

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -73,7 +73,7 @@ class DataChecker {
   }
 
   async checkNewData (auth) {
-    const methodCollMap = this._getMethodCollMap()
+    const methodCollMap = this.getMethodCollMap()
 
     if (this._isInterrupted) {
       return filterMethodCollMap(methodCollMap)
@@ -85,7 +85,7 @@ class DataChecker {
   }
 
   async checkNewPublicData () {
-    const methodCollMap = this._getMethodCollMap()
+    const methodCollMap = this.getMethodCollMap()
 
     if (this._isInterrupted) {
       return filterMethodCollMap(methodCollMap, true)
@@ -260,7 +260,7 @@ class DataChecker {
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
         schema.hasNewData = false
 
-        await this._checkNewCandlesData(method, schema)
+        await this.checkNewCandlesData(method, schema)
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue
@@ -451,7 +451,7 @@ class DataChecker {
     })
   }
 
-  async _checkNewCandlesData (
+  async checkNewCandlesData (
     method,
     schema
   ) {
@@ -715,7 +715,7 @@ class DataChecker {
     })
   }
 
-  _getMethodCollMap () {
+  getMethodCollMap () {
     return new Map(this._methodCollMap)
   }
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -207,6 +207,12 @@ class DataChecker {
         startConf
       )
 
+      if (!schema.hasNewData) {
+        await this.syncCollsManager.setCollAsSynced({
+          collName: method, userId: _id, subUserId
+        })
+      }
+
       return
     }
 
@@ -428,6 +434,21 @@ class DataChecker {
         timeframe
       )
     }
+
+    if (schema.hasNewData) {
+      return
+    }
+
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({ collName: method })
+
+    if (!hasCollBeenSyncedAtLeastOnce) {
+      return
+    }
+
+    await this.syncCollsManager.setCollAsSynced({
+      collName: method
+    })
   }
 
   async _checkNewCandlesData (
@@ -677,6 +698,21 @@ class DataChecker {
         CANDLES_TIMEFRAME
       )
     }
+
+    if (schema.hasNewData) {
+      return
+    }
+
+    const hasCollBeenSyncedAtLeastOnce = await this.syncCollsManager
+      .hasCollBeenSyncedAtLeastOnce({ collName: method })
+
+    if (!hasCollBeenSyncedAtLeastOnce) {
+      return
+    }
+
+    await this.syncCollsManager.setCollAsSynced({
+      collName: method
+    })
   }
 
   _getMethodCollMap () {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -68,8 +68,7 @@ class DataChecker {
       this._isInterrupted = true
     })
 
-    this._methodCollMap = this.syncSchema
-      .getMethodCollMap(methodCollMap)
+    this.setMethodCollMap(methodCollMap)
   }
 
   async checkNewData (auth) {
@@ -122,7 +121,7 @@ class DataChecker {
       return
     }
 
-    schema.hasNewData = false
+    this._resetSyncSchemaProps(schema)
 
     const args = this._getMethodArgMap(method, { auth, limit: 1 })
     args.params.notThrowError = true
@@ -251,16 +250,11 @@ class DataChecker {
         schema.name === this.ALLOWED_COLLS.PUBLIC_TRADES ||
         schema.name === this.ALLOWED_COLLS.TICKERS_HISTORY
       ) {
-        schema.hasNewData = false
-
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue
       }
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
-        schema.hasNewData = false
-        schema.start = []
-
         if (!schema.isSyncDoneForCurrencyConv) {
           await this.checkNewCandlesData(method, schema)
 
@@ -278,6 +272,8 @@ class DataChecker {
     if (this._isInterrupted) {
       return
     }
+
+    this._resetSyncSchemaProps(schema)
 
     const {
       confName,
@@ -464,6 +460,8 @@ class DataChecker {
     if (this._isInterrupted) {
       return
     }
+
+    this._resetSyncSchemaProps(schema)
 
     const {
       symbolFieldName,
@@ -723,6 +721,16 @@ class DataChecker {
 
   getMethodCollMap () {
     return new Map(this._methodCollMap)
+  }
+
+  setMethodCollMap (methodCollMap) {
+    this._methodCollMap = this.syncSchema
+      .getMethodCollMap(methodCollMap)
+  }
+
+  _resetSyncSchemaProps (schema) {
+    schema.hasNewData = false
+    schema.start = []
   }
 
   _getMethodArgMap (method, opts) {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -259,8 +259,14 @@ class DataChecker {
       }
       if (schema.name === this.ALLOWED_COLLS.CANDLES) {
         schema.hasNewData = false
+        schema.start = []
 
-        await this.checkNewCandlesData(method, schema)
+        if (!schema.isSyncDoneForCurrencyConv) {
+          await this.checkNewCandlesData(method, schema)
+
+          schema.isSyncDoneForCurrencyConv = true
+        }
+
         await this._checkNewConfigurablePublicData(method, schema)
 
         continue

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -55,12 +55,16 @@ class ConvertCurrencyHook extends DataInserterHook {
   /**
    * @override
    */
-  async execute () {
+  async execute (names = []) {
+    const _names = Array.isArray(names)
+      ? names
+      : [names]
     const { syncColls } = this._opts
 
     if (syncColls.every(name => (
       name !== this.ALLOWED_COLLS.ALL &&
-      name !== this.ALLOWED_COLLS.CANDLES
+      name !== this.ALLOWED_COLLS.CANDLES &&
+      name !== this.ALLOWED_COLLS.LEDGERS
     ))) {
       return
     }
@@ -68,6 +72,15 @@ class ConvertCurrencyHook extends DataInserterHook {
     const convSchema = this._getConvSchema()
 
     for (const [collName, schema] of convSchema) {
+      if (_names.length > 0) {
+        const isSkipped = _names.every((name) => (
+          !name ||
+          name !== collName
+        ))
+
+        if (isSkipped) continue
+      }
+
       let count = 0
       let _id = 0
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -399,6 +399,8 @@ class DataInserter extends EventEmitter {
       collName: this.SYNC_API_METHODS.CANDLES
     })
 
+    candlesSchema.isSyncDoneForCurrencyConv = true
+
     await this.convertCurrencyHook.execute(
       this.ALLOWED_COLLS.LEDGERS
     )

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -54,6 +54,7 @@ class DataInserter extends EventEmitter {
     syncSchema,
     TABLES_NAMES,
     ALLOWED_COLLS,
+    SYNC_API_METHODS,
     FOREX_SYMBS,
     authenticator,
     convertCurrencyHook,
@@ -71,6 +72,7 @@ class DataInserter extends EventEmitter {
     this.syncSchema = syncSchema
     this.TABLES_NAMES = TABLES_NAMES
     this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.SYNC_API_METHODS = SYNC_API_METHODS
     this.FOREX_SYMBS = FOREX_SYMBS
     this.authenticator = authenticator
     this.convertCurrencyHook = convertCurrencyHook
@@ -82,6 +84,7 @@ class DataInserter extends EventEmitter {
 
     this._asyncProgressHandlers = []
     this._auth = null
+    this._syncedSubUsers = []
     this._allowedCollsNames = getAllowedCollsNames(
       this.ALLOWED_COLLS
     )
@@ -293,8 +296,22 @@ class DataInserter extends EventEmitter {
     const methodCollMap = await this.dataChecker
       .checkNewData(auth)
     const size = this._methodCollMap.size
-    const { _id: userId, subUser } = { ...auth }
+    const {
+      _id: userId,
+      subUser,
+      subUsers,
+      isSubAccount
+    } = { ...auth }
     const { _id: subUserId } = { ...subUser }
+    const isLastSubUser = (
+      isSubAccount &&
+      subUsers.every((id) => (
+        [
+          ...this._syncedSubUsers,
+          subUserId
+        ].some((suId) => id === suId)
+      ))
+    )
 
     let count = 0
     let progress = 0
@@ -333,9 +350,16 @@ class DataInserter extends EventEmitter {
         )
       }
 
+      await this._prepareLedgers(method, { isLastSubUser })
+      await this._prepareMovements(method)
+
       await this.syncCollsManager.setCollAsSynced({
         collName: method, userId, subUserId
       })
+
+      if (isSubAccount) {
+        this._syncedSubUsers.push(subUserId)
+      }
 
       count += 1
       progress = Math.round(
@@ -348,6 +372,54 @@ class DataInserter extends EventEmitter {
     }
 
     return progress
+  }
+
+  /* If ledgers are syncing
+    sync candles,
+    convert currency,
+    recalc sub-account */
+  async _prepareLedgers (method, { isLastSubUser }) {
+    if (method !== this.SYNC_API_METHODS.LEDGERS) {
+      return
+    }
+
+    const candlesSchema = this.dataChecker
+      .getMethodCollMap().get(this.SYNC_API_METHODS.CANDLES)
+    candlesSchema.hasNewData = false
+
+    await this.dataChecker.checkNewCandlesData(
+      this.SYNC_API_METHODS.CANDLES,
+      candlesSchema
+    )
+    await this._insertApiDataPublicArrObjTypeToDb(
+      this.SYNC_API_METHODS.CANDLES,
+      candlesSchema
+    )
+    await this.syncCollsManager.setCollAsSynced({
+      collName: this.SYNC_API_METHODS.CANDLES
+    })
+
+    await this.convertCurrencyHook.execute(
+      this.ALLOWED_COLLS.LEDGERS
+    )
+
+    if (!isLastSubUser) {
+      return
+    }
+
+    await this.recalcSubAccountLedgersBalancesHook.execute()
+  }
+
+  /* If movements are syncing
+    convert currency */
+  async _prepareMovements (method) {
+    if (method !== this.SYNC_API_METHODS.MOVEMENTS) {
+      return
+    }
+
+    await this.convertCurrencyHook.execute(
+      this.ALLOWED_COLLS.MOVEMENTS
+    )
   }
 
   _getDataFromApi (methodApi, args, isCheckCall) {
@@ -828,13 +900,14 @@ decorate(inject(TYPES.ApiMiddleware), DataInserter, 2)
 decorate(inject(TYPES.SyncSchema), DataInserter, 3)
 decorate(inject(TYPES.TABLES_NAMES), DataInserter, 4)
 decorate(inject(TYPES.ALLOWED_COLLS), DataInserter, 5)
-decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 6)
-decorate(inject(TYPES.Authenticator), DataInserter, 7)
-decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 8)
-decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 9)
-decorate(inject(TYPES.DataChecker), DataInserter, 10)
-decorate(inject(TYPES.SyncInterrupter), DataInserter, 11)
-decorate(inject(TYPES.WSEventEmitter), DataInserter, 12)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 13)
+decorate(inject(TYPES.SYNC_API_METHODS), DataInserter, 6)
+decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 7)
+decorate(inject(TYPES.Authenticator), DataInserter, 8)
+decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 9)
+decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 10)
+decorate(inject(TYPES.DataChecker), DataInserter, 11)
+decorate(inject(TYPES.SyncInterrupter), DataInserter, 12)
+decorate(inject(TYPES.WSEventEmitter), DataInserter, 13)
+decorate(inject(TYPES.SyncCollsManager), DataInserter, 14)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -305,12 +305,14 @@ class DataInserter extends EventEmitter {
     const { _id: subUserId } = { ...subUser }
     const isLastSubUser = (
       isSubAccount &&
-      subUsers.every((id) => (
-        [
+      subUsers.every((subUser) => {
+        const { _id } = { ...subUser }
+
+        return [
           ...this._syncedSubUsers,
           subUserId
-        ].some((suId) => id === suId)
-      ))
+        ].some((suId) => _id === suId)
+      })
     )
 
     let count = 0
@@ -357,10 +359,6 @@ class DataInserter extends EventEmitter {
         collName: method, userId, subUserId
       })
 
-      if (isSubAccount) {
-        this._syncedSubUsers.push(subUserId)
-      }
-
       count += 1
       progress = Math.round(
         (((count / size) * 100) / this._auth.size) + userProgress
@@ -369,6 +367,10 @@ class DataInserter extends EventEmitter {
       if (progress < 100) {
         await this.setProgress(progress)
       }
+    }
+
+    if (isSubAccount) {
+      this._syncedSubUsers.push(subUserId)
     }
 
     return progress

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -387,7 +387,6 @@ class DataInserter extends EventEmitter {
 
     const candlesSchema = this.dataChecker
       .getMethodCollMap().get(this.SYNC_API_METHODS.CANDLES)
-    candlesSchema.hasNewData = false
 
     await this.dataChecker.checkNewCandlesData(
       this.SYNC_API_METHODS.CANDLES,

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -55,6 +55,9 @@ class PerformingLoan {
     )
       ? { $in: { currency: symbol } }
       : {}
+    const filterToSkipNotRecalcedBalance = user.isSubAccount
+      ? { _isBalanceRecalced: 1 }
+      : {}
 
     return this.dao.getElemsInCollBy(
       this.ALLOWED_COLLS.LEDGERS,
@@ -64,7 +67,8 @@ class PerformingLoan {
           user_id: user._id,
           $lte: { mts: end },
           $gte: { mts: start },
-          ...symbFilter
+          ...symbFilter,
+          ...filterToSkipNotRecalcedBalance
         },
         sort: [['mts', -1]],
         projection,

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -372,6 +372,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       confName: 'candlesConf',
+      isSyncDoneForCurrencyConv: false,
       isSyncRequiredAtLeastOnce: true,
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CANDLES)

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -191,7 +191,7 @@ class SyncCollsManager {
     const { _id: userId } = auth
     const {
       schema,
-      commonAllowedDiffInMs = 2 * 60 * 60 * 1000
+      commonAllowedDiffInMs = 24 * 60 * 60 * 1000
     } = { ...params }
 
     const completedColls = await this._getCompletedCollsBy({

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -278,6 +278,14 @@ class WSTransport {
           ? await handler(user, { ...args, action })
           : handler
 
+        if (
+          res &&
+          typeof res === 'object' &&
+          res.isNotEmitted
+        ) {
+          continue
+        }
+
         this._sendToOne(socket, sid, action, null, res)
       } catch (err) {
         this._sendToOne(socket, sid, action, err)

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -48,7 +48,7 @@ class WSEventEmitter {
         typeof auth !== 'object' ||
         user._id !== auth._id
       ) {
-        return
+        return { isNotEmitted: true }
       }
 
       return typeof handler === 'function'


### PR DESCRIPTION
This PR avoids throwing errors to not deny access to needed reports during sync. The main idea is as follows: instead of throwing the `DuringSyncMethodAccessError` error
https://github.com/bitfinexcom/bfx-reports-framework/blob/master/workers/loc.api/service.report.framework.js#L1175
that deny access during sync just check that tables which required for the needed report were synced and have sync interval between collections no more than specified. For example for the `balance history`, we should have data from `ledgers` and `candles` tables and in this case, we need to check those tables were synced at least once and sync interval between `ledgers` and `candles` should be no more than specified in the configurations. Also applies the following changes:
  - Omits ledgers with not recalced balance for sub-account to avoid wrong results
  - Adds the ability to start syncing candles for currency converting and convert ledgers balance to USD and recalc balance of sub-account immediately after finishing of syncing ledgers to reduce ledgers preparation delay to consistent data
  - Fixes updating syncing collections timestamp
  - Fixes emitting syncing step for multi-users by WS
  - Fixes syncing for multi-users during one sync