### PR TITLE
Clear all tables

### DIFF
--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -188,7 +188,10 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
         }
 
         await dao.dropAllTables({
-          exceptions: [TABLES_NAMES.USERS]
+          exceptions: [
+            TABLES_NAMES.USERS,
+            TABLES_NAMES.SUB_ACCOUNTS
+          ]
         })
 
         process.send({ state: 'all-tables-have-been-cleared' })

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -243,9 +243,19 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
-  async dropAllTables () {
+  async dropAllTables (opts) {
+    const {
+      exceptions = []
+    } = opts
+
+    const _exceptions = Array.isArray(exceptions)
+      ? exceptions
+      : []
     const tableNames = await this._getTablesNames()
-    const sql = tableNames.map((name) => (
+    const filteredTableNames = tableNames.filter((name) => (
+      !_exceptions.includes(name)
+    ))
+    const sql = filteredTableNames.map((name) => (
       `DROP TABLE IF EXISTS ${name}`
     ))
 


### PR DESCRIPTION
This PR adds the ability to clear all tables using IPC messages when being forked process in electron env. Basic changes:
  - Adds ability to drop all tables except `USERS` and `SUB_ACCOUNTS` to be able to login
  - Adds WAL checkpoint when initializing to sync DB file with WAL (reduces DB files size and stores last changes in DB file) https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
  
The clearing all tables would execute the following SQL:

```sql
BEGIN EXCLUSIVE
DROP TABLE IF EXISTS candles
DROP TABLE IF EXISTS changeLogs
DROP TABLE IF EXISTS completedOnFirstSyncColls
DROP TABLE IF EXISTS currencies
DROP TABLE IF EXISTS fundingCreditHistory
DROP TABLE IF EXISTS fundingLoanHistory
DROP TABLE IF EXISTS fundingOfferHistory
DROP TABLE IF EXISTS fundingTrades
DROP TABLE IF EXISTS futures
DROP TABLE IF EXISTS inactiveCurrencies
DROP TABLE IF EXISTS inactiveSymbols
DROP TABLE IF EXISTS ledgers
DROP TABLE IF EXISTS logins
DROP TABLE IF EXISTS mapSymbols
DROP TABLE IF EXISTS movements
DROP TABLE IF EXISTS orders
DROP TABLE IF EXISTS positionsHistory
DROP TABLE IF EXISTS positionsSnapshot
DROP TABLE IF EXISTS progress
DROP TABLE IF EXISTS publicTrades
DROP TABLE IF EXISTS publicСollsСonf
DROP TABLE IF EXISTS scheduler
DROP TABLE IF EXISTS statusMessages
DROP TABLE IF EXISTS symbols
DROP TABLE IF EXISTS syncMode
DROP TABLE IF EXISTS syncQueue
DROP TABLE IF EXISTS tickersHistory
DROP TABLE IF EXISTS trades
COMMIT
PRAGMA wal_checkpoint(RESTART)
VACUUM
```
