### PR TITLE
Add test case for csv common folder for group reports

### DIFF
--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const testCsvPathHasCommonFolder = ({ aggrRes }) => {
+  aggrRes.newFilePaths.forEach((newFilePath) => {
+    // example: reports/csv/user_full-tax-report_FROM_Fri-Dec-01-2017_TO_Fri-May-28-2021/user_full-tax-report_END_SNAPSHOT_Tue-Jun-08-2021.csv
+    assert.match(
+      newFilePath,
+      /csv\/[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+\.csv$/,
+      'Has csv common folder for group reports'
+    )
+  })
+}
+
+module.exports = {
+  testCsvPathHasCommonFolder
+}

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -13,6 +13,9 @@ const {
   delay,
   getParamsArrToTestTimeframeGrouping
 } = require('../helpers/helpers.core')
+const {
+  testCsvPathHasCommonFolder
+} = require('../helpers/helpers.tests')
 
 module.exports = (
   agent,
@@ -699,7 +702,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for starting snapshot, store csv to local folder', async function () {
@@ -724,7 +732,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getFullTaxReportCsv method for ending snapshot, store csv to local folder', async function () {
@@ -749,7 +762,12 @@ module.exports = (
       .expect('Content-Type', /json/)
       .expect(200)
 
-    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
   })
 
   it('it should be successfully performed by the getTradedVolumeCsv method', async function () {


### PR DESCRIPTION
This PR adds test cases for `csv` common folder for the group reports, adds it to the full tax report

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/231