### PR TITLE
Improve full snapshot report csv saving

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -632,6 +632,34 @@ module.exports = (
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getFullSnapshotReportCsv method, store csv to local folder', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(params.processorQueue)
+    const aggrPromise = queueToPromise(params.aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFullSnapshotReportCsv',
+        params: {
+          end
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(
+      procPromise,
+      aggrPromise,
+      res,
+      testCsvPathHasCommonFolder
+    )
+  })
+
   it('it should be successfully performed by the getPositionsSnapshotCsv method', async function () {
     this.timeout(60000)
 

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -234,26 +234,42 @@ class CsvJobData extends BaseCsvJobData {
       uInfo
     )
     const { params } = { ...args }
-    const { chunkCommonFolder } = { ...opts }
+    const { username } = { ...uInfo }
+
     const {
+      end,
       isStartSnapshot,
       isEndSnapshot
     } = { ...params }
-    const isBaseNameInName = isStartSnapshot || isEndSnapshot
-    const typeName = isStartSnapshot
+    const {
+      isFullTaxReport,
+      chunkCommonFolder: _chunkCommonFolder
+    } = { ...opts }
+    const _typeName = isStartSnapshot
       ? 'START_SNAPSHOT'
       : 'END_SNAPSHOT'
-    const fileName = isBaseNameInName
+    const typeName = (isStartSnapshot || isEndSnapshot)
+      ? _typeName
+      : 'MOMENT'
+    const fileName = isFullTaxReport
       ? `full-tax-report_${typeName}`
-      : 'full-snapshot-report'
+      : `full-snapshot-report_${typeName}`
+
+    const endDate = end
+      ? getDateString(end)
+      : getDateString()
+    const uName = username ? `${username}_` : ''
+    const chunkCommonFolder = (
+      _chunkCommonFolder &&
+      typeof _chunkCommonFolder === 'string'
+    )
+      ? _chunkCommonFolder
+      : `${uName}full-snapshot-report_TO_${endDate}`
 
     const csvArgs = getCsvArgs(
       args,
       null,
-      {
-        isOnMomentInName: !isBaseNameInName,
-        isBaseNameInName
-      }
+      { isBaseNameInName: true }
     )
 
     const jobData = {
@@ -368,7 +384,10 @@ class CsvJobData extends BaseCsvJobData {
         },
         uId,
         uInfo,
-        { chunkCommonFolder }
+        {
+          chunkCommonFolder,
+          isFullTaxReport: true
+        }
       )
     }
 


### PR DESCRIPTION
This PR improves the full snapshot report csv files saving.
Example of files structure:
  - folder: `user_full-snapshot-report_TO_Mon-Aug-24-2020`
    - file in the folder: `user_full-snapshot-report_MOMENT_Fri-Feb-5-2021.csv`
    - file in the folder: `user_full-snapshot-report_MOMENT_Thu-Jun-10-2021.csv`
    - file in the folder: `user_full-snapshot-report_MOMENT_Thu-Jun-10-2021-(1).csv`