### PR TITLE
Bump better-sqlite3 driver version up to 7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "better-npm-run": "^0.1.1",
-    "better-sqlite3": "7.1.2",
+    "better-sqlite3": "7.4.1",
     "bfx-facs-db-better-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-better-sqlite.git",
     "bfx-facs-scheduler": "git+https://github.com:bitfinexcom/bfx-facs-scheduler.git",
     "bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",


### PR DESCRIPTION
This PR bumps version of the `better-sqlite3` DB driver up to `7.4.1`. The reasons are the following:
  - the driver reached a point to have pre-built binaries for all OS (win, mac, linux) for the electron env, https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.4.1 This means that we can don't care about it and remove ugly fix from the `bfx-report-electron` repo, removing `better-sqlite3` pre-build binary for windows https://github.com/bitfinexcom/bfx-report-electron/blob/master/build/better-sqlite3-prebuild-bin-win/better_sqlite3.zip
  - added prebuilt binaries for Electron `v13`. This means that we can use Nodejs `v14` with the last features