### PR TITLE
Add helper to decorate injectable class

### DIFF
--- a/workers/loc.api/di/utils/decorate-injectable.js
+++ b/workers/loc.api/di/utils/decorate-injectable.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const {
+  decorateInjectable
+} = require('bfx-report/workers/loc.api/di/utils')
+
+const _TYPES = require('../types')
+
+module.exports = (
+  ModuleClass,
+  getDepsTypesFn,
+  TYPES = _TYPES
+) => decorateInjectable(
+  ModuleClass,
+  getDepsTypesFn,
+  TYPES
+)

--- a/workers/loc.api/di/utils/index.js
+++ b/workers/loc.api/di/utils/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const decorateInjectable = require('./decorate-injectable')
+
+module.exports = {
+  decorateInjectable
+}

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const {
-  decorate,
-  inject
-} = require('inversify')
 const BaseCsvJobData = require(
   'bfx-report/workers/loc.api/generate-csv/csv.job.data'
 )
@@ -12,13 +8,18 @@ const {
   checkJobAndGetUserData
 } = require('bfx-report/workers/loc.api/helpers')
 
-const TYPES = require('../di/types')
-
 const {
   checkParams,
   getDateString
 } = require('../helpers')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.FullSnapshotReportCsvWriter,
+  TYPES.FullTaxReportCsvWriter
+]
 class CsvJobData extends BaseCsvJobData {
   constructor (
     rService,
@@ -574,8 +575,6 @@ class CsvJobData extends BaseCsvJobData {
   }
 }
 
-decorate(inject(TYPES.RService), CsvJobData, 0)
-decorate(inject(TYPES.FullSnapshotReportCsvWriter), CsvJobData, 1)
-decorate(inject(TYPES.FullTaxReportCsvWriter), CsvJobData, 2)
+decorateInjectable(CsvJobData, depsTypes)
 
 module.exports = CsvJobData

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -2,15 +2,9 @@
 
 const { v4: uuidv4 } = require('uuid')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const { serializeVal } = require('../dao/helpers')
 const { isSubAccountApiKeys } = require('../../helpers')
 const {
@@ -23,6 +17,15 @@ const {
   pickSessionProps
 } = require('./helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.RService,
+  TYPES.Crypto,
+  TYPES.SyncFactory
+]
 class Authenticator {
   constructor (
     dao,
@@ -869,11 +872,6 @@ class Authenticator {
   }
 }
 
-decorate(injectable(), Authenticator)
-decorate(inject(TYPES.DAO), Authenticator, 0)
-decorate(inject(TYPES.TABLES_NAMES), Authenticator, 1)
-decorate(inject(TYPES.RService), Authenticator, 2)
-decorate(inject(TYPES.Crypto), Authenticator, 3)
-decorate(inject(TYPES.SyncFactory), Authenticator, 4)
+decorateInjectable(Authenticator, depsTypes)
 
 module.exports = Authenticator

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -2,13 +2,7 @@
 
 const { isEmpty } = require('lodash')
 const moment = require('moment')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   getMtsGroupedByTimeframe,
@@ -17,6 +11,16 @@ const {
 } = require('../helpers')
 const { getTimeframeQuery } = require('../dao/helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.Wallets,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.SYNC_API_METHODS,
+  TYPES.ALLOWED_COLLS
+]
 class BalanceHistory {
   constructor (
     dao,
@@ -454,12 +458,6 @@ class BalanceHistory {
   }
 }
 
-decorate(injectable(), BalanceHistory)
-decorate(inject(TYPES.DAO), BalanceHistory, 0)
-decorate(inject(TYPES.Wallets), BalanceHistory, 1)
-decorate(inject(TYPES.FOREX_SYMBS), BalanceHistory, 2)
-decorate(inject(TYPES.CurrencyConverter), BalanceHistory, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), BalanceHistory, 4)
-decorate(inject(TYPES.ALLOWED_COLLS), BalanceHistory, 5)
+decorateInjectable(BalanceHistory, depsTypes)
 
 module.exports = BalanceHistory

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -7,22 +7,23 @@ const {
   orderBy
 } = require('lodash')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   prepareResponse
 } = require('bfx-report/workers/loc.api/helpers')
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const {
   GetPublicDataError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator
+]
 class PublicСollsСonfAccessors {
   constructor (
     dao,
@@ -488,9 +489,6 @@ class PublicСollsСonfAccessors {
   }
 }
 
-decorate(injectable(), PublicСollsСonfAccessors)
-decorate(inject(TYPES.DAO), PublicСollsСonfAccessors, 0)
-decorate(inject(TYPES.TABLES_NAMES), PublicСollsСonfAccessors, 1)
-decorate(inject(TYPES.Authenticator), PublicСollsСonfAccessors, 2)
+decorateInjectable(PublicСollsСonfAccessors, depsTypes)
 
 module.exports = PublicСollsСonfAccessors

--- a/workers/loc.api/sync/crypto/index.js
+++ b/workers/loc.api/sync/crypto/index.js
@@ -3,15 +3,8 @@
 const crypto = require('crypto')
 const { promisify } = require('util')
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
-
-const TYPES = require('../../di/types')
 
 /**
  * Scrypt was introduced into Node.js in v10.5.0,
@@ -40,6 +33,11 @@ const scrypt = hasScrypt ? promisify(crypto.scrypt) : crypto.scrypt
 const randomBytes = promisify(crypto.randomBytes)
 const pbkdf2 = promisify(crypto.pbkdf2)
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF
+]
 class Crypto {
   constructor (CONF) {
     this.CONF = CONF
@@ -158,7 +156,6 @@ class Crypto {
   }
 }
 
-decorate(injectable(), Crypto)
-decorate(inject(TYPES.CONF), Crypto, 0)
+decorateInjectable(Crypto, depsTypes)
 
 module.exports = Crypto

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -3,11 +3,6 @@
 const moment = require('moment')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 const {
@@ -22,8 +17,17 @@ const {
   isForexSymb
 } = require('../helpers')
 const { tryParseJSON } = require('../../helpers')
-const TYPES = require('../../di/types')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SYNC_API_METHODS
+]
 class CurrencyConverter {
   constructor (
     rService,
@@ -914,12 +918,6 @@ class CurrencyConverter {
   }
 }
 
-decorate(injectable(), CurrencyConverter)
-decorate(inject(TYPES.RService), CurrencyConverter, 0)
-decorate(inject(TYPES.DAO), CurrencyConverter, 1)
-decorate(inject(TYPES.SyncSchema), CurrencyConverter, 2)
-decorate(inject(TYPES.FOREX_SYMBS), CurrencyConverter, 3)
-decorate(inject(TYPES.ALLOWED_COLLS), CurrencyConverter, 4)
-decorate(inject(TYPES.SYNC_API_METHODS), CurrencyConverter, 5)
+decorateInjectable(CurrencyConverter, depsTypes)
 
 module.exports = CurrencyConverter

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -2,11 +2,6 @@
 
 const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 const MAIN_DB_WORKER_ACTIONS = require(
   'bfx-facs-db-better-sqlite/worker/db-worker-actions/db-worker-actions.const'
 )
@@ -17,8 +12,6 @@ const {
 const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
-
-const TYPES = require('../../di/types')
 
 const DAO = require('./dao')
 const {
@@ -64,6 +57,15 @@ const {
   convertData,
   prepareDbResponse
 } = require('./helpers/find-in-coll-by')
+
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DB,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema,
+  TYPES.DbMigratorFactory
+]
 class BetterSqliteDAO extends DAO {
   constructor (...args) {
     super(...args)
@@ -926,10 +928,6 @@ class BetterSqliteDAO extends DAO {
   }
 }
 
-decorate(injectable(), BetterSqliteDAO)
-decorate(inject(TYPES.DB), BetterSqliteDAO, 0)
-decorate(inject(TYPES.TABLES_NAMES), BetterSqliteDAO, 1)
-decorate(inject(TYPES.SyncSchema), BetterSqliteDAO, 2)
-decorate(inject(TYPES.DbMigratorFactory), BetterSqliteDAO, 3)
+decorateInjectable(BetterSqliteDAO, depsTypes)
 
 module.exports = BetterSqliteDAO

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -1,14 +1,11 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   DAOInitializationError,
   ImplementationError
 } = require('../../errors')
+
+const { decorateInjectable } = require('../../di/utils')
 
 class DAO {
   constructor (
@@ -141,6 +138,6 @@ class DAO {
   async removeElemsFromDbIfNotInLists () { throw new ImplementationError() }
 }
 
-decorate(injectable(), DAO)
+decorateInjectable(DAO)
 
 module.exports = DAO

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -1,17 +1,14 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   DbMigrationVerCorrectnessError,
   DbVersionTypeError,
   MigrationLaunchingError
 } = require('../../../errors')
 
 const Migration = require('./migration')
+
+const { decorateInjectable } = require('../../../di/utils')
 
 class DbMigrator {
   constructor (
@@ -132,6 +129,6 @@ class DbMigrator {
   }
 }
 
-decorate(injectable(), DbMigrator)
+decorateInjectable(DbMigrator)
 
 module.exports = DbMigrator

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
-
 const DbMigrator = require('./db.migrator')
 const {
   MigrationLaunchingError
 } = require('../../../errors')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.MigrationsFactory,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema,
+  TYPES.Logger
+]
 class SqliteDbMigrator extends DbMigrator {
   /**
    * @override
@@ -48,10 +48,6 @@ class SqliteDbMigrator extends DbMigrator {
   }
 }
 
-decorate(injectable(), SqliteDbMigrator)
-decorate(inject(TYPES.MigrationsFactory), SqliteDbMigrator, 0)
-decorate(inject(TYPES.TABLES_NAMES), SqliteDbMigrator, 1)
-decorate(inject(TYPES.SyncSchema), SqliteDbMigrator, 2)
-decorate(inject(TYPES.Logger), SqliteDbMigrator, 3)
+decorateInjectable(SqliteDbMigrator, depsTypes)
 
 module.exports = SqliteDbMigrator

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
 const CHECKER_NAMES = require('./checker.names')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SYNC_API_METHODS,
+  TYPES.SyncCollsManager
+]
 class Checkers {
   constructor (
     SYNC_API_METHODS,
@@ -163,8 +162,6 @@ class Checkers {
   }
 }
 
-decorate(injectable(), Checkers)
-decorate(inject(TYPES.SYNC_API_METHODS), Checkers, 0)
-decorate(inject(TYPES.SyncCollsManager), Checkers, 1)
+decorateInjectable(Checkers, depsTypes)
 
 module.exports = Checkers

--- a/workers/loc.api/sync/data.consistency.checker/index.js
+++ b/workers/loc.api/sync/data.consistency.checker/index.js
@@ -1,18 +1,15 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const {
   DataConsistencyCheckerFindingError,
   DataConsistencyError
 } = require('../../errors')
 
-const TYPES = require('../../di/types')
+const { decorateInjectable } = require('../../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.Checkers
+]
 class DataConsistencyChecker {
   constructor (
     checkers
@@ -44,7 +41,6 @@ class DataConsistencyChecker {
   }
 }
 
-decorate(injectable(), DataConsistencyChecker)
-decorate(inject(TYPES.Checkers), DataConsistencyChecker, 0)
+decorateInjectable(DataConsistencyChecker, depsTypes)
 
 module.exports = DataConsistencyChecker

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -1,12 +1,5 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const SYNC_API_METHODS = require('../../schema/sync.api.methods')
 const {
   addPropsToResIfExist,
@@ -14,6 +7,11 @@ const {
   getCategoryFromDescription
 } = require('./helpers')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SearchClosePriceAndSumAmount
+]
 class ApiMiddlewareHandlerAfter {
   constructor (
     searchClosePriceAndSumAmount
@@ -178,7 +176,6 @@ class ApiMiddlewareHandlerAfter {
   }
 }
 
-decorate(injectable(), ApiMiddlewareHandlerAfter)
-decorate(inject(TYPES.SearchClosePriceAndSumAmount), ApiMiddlewareHandlerAfter, 0)
+decorateInjectable(ApiMiddlewareHandlerAfter, depsTypes)
 
 module.exports = ApiMiddlewareHandlerAfter

--- a/workers/loc.api/sync/data.inserter/api.middleware/index.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/index.js
@@ -3,14 +3,13 @@
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../../di/types')
+const { decorateInjectable } = require('../../../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.ApiMiddlewareHandlerAfter
+]
 class ApiMiddleware {
   constructor (
     rService,
@@ -58,8 +57,6 @@ class ApiMiddleware {
   }
 }
 
-decorate(injectable(), ApiMiddleware)
-decorate(inject(TYPES.RService), ApiMiddleware, 0)
-decorate(inject(TYPES.ApiMiddlewareHandlerAfter), ApiMiddleware, 1)
+decorateInjectable(ApiMiddleware, depsTypes)
 
 module.exports = ApiMiddleware

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -10,13 +10,7 @@ const {
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../../di/types')
 const {
   getMethodArgMap
 } = require('../helpers')
@@ -36,6 +30,19 @@ const {
   ALL_SYMBOLS_TO_SYNC
 } = require('../const')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.SyncInterrupter,
+  TYPES.SyncCollsManager
+]
 class DataChecker {
   constructor (
     rService,
@@ -756,15 +763,6 @@ class DataChecker {
   }
 }
 
-decorate(injectable(), DataChecker)
-decorate(inject(TYPES.RService), DataChecker, 0)
-decorate(inject(TYPES.DAO), DataChecker, 1)
-decorate(inject(TYPES.SyncSchema), DataChecker, 2)
-decorate(inject(TYPES.TABLES_NAMES), DataChecker, 3)
-decorate(inject(TYPES.ALLOWED_COLLS), DataChecker, 4)
-decorate(inject(TYPES.FOREX_SYMBS), DataChecker, 5)
-decorate(inject(TYPES.CurrencyConverter), DataChecker, 6)
-decorate(inject(TYPES.SyncInterrupter), DataChecker, 7)
-decorate(inject(TYPES.SyncCollsManager), DataChecker, 8)
+decorateInjectable(DataChecker, depsTypes)
 
 module.exports = DataChecker

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const { CONVERT_TO } = require('../const')
 const DataInserterHook = require('./data.inserter.hook')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.CurrencyConverter,
+  TYPES.ALLOWED_COLLS
+]
 class ConvertCurrencyHook extends DataInserterHook {
   constructor (
     dao,
@@ -139,9 +139,6 @@ class ConvertCurrencyHook extends DataInserterHook {
   }
 }
 
-decorate(injectable(), ConvertCurrencyHook)
-decorate(inject(TYPES.DAO), ConvertCurrencyHook, 0)
-decorate(inject(TYPES.CurrencyConverter), ConvertCurrencyHook, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), ConvertCurrencyHook, 2)
+decorateInjectable(ConvertCurrencyHook, depsTypes)
 
 module.exports = ConvertCurrencyHook

--- a/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
@@ -1,13 +1,10 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-
-const {
   ImplementationError
 } = require('../../../errors')
+
+const { decorateInjectable } = require('../../../di/utils')
 
 class DataInserterHook {
   constructor () {
@@ -44,6 +41,6 @@ class DataInserterHook {
   async execute () { throw new ImplementationError() }
 }
 
-decorate(injectable(), DataInserterHook)
+decorateInjectable(DataInserterHook)
 
 module.exports = DataInserterHook

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -2,18 +2,17 @@
 
 const { orderBy } = require('lodash')
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../../di/types')
 const DataInserterHook = require('./data.inserter.hook')
 const {
   SubAccountLedgersBalancesRecalcError
 } = require('../../../errors')
 
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES
+]
 class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
   constructor (
     dao,
@@ -353,8 +352,6 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
   }
 }
 
-decorate(injectable(), RecalcSubAccountLedgersBalancesHook)
-decorate(inject(TYPES.DAO), RecalcSubAccountLedgersBalancesHook, 0)
-decorate(inject(TYPES.TABLES_NAMES), RecalcSubAccountLedgersBalancesHook, 1)
+decorateInjectable(RecalcSubAccountLedgersBalancesHook, depsTypes)
 
 module.exports = RecalcSubAccountLedgersBalancesHook

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -11,13 +11,7 @@ const {
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   CANDLES_SECTION,
   ALL_SYMBOLS_TO_SYNC
@@ -46,6 +40,25 @@ const {
 
 const MESS_ERR_UNAUTH = 'ERR_AUTH_UNAUTHORIZED'
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.ApiMiddleware,
+  TYPES.SyncSchema,
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SYNC_API_METHODS,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.ConvertCurrencyHook,
+  TYPES.RecalcSubAccountLedgersBalancesHook,
+  TYPES.DataChecker,
+  TYPES.SyncInterrupter,
+  TYPES.WSEventEmitter,
+  TYPES.SyncCollsManager
+]
 class DataInserter extends EventEmitter {
   constructor (
     rService,
@@ -896,21 +909,6 @@ class DataInserter extends EventEmitter {
   }
 }
 
-decorate(injectable(), DataInserter)
-decorate(inject(TYPES.RService), DataInserter, 0)
-decorate(inject(TYPES.DAO), DataInserter, 1)
-decorate(inject(TYPES.ApiMiddleware), DataInserter, 2)
-decorate(inject(TYPES.SyncSchema), DataInserter, 3)
-decorate(inject(TYPES.TABLES_NAMES), DataInserter, 4)
-decorate(inject(TYPES.ALLOWED_COLLS), DataInserter, 5)
-decorate(inject(TYPES.SYNC_API_METHODS), DataInserter, 6)
-decorate(inject(TYPES.FOREX_SYMBS), DataInserter, 7)
-decorate(inject(TYPES.Authenticator), DataInserter, 8)
-decorate(inject(TYPES.ConvertCurrencyHook), DataInserter, 9)
-decorate(inject(TYPES.RecalcSubAccountLedgersBalancesHook), DataInserter, 10)
-decorate(inject(TYPES.DataChecker), DataInserter, 11)
-decorate(inject(TYPES.SyncInterrupter), DataInserter, 12)
-decorate(inject(TYPES.WSEventEmitter), DataInserter, 13)
-decorate(inject(TYPES.SyncCollsManager), DataInserter, 14)
+decorateInjectable(DataInserter, depsTypes)
 
 module.exports = DataInserter

--- a/workers/loc.api/sync/fees.report/index.js
+++ b/workers/loc.api/sync/fees.report/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Trades
+]
 class FeesReport {
   constructor (
     trades
@@ -23,7 +20,6 @@ class FeesReport {
   }
 }
 
-decorate(injectable(), FeesReport)
-decorate(inject(TYPES.Trades), FeesReport, 0)
+decorateInjectable(FeesReport, depsTypes)
 
 module.exports = FeesReport

--- a/workers/loc.api/sync/full.snapshot.report/index.js
+++ b/workers/loc.api/sync/full.snapshot.report/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Wallets,
+  TYPES.PositionsSnapshot
+]
 class FullSnapshotReport {
   constructor (
     wallets,
@@ -149,8 +147,6 @@ class FullSnapshotReport {
   }
 }
 
-decorate(injectable(), FullSnapshotReport)
-decorate(inject(TYPES.Wallets), FullSnapshotReport, 0)
-decorate(inject(TYPES.PositionsSnapshot), FullSnapshotReport, 1)
+decorateInjectable(FullSnapshotReport, depsTypes)
 
 module.exports = FullSnapshotReport

--- a/workers/loc.api/sync/full.tax.report/index.js
+++ b/workers/loc.api/sync/full.tax.report/index.js
@@ -1,16 +1,18 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-const {
   isForexSymb
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.ALLOWED_COLLS,
+  TYPES.FullSnapshotReport,
+  TYPES.Authenticator
+]
 class FullTaxReport {
   constructor (
     dao,
@@ -215,11 +217,6 @@ class FullTaxReport {
   }
 }
 
-decorate(injectable(), FullTaxReport)
-decorate(inject(TYPES.DAO), FullTaxReport, 0)
-decorate(inject(TYPES.SyncSchema), FullTaxReport, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), FullTaxReport, 2)
-decorate(inject(TYPES.FullSnapshotReport), FullTaxReport, 3)
-decorate(inject(TYPES.Authenticator), FullTaxReport, 4)
+decorateInjectable(FullTaxReport, depsTypes)
 
 module.exports = FullTaxReport

--- a/workers/loc.api/sync/index.js
+++ b/workers/loc.api/sync/index.js
@@ -1,14 +1,17 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../di/types')
 const { CollSyncPermissionError } = require('../errors')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.SyncQueue,
+  TYPES.RService,
+  TYPES.ALLOWED_COLLS,
+  TYPES.Progress,
+  TYPES.RedirectRequestsToApi,
+  TYPES.SyncInterrupter
+]
 class Sync {
   constructor (
     syncQueue,
@@ -124,12 +127,6 @@ class Sync {
   }
 }
 
-decorate(injectable(), Sync)
-decorate(inject(TYPES.SyncQueue), Sync, 0)
-decorate(inject(TYPES.RService), Sync, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), Sync, 2)
-decorate(inject(TYPES.Progress), Sync, 3)
-decorate(inject(TYPES.RedirectRequestsToApi), Sync, 4)
-decorate(inject(TYPES.SyncInterrupter), Sync, 5)
+decorateInjectable(Sync, depsTypes)
 
 module.exports = Sync

--- a/workers/loc.api/sync/order.trades/index.js
+++ b/workers/loc.api/sync/order.trades/index.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SubAccountApiData,
+  TYPES.RService,
+  TYPES.SYNC_API_METHODS
+]
 class OrderTrades {
   constructor (
     dao,
@@ -96,11 +97,6 @@ class OrderTrades {
   }
 }
 
-decorate(injectable(), OrderTrades)
-decorate(inject(TYPES.DAO), OrderTrades, 0)
-decorate(inject(TYPES.TABLES_NAMES), OrderTrades, 1)
-decorate(inject(TYPES.SubAccountApiData), OrderTrades, 2)
-decorate(inject(TYPES.RService), OrderTrades, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), OrderTrades, 4)
+decorateInjectable(OrderTrades, depsTypes)
 
 module.exports = OrderTrades

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -1,19 +1,22 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-const {
   calcGroupedData,
   groupByTimeframe,
   getStartMtsByTimeframe,
   getBackIterable
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class PerformingLoan {
   constructor (
     dao,
@@ -412,12 +415,6 @@ class PerformingLoan {
   }
 }
 
-decorate(injectable(), PerformingLoan)
-decorate(inject(TYPES.DAO), PerformingLoan, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), PerformingLoan, 1)
-decorate(inject(TYPES.SyncSchema), PerformingLoan, 2)
-decorate(inject(TYPES.FOREX_SYMBS), PerformingLoan, 3)
-decorate(inject(TYPES.Authenticator), PerformingLoan, 4)
-decorate(inject(TYPES.SYNC_API_METHODS), PerformingLoan, 5)
+decorateInjectable(PerformingLoan, depsTypes)
 
 module.exports = PerformingLoan

--- a/workers/loc.api/sync/positions.audit/index.js
+++ b/workers/loc.api/sync/positions.audit/index.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SubAccountApiData
+]
 class PositionsAudit {
   constructor (
     dao,
@@ -64,9 +63,6 @@ class PositionsAudit {
   }
 }
 
-decorate(injectable(), PositionsAudit)
-decorate(inject(TYPES.DAO), PositionsAudit, 0)
-decorate(inject(TYPES.TABLES_NAMES), PositionsAudit, 1)
-decorate(inject(TYPES.SubAccountApiData), PositionsAudit, 2)
+decorateInjectable(PositionsAudit, depsTypes)
 
 module.exports = PositionsAudit

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -3,21 +3,24 @@
 const { orderBy } = require('lodash')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   splitSymbolPairs
 } = require('bfx-report/workers/loc.api/helpers')
-
-const TYPES = require('../../di/types')
 
 const { getTimeframeQuery } = require('../dao/helpers')
 const {
   SyncedPositionsSnapshotParamsError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.CurrencyConverter,
+  TYPES.Authenticator
+]
 class PositionsSnapshot {
   constructor (
     rService,
@@ -636,12 +639,6 @@ class PositionsSnapshot {
   }
 }
 
-decorate(injectable(), PositionsSnapshot)
-decorate(inject(TYPES.RService), PositionsSnapshot, 0)
-decorate(inject(TYPES.DAO), PositionsSnapshot, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), PositionsSnapshot, 2)
-decorate(inject(TYPES.SyncSchema), PositionsSnapshot, 3)
-decorate(inject(TYPES.CurrencyConverter), PositionsSnapshot, 4)
-decorate(inject(TYPES.Authenticator), PositionsSnapshot, 5)
+decorateInjectable(PositionsSnapshot, depsTypes)
 
 module.exports = PositionsSnapshot

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -2,17 +2,19 @@
 
 const EventEmitter = require('events')
 const { isEmpty } = require('lodash')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   tryParseJSON
 } = require('../../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.WSEventEmitter,
+  TYPES.Logger
+]
 class Progress extends EventEmitter {
   constructor (
     dao,
@@ -70,10 +72,6 @@ class Progress extends EventEmitter {
   }
 }
 
-decorate(injectable(), Progress)
-decorate(inject(TYPES.DAO), Progress, 0)
-decorate(inject(TYPES.TABLES_NAMES), Progress, 1)
-decorate(inject(TYPES.WSEventEmitter), Progress, 2)
-decorate(inject(TYPES.Logger), Progress, 3)
+decorateInjectable(Progress, depsTypes)
 
 module.exports = Progress

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -1,10 +1,6 @@
 'use strict'
 
 const {
-  decorate,
-  injectable
-} = require('inversify')
-const {
   orderBy,
   isEmpty
 } = require('lodash')
@@ -19,6 +15,8 @@ const {
 const {
   DatePropNameError
 } = require('../../errors')
+
+const { decorateInjectable } = require('../../di/utils')
 
 class SubAccountApiData {
   _hasId (id) {
@@ -322,6 +320,6 @@ class SubAccountApiData {
   }
 }
 
-decorate(injectable(), SubAccountApiData)
+decorateInjectable(SubAccountApiData)
 
 module.exports = SubAccountApiData

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -1,15 +1,9 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
 
-const TYPES = require('../../di/types')
 const {
   isSubAccountApiKeys,
   getSubAccountAuthFromAuth
@@ -20,6 +14,14 @@ const {
   UserRemovingError
 } = require('../../errors')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator,
+  TYPES.Sync
+]
 class SubAccount {
   constructor (
     dao,
@@ -560,10 +562,6 @@ class SubAccount {
   }
 }
 
-decorate(injectable(), SubAccount)
-decorate(inject(TYPES.DAO), SubAccount, 0)
-decorate(inject(TYPES.TABLES_NAMES), SubAccount, 1)
-decorate(inject(TYPES.Authenticator), SubAccount, 2)
-decorate(inject(TYPES.Sync), SubAccount, 3)
+decorateInjectable(SubAccount, depsTypes)
 
 module.exports = SubAccount

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -5,18 +5,17 @@ const {
 } = require('bfx-report/workers/loc.api/errors')
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../../di/types')
-
-const {
   isHidden,
   isPublic
 } = require('../schema/utils')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.TABLES_NAMES,
+  TYPES.SyncSchema
+]
 class SyncCollsManager {
   constructor (
     dao,
@@ -291,9 +290,6 @@ class SyncCollsManager {
   }
 }
 
-decorate(injectable(), SyncCollsManager)
-decorate(inject(TYPES.DAO), SyncCollsManager, 0)
-decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
-decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)
+decorateInjectable(SyncCollsManager, depsTypes)
 
 module.exports = SyncCollsManager

--- a/workers/loc.api/sync/sync.interrupter/index.js
+++ b/workers/loc.api/sync/sync.interrupter/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable
-} = require('inversify')
-
 const Interrupter = require(
   'bfx-report/workers/loc.api/interrupter'
 )
+
+const { decorateInjectable } = require('../../di/utils')
 
 class SyncInterrupter extends Interrupter {
   constructor () {
@@ -65,6 +62,6 @@ class SyncInterrupter extends Interrupter {
   }
 }
 
-decorate(injectable(), SyncInterrupter)
+decorateInjectable(SyncInterrupter)
 
 module.exports = SyncInterrupter

--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -2,13 +2,7 @@
 
 const EventEmitter = require('events')
 const { isEmpty } = require('lodash')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const COLLS_TYPES = require('../schema/colls.types')
 
 const {
@@ -25,6 +19,17 @@ const {
   ERROR_JOB_STATE
 } = require('./sync.queue.states')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.TABLES_NAMES,
+  TYPES.ALLOWED_COLLS,
+  TYPES.DAO,
+  TYPES.DataInserterFactory,
+  TYPES.Progress,
+  TYPES.SyncSchema,
+  TYPES.SyncInterrupter
+]
 class SyncQueue extends EventEmitter {
   constructor (
     TABLES_NAMES,
@@ -341,13 +346,6 @@ class SyncQueue extends EventEmitter {
   }
 }
 
-decorate(injectable(), SyncQueue)
-decorate(inject(TYPES.TABLES_NAMES), SyncQueue, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), SyncQueue, 1)
-decorate(inject(TYPES.DAO), SyncQueue, 2)
-decorate(inject(TYPES.DataInserterFactory), SyncQueue, 3)
-decorate(inject(TYPES.Progress), SyncQueue, 4)
-decorate(inject(TYPES.SyncSchema), SyncQueue, 5)
-decorate(inject(TYPES.SyncInterrupter), SyncQueue, 6)
+decorateInjectable(SyncQueue, depsTypes)
 
 module.exports = SyncQueue

--- a/workers/loc.api/sync/traded.volume/index.js
+++ b/workers/loc.api/sync/traded.volume/index.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.Trades
+]
 class TradedVolume {
   constructor (
     trades
@@ -23,7 +20,6 @@ class TradedVolume {
   }
 }
 
-decorate(injectable(), TradedVolume)
-decorate(inject(TYPES.Trades), TradedVolume, 0)
+decorateInjectable(TradedVolume, depsTypes)
 
 module.exports = TradedVolume

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -1,21 +1,26 @@
 'use strict'
 
 const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-const {
   splitSymbolPairs
 } = require('bfx-report/workers/loc.api/helpers')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   groupByTimeframe,
   getMtsGroupedByTimeframe
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SyncSchema,
+  TYPES.FOREX_SYMBS,
+  TYPES.CurrencyConverter,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class Trades {
   constructor (
     dao,
@@ -313,13 +318,6 @@ class Trades {
   }
 }
 
-decorate(injectable(), Trades)
-decorate(inject(TYPES.DAO), Trades, 0)
-decorate(inject(TYPES.ALLOWED_COLLS), Trades, 1)
-decorate(inject(TYPES.SyncSchema), Trades, 2)
-decorate(inject(TYPES.FOREX_SYMBS), Trades, 3)
-decorate(inject(TYPES.CurrencyConverter), Trades, 4)
-decorate(inject(TYPES.Authenticator), Trades, 5)
-decorate(inject(TYPES.SYNC_API_METHODS), Trades, 6)
+decorateInjectable(Trades, depsTypes)
 
 module.exports = Trades

--- a/workers/loc.api/sync/wallets/index.js
+++ b/workers/loc.api/sync/wallets/index.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../../di/utils')
 
-const TYPES = require('../../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.CurrencyConverter,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class Wallets {
   constructor (
     dao,
@@ -115,11 +116,6 @@ class Wallets {
   }
 }
 
-decorate(injectable(), Wallets)
-decorate(inject(TYPES.DAO), Wallets, 0)
-decorate(inject(TYPES.CurrencyConverter), Wallets, 1)
-decorate(inject(TYPES.TABLES_NAMES), Wallets, 2)
-decorate(inject(TYPES.Authenticator), Wallets, 3)
-decorate(inject(TYPES.SYNC_API_METHODS), Wallets, 4)
+decorateInjectable(Wallets, depsTypes)
 
 module.exports = Wallets

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -1,13 +1,7 @@
 'use strict'
 
 const moment = require('moment')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../../di/types')
 const {
   calcGroupedData,
   groupByTimeframe,
@@ -15,6 +9,19 @@ const {
   getStartMtsByTimeframe
 } = require('../helpers')
 
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.ALLOWED_COLLS,
+  TYPES.Wallets,
+  TYPES.BalanceHistory,
+  TYPES.PositionsSnapshot,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS
+]
 class WinLoss {
   constructor (
     dao,
@@ -403,15 +410,6 @@ class WinLoss {
   }
 }
 
-decorate(injectable(), WinLoss)
-decorate(inject(TYPES.DAO), WinLoss, 0)
-decorate(inject(TYPES.SyncSchema), WinLoss, 1)
-decorate(inject(TYPES.ALLOWED_COLLS), WinLoss, 2)
-decorate(inject(TYPES.Wallets), WinLoss, 3)
-decorate(inject(TYPES.BalanceHistory), WinLoss, 4)
-decorate(inject(TYPES.PositionsSnapshot), WinLoss, 5)
-decorate(inject(TYPES.FOREX_SYMBS), WinLoss, 6)
-decorate(inject(TYPES.Authenticator), WinLoss, 7)
-decorate(inject(TYPES.SYNC_API_METHODS), WinLoss, 8)
+decorateInjectable(WinLoss, depsTypes)
 
 module.exports = WinLoss

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -3,18 +3,22 @@
 const uuid = require('uuid')
 const { omit } = require('lodash')
 const { PeerRPCServer } = require('grenache-nodejs-ws')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../di/types')
 
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF,
+  TYPES.RService,
+  TYPES.DAO,
+  TYPES.Link,
+  TYPES.GRC_BFX_OPTS,
+  TYPES.TABLES_NAMES,
+  TYPES.Authenticator
+]
 class WSTransport {
   constructor (
     { wsPort },
@@ -333,13 +337,6 @@ class WSTransport {
   }
 }
 
-decorate(injectable(), WSTransport)
-decorate(inject(TYPES.CONF), WSTransport, 0)
-decorate(inject(TYPES.RService), WSTransport, 1)
-decorate(inject(TYPES.DAO), WSTransport, 2)
-decorate(inject(TYPES.Link), WSTransport, 3)
-decorate(inject(TYPES.GRC_BFX_OPTS), WSTransport, 4)
-decorate(inject(TYPES.TABLES_NAMES), WSTransport, 5)
-decorate(inject(TYPES.Authenticator), WSTransport, 6)
+decorateInjectable(WSTransport, depsTypes)
 
 module.exports = WSTransport

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
+const { decorateInjectable } = require('../di/utils')
 
-const TYPES = require('../di/types')
-
+const depsTypes = (TYPES) => [
+  TYPES.WSTransport
+]
 class WSEventEmitter {
   constructor (wsTransport) {
     this.wsTransport = wsTransport
@@ -67,7 +64,6 @@ class WSEventEmitter {
   }
 }
 
-decorate(injectable(), WSEventEmitter)
-decorate(inject(TYPES.WSTransport), WSEventEmitter, 0)
+decorateInjectable(WSEventEmitter, depsTypes)
 
 module.exports = WSEventEmitter


### PR DESCRIPTION
This PR adds a helper to decorate injectable class of modules to improve readability and reduce the writing code of new modules. It's refactoring related to this PR of the main repo https://github.com/bitfinexcom/bfx-report/pull/219

instead of:
```js
const {
  decorate,
  injectable,
  inject
} = require('inversify')

const TYPES = require('../../di/types')

class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorate(injectable(), SyncCollsManager)
decorate(inject(TYPES.DAO), SyncCollsManager, 0)
decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)

module.exports = SyncCollsManager
```

writes as shown bellow:
```js
const { decorateInjectable } = require('../../di/utils')

const depsTypes = (TYPES) => [
  TYPES.DAO,
  TYPES.TABLES_NAMES,
  TYPES.SyncSchema
]
class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorateInjectable(SyncCollsManager, depsTypes)

module.exports = SyncCollsManager
```