### PR TITLE
Rework JSON-RPC response

### DIFF
--- a/test/3-api-filter-sync-mode-sqlite.spec.js
+++ b/test/3-api-filter-sync-mode-sqlite.spec.js
@@ -826,12 +826,12 @@ describe('API filter', () => {
         .type('json')
         .send(args)
         .expect('Content-Type', /json/)
-        .expect(500)
+        .expect(400)
 
       assert.isObject(res.body)
       assert.isObject(res.body.error)
-      assert.propertyVal(res.body.error, 'code', 500)
-      assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+      assert.propertyVal(res.body.error, 'code', 400)
+      assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
       assert.propertyVal(res.body, 'id', 5)
     }
   })

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -197,7 +197,9 @@ module.exports = (
     assert.isObject(res.body.error)
     assert.propertyVal(res.body.error, 'code', 401)
     assert.propertyVal(res.body.error, 'message', 'Unauthorized')
+    assert.propertyVal(res.body.error, 'data', null)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isString(res.body.jsonrpc)
   })
 
   it('it should be successfully performed by the signOut method', async function () {
@@ -2041,12 +2043,19 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.isArray(res.body.error.data)
+    assert.isAbove(res.body.error.data.length, 0)
+
+    res.body.error.data.forEach((item) => {
+      assert.isObject(item)
+    })
+
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -2232,12 +2241,12 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -2482,12 +2491,12 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -2582,11 +2591,11 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(400)
+      .expect(422)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'code', 422)
     assert.propertyVal(res.body.error, 'message', 'A greater limit is needed as to show the data correctly')
     assert.propertyVal(res.body, 'id', 5)
   })
@@ -2720,12 +2729,12 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -3046,11 +3055,11 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(400)
+      .expect(422)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'code', 422)
     assert.propertyVal(res.body.error, 'message', 'For public trades export please select a time frame smaller than a month')
     assert.propertyVal(res.body, 'id', 5)
   })
@@ -3075,12 +3084,12 @@ module.exports = (
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -2,7 +2,9 @@
 
 const {
   BaseError,
-  AuthError
+  AuthError,
+  ConflictError,
+  UnprocessableEntityError
 } = require('bfx-report/workers/loc.api/errors')
 
 class CollSyncPermissionError extends BaseError {
@@ -41,7 +43,7 @@ class UpdateRecordError extends BaseError {
       ? `_OF_${name.toUpperCase()}`
       : ''
 
-    super(`ERR_CAN_NOT_UPDATE_RECORD_OF_${recordName}`)
+    super(`ERR_CAN_NOT_UPDATE_RECORD${recordName}`)
   }
 }
 
@@ -59,18 +61,14 @@ class DAOInitializationError extends BaseError {
 
 class ServerAvailabilityError extends BaseError {
   constructor (restUrl) {
-    super(`The server ${restUrl} is not available`)
+    super(`ERR_SERVER_${restUrl}_IS_NOT_AVAILABLE`)
+
+    this.statusMessage = `The server ${restUrl} is not available`
   }
 }
 
 class ObjectMappingError extends BaseError {
   constructor (message = 'ERR_MAPPING_AN_OBJECT_BY_THE_SCHEMA') {
-    super(message)
-  }
-}
-
-class DuringSyncMethodAccessError extends BaseError {
-  constructor (message = 'ERR_DURING_SYNC_METHOD_IS_NOT_AVAILABLE') {
     super(message)
   }
 }
@@ -100,37 +98,45 @@ class DbVersionTypeError extends BaseError {
 }
 
 class MigrationLaunchingError extends BaseError {
-  constructor (message = 'ERR_DB_MIGRATION_HAS_FAILED') {
+  constructor (message = 'ERR_DB_MIGRATION_HAS_BEEN_FAILED') {
     super(message)
   }
 }
 
 class SubAccountCreatingError extends AuthError {
-  constructor (message = 'ERR_SUB_ACCOUNT_CREATION_HAS_FAILED') {
+  constructor (message = 'ERR_SUB_ACCOUNT_CREATION_HAS_BEEN_FAILED') {
     super(message)
+
+    this.statusMessage = 'Sub account creation has been failed'
   }
 }
 
 class SubAccountUpdatingError extends AuthError {
-  constructor (message = 'ERR_SUB_ACCOUNT_UPDATE_HAS_FAILED') {
+  constructor (message = 'ERR_SUB_ACCOUNT_UPDATE_HAS_BEEN_FAILED') {
     super(message)
+
+    this.statusMessage = 'Sub account update has been failed'
   }
 }
 
 class UserRemovingError extends AuthError {
-  constructor (message = 'ERR_USER_REMOVE_HAS_FAILED') {
+  constructor (message = 'ERR_USER_REMOVE_HAS_BEEN_FAILED') {
     super(message)
+
+    this.statusMessage = 'User remove has been failed'
   }
 }
 
 class UserWasPreviouslyStoredInDbError extends AuthError {
   constructor (message = 'ERR_USER_WAS_PREVIOUSLY_STORED_IN_DB') {
     super(message)
+
+    this.statusMessage = 'User was previously stored in DB'
   }
 }
 
 class SubAccountLedgersBalancesRecalcError extends BaseError {
-  constructor (message = 'ERR_SUB_ACCOUNT_LEDGERS_BALANCES_RECALC_HAS_FAILED') {
+  constructor (message = 'ERR_SUB_ACCOUNT_LEDGERS_BALANCES_RECALC_HAS_BEEN_FAILED') {
     super(message)
   }
 }
@@ -142,14 +148,16 @@ class DatePropNameError extends BaseError {
 }
 
 class GetPublicDataError extends BaseError {
-  constructor (message = 'ERR_GETTING_PUBLIC_DATA_HAS_FAILED') {
+  constructor (message = 'ERR_GETTING_PUBLIC_DATA_HAS_BEEN_FAILED') {
     super(message)
   }
 }
 
-class SyncedPositionsSnapshotParamsError extends BaseError {
+class SyncedPositionsSnapshotParamsError extends UnprocessableEntityError {
   constructor (message = 'ERR_SYNCED_POSITIONS_SNAPSHOT_PARAMS_IS_NOT_CORRECT') {
     super(message)
+
+    this.statusMessage = 'The synced positions snapshot params is not correct'
   }
 }
 
@@ -159,9 +167,11 @@ class DataConsistencyCheckerFindingError extends BaseError {
   }
 }
 
-class DataConsistencyError extends BaseError {
+class DataConsistencyError extends ConflictError {
   constructor (message = 'ERR_COLLECTIONS_DATA_IS_NOT_CONSISTENT') {
     super(message)
+
+    this.statusMessage = 'The db has inconsistent data, please force sync and wait for end and then try again'
   }
 }
 
@@ -177,7 +187,6 @@ module.exports = {
   DAOInitializationError,
   ServerAvailabilityError,
   ObjectMappingError,
-  DuringSyncMethodAccessError,
   CurrencyConversionDataFindingError,
   SqlCorrectnessError,
   DbMigrationVerCorrectnessError,

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -25,24 +25,8 @@ module.exports = (
   handler,
   name,
   args,
-  done
+  cb
 ) => {
-  const cb = typeof name === 'function'
-    ? name
-    : args
-  const _done = typeof cb === 'function'
-    ? cb
-    : done
-
-  const _argsFromNameParam = name && typeof name === 'object'
-    ? name
-    : args
-  const _args = (
-    _argsFromNameParam &&
-    typeof _argsFromNameParam === 'object'
-  )
-    ? _argsFromNameParam
-    : {}
   const _name = typeof name === 'string'
     ? `${name} [PROTECTED]`
     : name
@@ -54,12 +38,13 @@ module.exports = (
   const _handler = _getHandler(
     authenticator,
     handler,
-    _args
+    args
   )
 
   return _responder(
     _handler,
     _name,
-    _done
+    args,
+    cb
   )
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -6,7 +6,7 @@ const {
 } = require('lodash')
 const {
   AuthError,
-  FindMethodError
+  BadRequestError
 } = require('bfx-report/workers/loc.api/errors')
 const {
   getTimezoneConf,
@@ -183,7 +183,7 @@ class FrameworkReportService extends ReportService {
         const _args = omit(args, ['pingMethod'])
 
         if (typeof this[pingMethod] !== 'function') {
-          throw new FindMethodError()
+          throw new BadRequestError()
         }
 
         await this[pingMethod](_args)

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -85,19 +85,19 @@ class FrameworkReportService extends ReportService {
   signUp (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.signUp(args)
-    }, 'signUp', cb)
+    }, 'signUp', args, cb)
   }
 
   signIn (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.signIn(args)
-    }, 'signIn', cb)
+    }, 'signIn', args, cb)
   }
 
   signOut (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.signOut(args)
-    }, 'signOut', cb)
+    }, 'signOut', args, cb)
   }
 
   recoverPassword (space, args, cb) {
@@ -110,7 +110,7 @@ class FrameworkReportService extends ReportService {
       }
 
       return this._authenticator.recoverPassword(args)
-    }, 'recoverPassword', cb)
+    }, 'recoverPassword', args, cb)
   }
 
   verifyUser (space, args, cb) {
@@ -130,7 +130,7 @@ class FrameworkReportService extends ReportService {
           ]
         }
       )
-    }, 'verifyUser', cb)
+    }, 'verifyUser', args, cb)
   }
 
   getUsers (space, args, cb) {
@@ -149,13 +149,13 @@ class FrameworkReportService extends ReportService {
           ]
         }
       )
-    }, 'getUsers', cb)
+    }, 'getUsers', args, cb)
   }
 
   removeUser (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.removeUser(args)
-    }, 'removeUser', cb)
+    }, 'removeUser', args, cb)
   }
 
   createSubAccount (space, args, cb) {
@@ -164,7 +164,7 @@ class FrameworkReportService extends ReportService {
 
       return this._subAccount
         .createSubAccount(args)
-    }, 'createSubAccount', cb)
+    }, 'createSubAccount', args, cb)
   }
 
   updateSubAccount (space, args, cb) {
@@ -173,7 +173,7 @@ class FrameworkReportService extends ReportService {
 
       return this._subAccount
         .updateSubAccount(args)
-    }, 'updateSubAccount', cb)
+    }, 'updateSubAccount', args, cb)
   }
 
   pingApi (space, args, cb) {
@@ -204,7 +204,7 @@ class FrameworkReportService extends ReportService {
 
         throw _err
       }
-    }, 'pingApi', cb)
+    }, 'pingApi', args, cb)
   }
 
   enableSyncMode (space, args, cb) {
@@ -228,7 +228,7 @@ class FrameworkReportService extends ReportService {
       await this._sync.start(true)
 
       return true
-    }, 'enableSyncMode', cb)
+    }, 'enableSyncMode', args, cb)
   }
 
   disableSyncMode (space, args, cb) {
@@ -243,7 +243,7 @@ class FrameworkReportService extends ReportService {
       )
 
       return true
-    }, 'disableSyncMode', cb)
+    }, 'disableSyncMode', args, cb)
   }
 
   isSyncModeWithDbData (space, args, cb) {
@@ -253,9 +253,6 @@ class FrameworkReportService extends ReportService {
     const responder = isRequiredUser
       ? this._privResponder
       : this._responder
-    const endingArgs = isRequiredUser
-      ? [args, cb]
-      : [cb]
 
     return responder(async () => {
       const { auth } = { ...args }
@@ -270,7 +267,7 @@ class FrameworkReportService extends ReportService {
         !!firstElem.isEnable &&
         isDataFromDb
       )
-    }, 'isSyncModeWithDbData', ...endingArgs)
+    }, 'isSyncModeWithDbData', args, cb)
   }
 
   enableScheduler (space, args, cb) {
@@ -313,7 +310,7 @@ class FrameworkReportService extends ReportService {
       } catch (err) {
         return false
       }
-    }, 'isSchedulerEnabled', cb)
+    }, 'isSchedulerEnabled', args, cb)
   }
 
   getSyncProgress (space, args, cb) {
@@ -560,7 +557,7 @@ class FrameworkReportService extends ReportService {
         inactiveCurrencies,
         inactiveSymbols
       }
-    }, 'getSymbols', cb)
+    }, 'getSymbols', args, cb)
   }
 
   /**
@@ -623,9 +620,6 @@ class FrameworkReportService extends ReportService {
     const responder = isRequiredUser
       ? this._privResponder
       : this._responder
-    const endingArgs = isRequiredUser
-      ? [args, cb]
-      : [cb]
 
     return responder(async () => {
       return this._positionsAudit
@@ -643,7 +637,7 @@ class FrameworkReportService extends ReportService {
             )
           }
         )
-    }, 'getPositionsAudit', ...endingArgs)
+    }, 'getPositionsAudit', args, cb)
   }
 
   /**
@@ -1246,7 +1240,7 @@ class FrameworkReportService extends ReportService {
         'getMultipleCsvJobData',
         args
       )
-    }, 'getMultipleCsv', cb)
+    }, 'getMultipleCsv', args, cb)
   }
 
   getBalanceHistoryCsv (space, args, cb) {
@@ -1255,7 +1249,7 @@ class FrameworkReportService extends ReportService {
         'getBalanceHistoryCsvJobData',
         args
       )
-    }, 'getBalanceHistoryCsv', cb)
+    }, 'getBalanceHistoryCsv', args, cb)
   }
 
   getWinLossCsv (space, args, cb) {
@@ -1264,7 +1258,7 @@ class FrameworkReportService extends ReportService {
         'getWinLossCsvJobData',
         args
       )
-    }, 'getWinLossCsv', cb)
+    }, 'getWinLossCsv', args, cb)
   }
 
   getPositionsSnapshotCsv (space, args, cb) {
@@ -1273,7 +1267,7 @@ class FrameworkReportService extends ReportService {
         'getPositionsSnapshotCsvJobData',
         args
       )
-    }, 'getPositionsSnapshotCsv', cb)
+    }, 'getPositionsSnapshotCsv', args, cb)
   }
 
   getFullSnapshotReportCsv (space, args, cb) {
@@ -1282,7 +1276,7 @@ class FrameworkReportService extends ReportService {
         'getFullSnapshotReportCsvJobData',
         args
       )
-    }, 'getFullSnapshotReportCsv', cb)
+    }, 'getFullSnapshotReportCsv', args, cb)
   }
 
   getFullTaxReportCsv (space, args, cb) {
@@ -1291,7 +1285,7 @@ class FrameworkReportService extends ReportService {
         'getFullTaxReportCsvJobData',
         args
       )
-    }, 'getFullTaxReportCsv', cb)
+    }, 'getFullTaxReportCsv', args, cb)
   }
 
   getTradedVolumeCsv (space, args, cb) {
@@ -1300,7 +1294,7 @@ class FrameworkReportService extends ReportService {
         'getTradedVolumeCsvJobData',
         args
       )
-    }, 'getTradedVolumeCsv', cb)
+    }, 'getTradedVolumeCsv', args, cb)
   }
 
   getFeesReportCsv (space, args, cb) {
@@ -1309,7 +1303,7 @@ class FrameworkReportService extends ReportService {
         'getFeesReportCsvJobData',
         args
       )
-    }, 'getFeesReportCsv', cb)
+    }, 'getFeesReportCsv', args, cb)
   }
 
   getPerformingLoanCsv (space, args, cb) {
@@ -1318,7 +1312,7 @@ class FrameworkReportService extends ReportService {
         'getPerformingLoanCsvJobData',
         args
       )
-    }, 'getPerformingLoanCsv', cb)
+    }, 'getPerformingLoanCsv', args, cb)
   }
 
   getCandlesCsv (space, args, cb) {
@@ -1330,7 +1324,7 @@ class FrameworkReportService extends ReportService {
       checkParams(args, 'paramsSchemaForCandlesCsv')
 
       return super.getCandlesCsv(space, args)
-    }, 'getCandlesCsv', cb)
+    }, 'getCandlesCsv', args, cb)
   }
 }
 

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -250,7 +250,7 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
-  async dropAllTables (opts) {
+  async dropAllTables (opts = {}) {
     const {
       exceptions = []
     } = opts

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -242,11 +242,24 @@ class WSTransport {
   }
 
   _sendToOne (socket, sid, action, err, result = null) {
-    const res = this.transport.format(
-      [sid, err ? err.message : null, { action, result }]
-    )
+    this.responder(
+      () => {
+        if (err) {
+          throw err
+        }
 
-    socket.send(res)
+        return result
+      },
+      action,
+      {},
+      (err, res) => {
+        const _res = this.transport.format(
+          [sid, err, { ...res, action }]
+        )
+
+        socket.send(_res)
+      }
+    )
   }
 
   async send (

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -5,7 +5,7 @@ const { omit } = require('lodash')
 const { PeerRPCServer } = require('grenache-nodejs-ws')
 
 const {
-  FindMethodError
+  BadRequestError
 } = require('bfx-report/workers/loc.api/errors')
 
 const { decorateInjectable } = require('../di/utils')
@@ -17,7 +17,8 @@ const depsTypes = (TYPES) => [
   TYPES.Link,
   TYPES.GRC_BFX_OPTS,
   TYPES.TABLES_NAMES,
-  TYPES.Authenticator
+  TYPES.Authenticator,
+  TYPES.Responder
 ]
 class WSTransport {
   constructor (
@@ -27,7 +28,8 @@ class WSTransport {
     link,
     grcBfxOpts,
     TABLES_NAMES,
-    authenticator
+    authenticator,
+    responder
   ) {
     this.wsPort = wsPort
     this.rService = rService
@@ -36,6 +38,7 @@ class WSTransport {
     this.opts = { ...grcBfxOpts }
     this.TABLES_NAMES = TABLES_NAMES
     this.authenticator = authenticator
+    this.responder = responder
 
     this._active = false
     this._sockets = new Map()
@@ -104,7 +107,12 @@ class WSTransport {
         typeof this.rService[method] !== 'function' ||
         /^_/.test(method)
       ) {
-        reply(new FindMethodError())
+        this.responder(
+          () => new BadRequestError(),
+          method,
+          args,
+          reply
+        )
 
         return
       }


### PR DESCRIPTION
This PR reworks `JSON-RPC` response to follow `JSON-RPC v2.0` specification
https://www.jsonrpc.org/specification
The idea is: send a status code and status message in the grenache service in JSON. And express would just proxy it. To have all logic in one place related to detecting and logging errors
Base changes:
  - Reworks `JSON-RPC` response
  - Reworks common error classes
  - Fixes corresponding test cases
  - Fixes dropping all tables for tests
  - Fixes sending response by the WebSockets

**Depends** on these PRs:
  - https://github.com/bitfinexcom/bfx-report-express/pull/16
  - https://github.com/bitfinexcom/bfx-report/pull/240