### PR TITLE
Fix account summary response for sub-account

### DIFF
--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -8,7 +8,8 @@ const {
   getDateString,
   isNotSyncRequired,
   sumObjectsNumbers,
-  sumAllObjectsNumbers
+  sumAllObjectsNumbers,
+  sumArrayVolumes
 } = require('./utils')
 const {
   isEnotfoundError,
@@ -33,5 +34,6 @@ module.exports = {
   getAuthFromSubAccountAuth,
   getSubAccountAuthFromAuth,
   sumObjectsNumbers,
-  sumAllObjectsNumbers
+  sumAllObjectsNumbers,
+  sumArrayVolumes
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -103,6 +103,61 @@ const sumAllObjectsNumbers = (propName, objects = []) => {
   }, {})
 }
 
+const sumArrayVolumes = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (!Array.isArray(curr?.[propName])) {
+      return accum
+    }
+
+    for (const obj of curr[propName]) {
+      if (typeof obj?.curr !== 'string') {
+        continue
+      }
+
+      const entries = Object.entries(obj)
+        .filter(([key]) => key !== 'curr')
+
+      if (entries.length === 0) {
+        continue
+      }
+
+      if (accum.length === 0) {
+        accum.push({ ...obj })
+
+        continue
+      }
+
+      const accumObjIndex = accum
+        .findIndex((item) => item?.curr === obj.curr)
+
+      if (accumObjIndex === -1) {
+        accum.push({ ...obj })
+
+        continue
+      }
+
+      const resObj = entries.reduce((accum, [key, vol]) => {
+        const accumVol = Number.isFinite(accum?.[key])
+          ? accum[key]
+          : 0
+        const currVol = Number.isFinite(vol)
+          ? vol
+          : 0
+
+        accum[key] = accumVol + currVol
+
+        return accum
+      }, accum[accumObjIndex])
+
+      // For right order in resulting array
+      accum.splice(accumObjIndex, 1)
+      accum.push(resObj)
+    }
+
+    return accum
+  }, [])
+}
+
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -110,5 +165,6 @@ module.exports = {
   getDateString,
   isNotSyncRequired,
   sumObjectsNumbers,
-  sumAllObjectsNumbers
+  sumAllObjectsNumbers,
+  sumArrayVolumes
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -26,7 +26,8 @@ const {
   collObjToArr,
   getAuthFromSubAccountAuth,
   sumObjectsNumbers,
-  sumAllObjectsNumbers
+  sumAllObjectsNumbers,
+  sumArrayVolumes
 } = require('./helpers')
 
 const INITIAL_PROGRESS = 'SYNCHRONIZATION_HAS_NOT_STARTED_YET'
@@ -1073,7 +1074,6 @@ class FrameworkReportService extends ReportService {
   }
 
   /**
-   * TODO:
    * @override
    */
   getAccountSummary (space, args, cb) {
@@ -1093,7 +1093,8 @@ class FrameworkReportService extends ReportService {
         )
 
       const objRes = {
-        trade_vol_30d: arrRes[0]?.trade_vol_30d ?? [], // TODO: not complete, it should be []
+        trade_vol_30d: sumArrayVolumes(
+          'trade_vol_30d', arrRes),
         fees_trading_30d: sumAllObjectsNumbers(
           'fees_trading_30d', arrRes),
         fees_trading_total_30d: sumObjectsNumbers(


### PR DESCRIPTION
This PR adds ability to sum of the `account summary` response of all sub-users for sub-account

One sub-user can have this `account summary` sample response:
```jsonc
"trade_vol_30d": [
  { "curr": "DOGE", vol: 123.321 },
  { "curr": "UST", vol: 9876.12345 },
  {
    "curr": "Total (USD)",
    "vol": 9876.54321,
    "vol_safe": 56.789,
    "vol_maker": 9876.54321,
    "vol_BFX": 9876.54321,
    "vol_BFX_safe": 56.789,
    "vol_BFX_maker": 9876.54321
  }
],
"fees_trading_30d": { "USD": 0.012345 },
"fees_trading_total_30d": 0.012345,
"fees_funding_30d": { "USD": 100.123 },
"fees_funding_total_30d": 100.123,
"makerFee": 0,
"derivMakerRebate": -0.000225,
"takerFeeToCrypto": 0.002,
"takerFeeToStable": 0.002,
"takerFeeToFiat": 0.002,
"derivTakerFee": 0.0007654321,
"leoLev": 0,
"leoAmountAvg": 0.004321
```

Need to sum those responses for all sub-users