### PR TITLE
Bump better-sqlite3 version up to 7.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "better-npm-run": "^0.1.1",
-    "better-sqlite3": "7.1.1",
+    "better-sqlite3": "7.1.2",
     "bfx-facs-db-better-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-better-sqlite.git",
     "bfx-facs-scheduler": "git+https://github.com:bitfinexcom/bfx-facs-scheduler.git",
     "bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",


### PR DESCRIPTION
This PR bumps the `better-sqlite3` version up to `7.1.2`. The driver was published with `v7.1.2` which:
  - Adds support for electronjs `v11.*`
  - Adds Nodejs `v14` to prebuild
  - Upgrads `SQLite3` to version `3.34.0`
  - Adds some memory fixes