### PR TITLE
Add weekly timeframe to reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
     "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
-    "grenache-grape": "^0.9.8",
+    "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "mocha": "^6.1.4",
     "chai": "^4.2.0",
     "nodemon": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grenache-grape": "^0.9.8",
     "mocha": "^6.1.4",
     "chai": "^4.2.0",
-    "nodemon": "^1.18.10",
+    "nodemon": "^2.0.7",
     "supertest": "^4.0.2",
     "standard": "^16.0.3"
   },

--- a/test/helpers/helpers.core.js
+++ b/test/helpers/helpers.core.js
@@ -26,7 +26,7 @@ const delay = (mc = 500) => _delay(mc)
 
 const getParamsArrToTestTimeframeGrouping = (
   params = {},
-  timeframes = ['day', 'month', 'year']
+  timeframes = ['day', 'week', 'month', 'year']
 ) => {
   return Array(timeframes.length)
     .fill({ ...params })

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -170,6 +170,7 @@ const paramsSchemaForRiskApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -204,6 +205,7 @@ const paramsSchemaForBalanceHistoryApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -242,6 +244,7 @@ const paramsSchemaForFullTaxReportApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -262,6 +265,7 @@ const paramsSchemaForWinLossApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -282,6 +286,7 @@ const paramsSchemaForTradedVolumeApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -305,6 +310,7 @@ const paramsSchemaForFeesReportApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]
@@ -328,6 +334,7 @@ const paramsSchemaForPerformingLoanApi = {
       type: 'string',
       enum: [
         'day',
+        'week',
         'month',
         'year'
       ]

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -163,41 +163,6 @@ const paramsSchemaForEditCandlesСonf = {
   }
 }
 
-const paramsSchemaForRiskApi = {
-  type: 'object',
-  properties: {
-    timeframe: {
-      type: 'string',
-      enum: [
-        'day',
-        'week',
-        'month',
-        'year'
-      ]
-    },
-    start: {
-      type: 'integer'
-    },
-    end: {
-      type: 'integer'
-    },
-    skip: {
-      type: 'array',
-      minItems: 1,
-      maxItems: 3,
-      items: {
-        type: 'string',
-        enum: [
-          'trades',
-          'marginTrades',
-          'fundingPayment',
-          'movementFees'
-        ]
-      }
-    }
-  }
-}
-
 const paramsSchemaForBalanceHistoryApi = {
   type: 'object',
   properties: {
@@ -240,15 +205,6 @@ const paramsSchemaForFullSnapshotReportApi = {
 const paramsSchemaForFullTaxReportApi = {
   type: 'object',
   properties: {
-    timeframe: {
-      type: 'string',
-      enum: [
-        'day',
-        'week',
-        'month',
-        'year'
-      ]
-    },
     end: {
       type: 'integer'
     },
@@ -356,15 +312,6 @@ const {
   dateFormat
 } = { ...paramsSchemaForCsv.properties }
 
-const paramsSchemaForRiskCsv = {
-  type: 'object',
-  properties: {
-    ...cloneDeep(paramsSchemaForRiskApi.properties),
-    timezone,
-    dateFormat
-  }
-}
-
 const paramsSchemaForBalanceHistoryCsv = {
   type: 'object',
   properties: {
@@ -456,7 +403,6 @@ module.exports = {
   paramsSchemaForEditCandlesСonf,
   paramsSchemaForCreateSubAccount,
   paramsSchemaForUpdateSubAccount,
-  paramsSchemaForRiskApi,
   paramsSchemaForBalanceHistoryApi,
   paramsSchemaForWinLossApi,
   paramsSchemaForPositionsSnapshotApi,
@@ -466,7 +412,6 @@ module.exports = {
   paramsSchemaForFeesReportApi,
   paramsSchemaForPerformingLoanApi,
   paramsSchemaForCandlesApi,
-  paramsSchemaForRiskCsv,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,
   paramsSchemaForPositionsSnapshotCsv,

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -165,6 +165,9 @@ class BalanceHistory {
     if (timeframe === 'month') {
       mtsMoment.add(1, 'months')
     }
+    if (timeframe === 'week') {
+      mtsMoment.add(1, 'weeks')
+    }
     if (timeframe === 'year') {
       mtsMoment.add(1, 'years')
     }

--- a/workers/loc.api/sync/dao/helpers/get-timeframe-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-timeframe-query.js
@@ -7,11 +7,12 @@ module.exports = (timeframe, params) => {
   } = { ...params }
 
   const day = timeframe === 'day' ? '-%m-%d' : ''
+  const week = timeframe === 'week' ? '-%W' : ''
   const month = timeframe === 'month' ? '-%m' : ''
   const year = '%Y'
 
   return `strftime(
-    '${year}${month}${day}',
+    '${year}${month}${week}${day}',
     ${propName}/1000,
     'unixepoch'
   ) AS ${alias}`

--- a/workers/loc.api/sync/helpers/get-mts-grouped-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/get-mts-grouped-by-timeframe.js
@@ -42,6 +42,11 @@ module.exports = (
 
       continue
     }
+    if (timeframe === 'week') {
+      currMoment.add(1, 'weeks')
+
+      continue
+    }
     if (timeframe === 'month') {
       currMoment.add(1, 'months')
 

--- a/workers/loc.api/sync/helpers/get-start-mts-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/get-start-mts-by-timeframe.js
@@ -1,24 +1,35 @@
 'use strict'
 
+const moment = require('moment')
+
 module.exports = (ts, timeframe = 'year') => {
-  const date = ts instanceof Date ? ts : new Date(ts)
-  const year = date.getUTCFullYear()
-  const month = date.getUTCMonth()
-  const day = date.getUTCDate()
+  const date = moment.utc(ts)
+
+  const year = date.year()
+  const month = date.month()
+  const weekYear = date.isoWeekYear()
+  const week = date.isoWeek()
+  const day = date.dayOfYear()
+
+  const momentDate = moment.utc({ year })
 
   if (timeframe === 'day') {
-    return Date.UTC(
-      year,
-      month,
-      day
-    )
+    momentDate.dayOfYear(day)
+
+    return momentDate.valueOf()
+  }
+  if (timeframe === 'week') {
+    momentDate.isoWeekYear(weekYear)
+    momentDate.isoWeekday(1)
+    momentDate.isoWeek(week)
+
+    return momentDate.valueOf()
   }
   if (timeframe === 'month') {
-    return Date.UTC(
-      year,
-      month
-    )
+    momentDate.month(month)
+
+    return momentDate.valueOf()
   }
 
-  return Date.UTC(year)
+  return momentDate.valueOf()
 }

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -63,6 +63,14 @@ const _isMonthlyTimeframe = (params) => {
   return _checkTimeframe(params)
 }
 
+const _isWeeklyTimeframe = (params) => {
+  if (params.timeframe !== 'week') {
+    return false
+  }
+
+  return _checkTimeframe(params)
+}
+
 const _isDailyTimeframe = (params) => {
   if (params.timeframe !== 'day') {
     return false
@@ -83,6 +91,7 @@ const _isNotEmptyGroupItem = ({ mts, vals }) => {
 const _isTimeframe = (timeframe) => {
   return (
     timeframe === 'day' ||
+    timeframe === 'week' ||
     timeframe === 'month' ||
     timeframe === 'year'
   )
@@ -205,6 +214,20 @@ module.exports = async (
       continue
     }
     if (_isMonthlyTimeframe(paramsToCheck)) {
+      const groupItem = await _getGroupItem(
+        subRes,
+        timeframe,
+        symbol,
+        dateFieldName,
+        symbolFieldName,
+        calcDataFn
+      )
+
+      _addFragment(res, subRes, groupItem)
+
+      continue
+    }
+    if (_isWeeklyTimeframe(paramsToCheck)) {
       const groupItem = await _getGroupItem(
         subRes,
         timeframe,

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -250,6 +250,9 @@ class WinLoss {
       if (timeframe === 'day') {
         mtsMoment.add(1, 'days')
       }
+      if (timeframe === 'week') {
+        mtsMoment.add(1, 'weeks')
+      }
       if (timeframe === 'month') {
         mtsMoment.add(1, 'months')
       }


### PR DESCRIPTION
This PR adds the weekly timeframe to `getWinLoss()`, `getTradedVolume()`, `getFeesReport()`, `getPerformingLoan()`, `getBalanceHistory()` reports

Request example:

```jsonc
{
    "auth": {
        "token": "some-token"
    },
    "method": "getWinLoss",
    "params": {
        "end": 1587519905000,
        "timeframe": "week" // may be: 'day', 'week', 'month', 'year'
    }
}
```

Response example:
```jsonc
{
  "result": [
    {
      "mts": 1587519905000,
      "USD": 123456.654321
    },
    {
      "mts": 1587340800000, // .toUTCString() -> 'Mon, 20 Apr 2020 00:00:00 GMT'
      "USD": 12345.54321
    },
    {
      "mts": 1586736000000, // .toUTCString() -> 'Mon, 13 Apr 2020 00:00:00 GMT'
      "USD": 1234.4321
    },
    {
      "mts": 1586131200000, // .toUTCString() -> 'Mon, 06 Apr 2020 00:00:00 GMT'
      "USD": 123.321
    },
    {
      "mts": 0,
      "USD": 0
    }
  ],
  "id": null
}
```