### PR TITLE
Fix csv loop handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "better-npm-run": "^0.1.1",
-    "better-sqlite3": "7.4.1",
+    "better-sqlite3": "7.4.3",
     "bfx-facs-db-better-sqlite": "git+https://github.com/bitfinexcom/bfx-facs-db-better-sqlite.git",
     "bfx-facs-scheduler": "git+https://github.com:bitfinexcom/bfx-facs-scheduler.git",
     "bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",


### PR DESCRIPTION
This PR fixes csv loop handling. Basic changes:
  - passes an error from csv stream to writable. Use safe `stream.pipeline()` instead of `pipe()` https://nodejs.org/docs/latest-v14.x/api/stream.html#stream_stream_pipeline_source_transforms_destination_callback The `stream.pipeline()` module method pipes between streams forwarding errors and properly cleaning up. The `pipeline` should be used instead of `pipe`, as `pipe` is unsafe
  - bumps `better-sqlite3` version up to `7.4.3` to have these:
      - https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.4.3
      - https://github.com/JoshuaWise/better-sqlite3/releases/tag/v7.4.2
      - https://www.sqlite.org/releaselog/3_36_0.html
  
  **Depends** on this PR:
    - https://github.com/bitfinexcom/bfx-report/pull/246