### PR TITLE
Don't check change logs have been synced at least once

### DIFF
--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -227,7 +227,7 @@ const _methodCollMap = new Map([
       sort: [['mtsCreate', -1]],
       hasNewData: false,
       start: [],
-      isSyncRequiredAtLeastOnce: true,
+      isSyncRequiredAtLeastOnce: false,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
     }


### PR DESCRIPTION
This PR fixes launching the app for the first time, the issue is following: we should not check that `change logs` have been synced at least once due to some fresh users may not have entries in that tables. And it would initiate a sync every time when the app launches