### PR TITLE
Fix win-loss calculation

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -3,8 +3,7 @@
 const {
   BaseError,
   AuthError,
-  ConflictError,
-  UnprocessableEntityError
+  ConflictError
 } = require('bfx-report/workers/loc.api/errors')
 
 class CollSyncPermissionError extends BaseError {
@@ -153,14 +152,6 @@ class GetPublicDataError extends BaseError {
   }
 }
 
-class SyncedPositionsSnapshotParamsError extends UnprocessableEntityError {
-  constructor (message = 'ERR_SYNCED_POSITIONS_SNAPSHOT_PARAMS_IS_NOT_CORRECT') {
-    super(message)
-
-    this.statusMessage = 'The synced positions snapshot params is not correct'
-  }
-}
-
 class DataConsistencyCheckerFindingError extends BaseError {
   constructor (message = 'ERR_DATA_CONSISTENCY_CHECKER_HAS_NOT_BEEN_FOUND') {
     super(message)
@@ -199,7 +190,6 @@ module.exports = {
   SubAccountLedgersBalancesRecalcError,
   DatePropNameError,
   GetPublicDataError,
-  SyncedPositionsSnapshotParamsError,
   DataConsistencyCheckerFindingError,
   DataConsistencyError
 }

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -401,13 +401,10 @@ class CurrencyConverter {
       mts
     }
   ) {
-    if (!this._isRequiredConvToForex(convertTo)) {
-      return null
-    }
-
     const end = Number.isInteger(mts)
       ? mts
       : item[dateFieldName]
+    const isRequiredConvToForex = this._isRequiredConvToForex(convertTo)
     const isRequiredConvFromForex = this._isRequiredConvFromForex(
       item,
       {
@@ -437,6 +434,27 @@ class CurrencyConverter {
       }
 
       return btcPriceOut / btcPriceIn
+    }
+    if (!isRequiredConvToForex) {
+      const usdPriceIn = await _getPrice(
+        `t${item[symbolFieldName]}USD`,
+        end
+      )
+      const usdPriceOut = await _getPrice(
+        `t${convertTo}USD`,
+        end
+      )
+
+      if (
+        !usdPriceIn ||
+        !usdPriceOut ||
+        !Number.isFinite(usdPriceIn) ||
+        !Number.isFinite(usdPriceOut)
+      ) {
+        return null
+      }
+
+      return usdPriceIn / usdPriceOut
     }
 
     const price = await _getPrice(

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -159,9 +159,39 @@ class CurrencyConverter {
       return
     }
 
-    return synonymous.map(([symbol, conversion]) => (
-      [`${prefix}${symbol}${lastSymb}`, conversion]
-    ))
+    return synonymous.reduce((accum, [symbol, conversion]) => {
+      const separator = (
+        symbol.length > 3 ||
+        lastSymb.length > 3
+      )
+        ? ':'
+        : ''
+
+      accum.push([
+        `${prefix}${symbol}${separator}${lastSymb}`,
+        conversion
+      ])
+
+      if (
+        symbol.length >= 4 &&
+        /F0$/i.test(symbol)
+      ) {
+        const _symbol = this._getConvertingSymb(symbol)
+        const _separator = (
+          _symbol.length > 3 ||
+          lastSymb.length > 3
+        )
+          ? ':'
+          : ''
+
+        accum.push([
+          `${prefix}${_symbol}${_separator}${lastSymb}`,
+          conversion
+        ])
+      }
+
+      return accum
+    }, [])
   }
 
   async _priceFinder (

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -759,11 +759,15 @@ class CurrencyConverter {
   /**
    * if api is not available convert by candles
    */
-  convert (data, convSchema) {
+  async convert (data, convSchema) {
     try {
-      return this.convertByPublicTrades(data, convSchema)
+      const res = await this.convertByPublicTrades(data, convSchema)
+
+      return res
     } catch (err) {
-      return this.convertByCandles(data, convSchema)
+      const res = await this.convertByCandles(data, convSchema)
+
+      return res
     }
   }
 

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -78,8 +78,8 @@ class ApiMiddlewareHandlerAfter {
         continue
       }
 
-      const pl = (closePrice - basePrice) * sumAmount
-      const plPerc = ((closePrice / basePrice) - 1) * 100 * Math.sign(sumAmount)
+      const pl = (closePrice - basePrice) * Math.abs(sumAmount)
+      const plPerc = ((closePrice / basePrice) - 1) * 100
 
       res.push({
         ...position,

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -78,8 +78,8 @@ class ApiMiddlewareHandlerAfter {
         continue
       }
 
-      const pl = (closePrice - basePrice) * Math.abs(sumAmount)
-      const plPerc = ((closePrice / basePrice) - 1) * 100
+      const pl = (closePrice - basePrice) * sumAmount
+      const plPerc = ((closePrice / basePrice) - 1) * 100 * Math.sign(sumAmount)
 
       res.push({
         ...position,

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -584,25 +584,14 @@ class DataChecker {
         notCheckNextPage: true,
         symbol
       }
-      const _argsForLastElem = this._getMethodArgMap(method, {}, 1)
-      const argsForLastElem = {
-        ..._argsForLastElem,
-        params: {
-          ..._argsForLastElem.params,
-          ...params
-        }
-      }
-      const _argsForReceivingStart = this._getMethodArgMap(
+      const argsForLastElem = this._getMethodArgMap(
         method,
-        { limit: 1, end: _start }
+        { limit: 1, params }
       )
-      const argsForReceivingStart = {
-        ..._argsForReceivingStart,
-        params: {
-          ..._argsForReceivingStart.params,
-          ...params
-        }
-      }
+      const argsForReceivingStart = this._getMethodArgMap(
+        method,
+        { limit: 1, end: _start, params }
+      )
 
       const filter = {
         [symbolFieldName]: symbol,

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -665,7 +665,7 @@ class DataInserter extends EventEmitter {
         prevRes.length > 0 &&
         prevRes.every((item, i) => (
           Object.entries(res[i]).every(([key, val]) => (
-            item[key] = val
+            item[key] === val
           ))
         ))
       ) {

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -117,7 +117,14 @@ const _getGroupItem = async (
   const mts = _isTimeframe(timeframe)
     ? getStartMtsByTimeframe(last, timeframe)
     : _mts
-  const vals = await calcDataFn(data, symbolFieldName, symbol)
+  const args = {
+    symbolFieldName,
+    symbol,
+    timeframe,
+    mts
+  }
+
+  const vals = await calcDataFn(data, args)
 
   return {
     mts,

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -7,9 +7,6 @@ const {
 } = require('bfx-report/workers/loc.api/helpers')
 
 const { getTimeframeQuery } = require('../dao/helpers')
-const {
-  SyncedPositionsSnapshotParamsError
-} = require('../../errors')
 
 const { decorateInjectable } = require('../../di/utils')
 
@@ -577,13 +574,6 @@ class PositionsSnapshot {
     const user = await this.authenticator
       .verifyRequestUser({ auth })
     const emptyRes = []
-
-    if (
-      Number.isInteger(start) &&
-      Number.isInteger(end)
-    ) {
-      throw new SyncedPositionsSnapshotParamsError()
-    }
 
     const syncedPositionsSnapshot = await this._getPositionsSnapshotFromDb(
       user,

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -284,7 +284,7 @@ class PositionsSnapshot {
 
       const pl = ((actualPrice - basePrice) * Math.abs(amount)) -
         Math.abs(convertedMarginFunding)
-      const plPerc = ((actualPrice / basePrice) - 1) * 100 * Math.sign(amount)
+      const plPerc = ((actualPrice / basePrice) - 1) * 100
       const {
         plUsd,
         currency

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -110,32 +110,11 @@ class PositionsSnapshot {
     const isStartExisted = Number.isInteger(start)
     const isEndExisted = Number.isInteger(end)
 
-    const startSqlTimeframe = this._getTimeframeQuery(
-      'startMtsUpdateStr',
-      isStartExisted
-    )
-    const endSqlTimeframe = this._getTimeframeQuery(
-      'endMtsUpdateStr',
-      isEndExisted
-    )
-
-    const startMtsUpdateStr = this._getMtsStr(
-      start,
-      'startMtsUpdateStr'
-    )
-    const endMtsUpdateStr = this._getMtsStr(
-      end,
-      'endMtsUpdateStr'
-    )
-
     const gteFilter = isStartExisted
       ? { $gte: { mtsUpdate: start } }
       : {}
     const lteFilter = isEndExisted
       ? { $lte: { mtsUpdate: end } }
-      : {}
-    const eqFilter = isStartExisted || isEndExisted
-      ? { $eq: { ...startMtsUpdateStr, ...endMtsUpdateStr } }
       : {}
 
     return this.dao.getElemsInCollBy(
@@ -144,15 +123,10 @@ class PositionsSnapshot {
         filter: {
           user_id: user._id,
           ...gteFilter,
-          ...lteFilter,
-          ...eqFilter
+          ...lteFilter
         },
         sort: [['mtsUpdate', -1]],
-        projection: [
-          ...this.positionsSnapshotModel,
-          ...startSqlTimeframe,
-          ...endSqlTimeframe
-        ],
+        projection: this.positionsSnapshotModel,
         exclude: ['user_id'],
         isExcludePrivate: true
       }

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -263,7 +263,8 @@ class PositionsSnapshot {
       const {
         symbol,
         basePrice,
-        amount
+        amount,
+        marginFunding
       } = { ...position }
 
       const resPositions = {
@@ -293,7 +294,15 @@ class PositionsSnapshot {
         continue
       }
 
-      const pl = (actualPrice - basePrice) * amount
+      const _marginFunding = Number.isFinite(marginFunding)
+        ? marginFunding
+        : 0
+      const isMarginFundingCrypto = _marginFunding < 0
+      const marginFundingCrypto = isMarginFundingCrypto
+        ? _marginFunding
+        : _marginFunding / actualPrice
+
+      const pl = ((actualPrice - basePrice) * amount) - Math.abs(marginFundingCrypto)
       const plPerc = ((actualPrice / basePrice) - 1) * 100 * Math.sign(amount)
       const {
         plUsd,

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -6,8 +6,6 @@ const {
   splitSymbolPairs
 } = require('bfx-report/workers/loc.api/helpers')
 
-const { getTimeframeQuery } = require('../dao/helpers')
-
 const { decorateInjectable } = require('../../di/utils')
 
 const depsTypes = (TYPES) => [
@@ -64,38 +62,6 @@ class PositionsSnapshot {
         isExcludePrivate: true
       }
     )
-  }
-
-  _getTimeframeQuery (alias, isMtsExisted) {
-    const res = getTimeframeQuery(
-      'day',
-      {
-        propName: 'mtsUpdate',
-        alias
-      }
-    )
-
-    return isMtsExisted ? [res] : []
-  }
-
-  _getMtsStr (mts, propName) {
-    if (
-      !Number.isInteger(mts) ||
-      mts === 0
-    ) {
-      return
-    }
-
-    const date = new Date(mts)
-    const year = date.getUTCFullYear()
-    const _month = date.getUTCMonth() + 1
-    const month = _month < 10
-      ? `0${_month}`
-      : _month
-    const day = date.getUTCDate()
-    const mtsStr = `${year}-${month}-${day}`
-
-    return { [propName]: mtsStr }
   }
 
   _getPositionsSnapshotFromDb (
@@ -591,7 +557,7 @@ class PositionsSnapshot {
       positionsSnapshot
     } = await this._getCalculatedPositions(
       syncedPositionsSnapshot,
-      start || end,
+      end ?? start,
       { isNotTickersRequired: true }
     )
 

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -245,9 +245,9 @@ class PositionsSnapshot {
         ? _marginFunding
         : _marginFunding * actualPrice
 
-      const pl = ((actualPrice - basePrice) * Math.abs(amount)) -
+      const pl = ((actualPrice - basePrice) * amount) -
         Math.abs(convertedMarginFunding)
-      const plPerc = ((actualPrice / basePrice) - 1) * 100
+      const plPerc = ((actualPrice / basePrice) - 1) * 100 * Math.sign(amount)
       const {
         plUsd,
         currency

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -49,13 +49,13 @@ class WinLoss {
   async _getPlFromPositionsSnapshot (args = {}) {
     const {
       auth,
-      params: { mts }
+      params: { mts, isStart, isEnd }
     } = args
 
     const {
       start,
       end
-    } = this._getStartAndEndMtsForDay(mts)
+    } = this._getStartAndEndMtsForDay({ mts, isStart, isEnd })
 
     const dailyPositionsSnapshots = await this.positionsSnapshot
       .getSyncedPositionsSnapshot({
@@ -71,7 +71,9 @@ class WinLoss {
     )
   }
 
-  _getStartAndEndMtsForDay (mts) {
+  _getStartAndEndMtsForDay (params = {}) {
+    const { mts, isStart, isEnd } = params
+
     const date = moment.utc(mts)
     const year = date.year()
     const day = date.dayOfYear()
@@ -83,8 +85,12 @@ class WinLoss {
       .subtract(1, 'ms')
 
     return {
-      start: startDate.valueOf(),
-      end: endDate.valueOf()
+      start: isStart
+        ? mts
+        : startDate.valueOf(),
+      end: isEnd
+        ? mts
+        : endDate.valueOf()
     }
   }
 
@@ -355,11 +361,11 @@ class WinLoss {
 
     const startPlPromise = this._getPlFromPositionsSnapshot({
       auth,
-      params: { mts: start }
+      params: { mts: start, isStart: true }
     })
     const endPlPromise = this._getPlFromPositionsSnapshot({
       auth,
-      params: { mts: end }
+      params: { mts: end, isEnd: true }
     })
 
     const withdrawalsPromise = this.movements.getMovements({

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -137,9 +137,13 @@ class WinLoss {
 
   _calcMovements (
     data = [],
-    symbolFieldName,
-    symbol = []
+    args = {}
   ) {
+    const {
+      symbolFieldName,
+      symbol = []
+    } = args
+
     return data.reduce((accum, movement = {}) => {
       const { amount, amountUsd } = { ...movement }
       const currSymb = movement[symbolFieldName]

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -57,10 +57,12 @@ class WinLoss {
 
   _isClosedPosition (positionsHistory, mts, id) {
     return (
-      positionsHistory &&
-      typeof positionsHistory === 'object' &&
-      positionsHistory.id === id &&
-      positionsHistory.mts === mts
+      Array.isArray(positionsHistory) &&
+      positionsHistory.length > 0 &&
+      positionsHistory.some((item) => (
+        item.id === id &&
+        item.mts === mts
+      ))
     )
   }
 

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -338,6 +338,21 @@ class WinLoss {
       positionsHistoryPromise
     ])
 
+    const positionsHistoryNormByMts = positionsHistory.map((pos) => {
+      if (
+        pos &&
+        typeof pos === 'object' &&
+        Number.isFinite(pos.mtsUpdate)
+      ) {
+        pos.mts = getStartMtsByTimeframe(
+          pos.mtsUpdate,
+          timeframe
+        )
+      }
+
+      return pos
+    })
+
     const withdrawalsGroupedByTimeframePromise = groupByTimeframe(
       withdrawals,
       { timeframe, start, end },

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -73,7 +73,8 @@ class WinLoss {
     const year = date.year()
     const day = date.dayOfYear()
 
-    const startDate = moment.utc({ year, day })
+    const startDate = moment.utc({ year })
+      .dayOfYear(day)
     const endDate = moment(startDate)
       .add(1, 'day')
       .subtract(1, 'ms')

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -62,9 +62,12 @@ class WinLoss {
         auth,
         params: { start, end }
       })
+    const filteredPositions = this._filterPositionsDuplicateBySymb(
+      dailyPositionsSnapshots
+    )
 
     return this._calcPlFromPositionsSnapshots(
-      dailyPositionsSnapshots
+      filteredPositions
     )
   }
 
@@ -83,6 +86,26 @@ class WinLoss {
       start: startDate.valueOf(),
       end: endDate.valueOf()
     }
+  }
+
+  _filterPositionsDuplicateBySymb (positions) {
+    if (
+      !Array.isArray(positions) ||
+      positions.length === 0
+    ) {
+      return positions
+    }
+
+    return positions.reduce((accum, position) => {
+      if (
+        typeof position?.symbol === 'string' &&
+        accum.every((item) => item?.symbol !== position?.symbol)
+      ) {
+        accum.push(position)
+      }
+
+      return accum
+    }, [])
   }
 
   _calcPlFromPositionsSnapshots (positions) {


### PR DESCRIPTION
This PR fixes the `win/loss` calculation. Basic changes:
  - fixes `pl` calculation
  - fixes `pl` converting to usd
  - fixes getting currency price from DB when the bfx `api_v2` is not available, useful when the internet is disconnected. Also, it covers pairs like `tBTCF0:USTF0`
  - fixes adding pl to win/loss. The positions that were open at the start or end check the pl of the start or end. Have into consideration that as to consider the pl of the end just one position snapshot is required per trading pair, same for start