### PR TITLE
Add DB backup

### DIFF
--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -176,7 +176,6 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
     this.scheduler_sync.add(name, () => sync.start(), rule)
     this.scheduler_sync.mem.get(name).rule = rule
 
-    processMessageManager.init()
     processMessageManager.sendState(
       processMessageManager.PROCESS_MESSAGES.READY_WORKER
     )

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -100,17 +100,19 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
   init () {
     super.init()
 
-    const dbPathAbsolute = path.isAbsolute(argv.dbFolder)
+    this.conf[this.group].dbPathAbsolute = path.isAbsolute(argv.dbFolder)
       ? argv.dbFolder
       : path.join(this.ctx.root, argv.dbFolder)
     const workerPathAbsolute = path.join(
       this.ctx.root,
       'workers/loc.api/sync/dao/sqlite-worker/index.js'
     )
+
     const {
       syncMode,
       dbDriver,
-      verboseSql
+      verboseSql,
+      dbPathAbsolute
     } = this.conf[this.group]
     const facs = []
 

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -181,7 +181,9 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
     this.scheduler_sync.mem.get(name).rule = rule
 
     processMessageManager.init()
-    processMessageManager.sendState('ready:worker')
+    processMessageManager.sendState(
+      processMessageManager.PROCESS_MESSAGES.READY_WORKER
+    )
   }
 
   async stopService () {

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -1,9 +1,5 @@
 'use strict'
 
-if (typeof process.send !== 'function') {
-  process.send = () => {}
-}
-
 const WrkReportServiceApi = require(
   'bfx-report/workers/api.service.report.wrk'
 )

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -97,6 +97,7 @@ const {
 const Crypto = require('../sync/crypto')
 const Authenticator = require('../sync/authenticator')
 const privResponder = require('../responder')
+const ProcessMessageManager = require('../process.message.manager')
 
 decorate(injectable(), EventEmitter)
 
@@ -162,6 +163,9 @@ module.exports = ({
     bind(TYPES.CHECKER_NAMES).toConstantValue(CHECKER_NAMES)
     bind(TYPES.GRC_BFX_OPTS).toConstantValue(grcBfxOpts)
     bind(TYPES.FOREX_SYMBS).toConstantValue(FOREX_SYMBS)
+    bind(TYPES.ProcessMessageManager)
+      .to(ProcessMessageManager)
+      .inSingletonScope()
     bind(TYPES.WSTransport)
       .to(WSTransport)
       .inSingletonScope()

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -85,6 +85,9 @@ const FullTaxReport = require('../sync/full.tax.report')
 const SqliteDbMigrator = require(
   '../sync/dao/db-migrations/sqlite.db.migrator'
 )
+const DBBackupManager = require(
+  '../sync/dao/db.backup.manager'
+)
 const {
   migrationsFactory,
   dbMigratorFactory,
@@ -188,6 +191,9 @@ module.exports = ({
       .toFactory(migrationsFactory)
     bind(TYPES.SqliteDbMigrator)
       .to(SqliteDbMigrator)
+      .inSingletonScope()
+    bind(TYPES.DBBackupManager)
+      .to(DBBackupManager)
       .inSingletonScope()
     bind(TYPES.DbMigratorFactory)
       .toFactory(dbMigratorFactory)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -92,7 +92,8 @@ const {
   migrationsFactory,
   dbMigratorFactory,
   dataInserterFactory,
-  syncFactory
+  syncFactory,
+  processMessageManagerFactory
 } = require('./factories')
 const Crypto = require('../sync/crypto')
 const Authenticator = require('../sync/authenticator')
@@ -185,6 +186,8 @@ module.exports = ({
       .inSingletonScope()
     bind(TYPES.SyncFactory)
       .toFactory(syncFactory)
+    bind(TYPES.ProcessMessageManagerFactory)
+      .toFactory(processMessageManagerFactory)
     bind(TYPES.Authenticator)
       .to(Authenticator)
       .inSingletonScope()

--- a/workers/loc.api/di/factories/index.js
+++ b/workers/loc.api/di/factories/index.js
@@ -4,10 +4,12 @@ const migrationsFactory = require('./migrations-factory')
 const dbMigratorFactory = require('./db-migrator-factory')
 const dataInserterFactory = require('./data-inserter-factory')
 const syncFactory = require('./sync-factory')
+const processMessageManagerFactory = require('./process-message-manager-factory')
 
 module.exports = {
   migrationsFactory,
   dbMigratorFactory,
   dataInserterFactory,
-  syncFactory
+  syncFactory,
+  processMessageManagerFactory
 }

--- a/workers/loc.api/di/factories/migrations-factory.js
+++ b/workers/loc.api/di/factories/migrations-factory.js
@@ -11,12 +11,16 @@ module.exports = (ctx) => {
   const { dbDriver } = ctx.container.get(
     TYPES.CONF
   )
-  const migrationsType = dbDriver === 'better-sqlite'
-    ? 'sqlite'
-    : dbDriver
   const logger = ctx.container.get(
     TYPES.Logger
   )
+  const processMessageManager = ctx.container.get(
+    TYPES.ProcessMessageManager
+  )
+
+  const migrationsType = dbDriver === 'better-sqlite'
+    ? 'sqlite'
+    : dbDriver
 
   return (migrationsVer = []) => {
     const versions = Array.isArray(migrationsVer)
@@ -45,7 +49,9 @@ module.exports = (ctx) => {
         return new Migration(ver, ...deps)
       } catch (err) {
         logger.debug(err)
-        process.send({ state: 'error:migrations' })
+        processMessageManager.sendState(
+          processMessageManager.PROCESS_MESSAGES.ERROR_MIGRATIONS
+        )
 
         throw new MigrationLaunchingError()
       }

--- a/workers/loc.api/di/factories/process-message-manager-factory.js
+++ b/workers/loc.api/di/factories/process-message-manager-factory.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const TYPES = require('../types')
+
+module.exports = (ctx) => {
+  const { dbDriver } = ctx.container.get(
+    TYPES.CONF
+  )
+
+  return () => {
+    const dao = ctx.container.get(
+      TYPES.DAO
+    )
+
+    if (dbDriver === 'better-sqlite') {
+      const processMessageManager = ctx.container.get(
+        TYPES.ProcessMessageManager
+      )
+      processMessageManager.setDao(dao)
+
+      return processMessageManager
+    }
+  }
+}

--- a/workers/loc.api/di/factories/process-message-manager-factory.js
+++ b/workers/loc.api/di/factories/process-message-manager-factory.js
@@ -11,12 +11,18 @@ module.exports = (ctx) => {
     const dao = ctx.container.get(
       TYPES.DAO
     )
+    const dbBackupManager = ctx.container.get(
+      TYPES.DBBackupManager
+    )
 
     if (dbDriver === 'better-sqlite') {
       const processMessageManager = ctx.container.get(
         TYPES.ProcessMessageManager
       )
-      processMessageManager.setDao(dao)
+      processMessageManager.setDeps({
+        dao,
+        dbBackupManager
+      })
 
       return processMessageManager
     }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -61,5 +61,6 @@ module.exports = {
   DataConsistencyChecker: Symbol.for('DataConsistencyChecker'),
   Movements: Symbol.for('Movements'),
   WinLossVSAccountBalance: Symbol.for('WinLossVSAccountBalance'),
-  DBBackupManager: Symbol.for('DBBackupManager')
+  DBBackupManager: Symbol.for('DBBackupManager'),
+  ProcessMessageManager: Symbol.for('ProcessMessageManager')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -60,5 +60,6 @@ module.exports = {
   Checkers: Symbol.for('Checkers'),
   DataConsistencyChecker: Symbol.for('DataConsistencyChecker'),
   Movements: Symbol.for('Movements'),
-  WinLossVSAccountBalance: Symbol.for('WinLossVSAccountBalance')
+  WinLossVSAccountBalance: Symbol.for('WinLossVSAccountBalance'),
+  DBBackupManager: Symbol.for('DBBackupManager')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -62,5 +62,6 @@ module.exports = {
   Movements: Symbol.for('Movements'),
   WinLossVSAccountBalance: Symbol.for('WinLossVSAccountBalance'),
   DBBackupManager: Symbol.for('DBBackupManager'),
-  ProcessMessageManager: Symbol.for('ProcessMessageManager')
+  ProcessMessageManager: Symbol.for('ProcessMessageManager'),
+  ProcessMessageManagerFactory: Symbol.for('ProcessMessageManagerFactory')
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -166,6 +166,12 @@ class DataConsistencyError extends ConflictError {
   }
 }
 
+class ProcessStateSendingError extends BaseError {
+  constructor (message = 'ERR_PROCESS_STATE_SENDING_IS_NOT_CORRECT') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -191,5 +197,6 @@ module.exports = {
   DatePropNameError,
   GetPublicDataError,
   DataConsistencyCheckerFindingError,
-  DataConsistencyError
+  DataConsistencyError,
+  ProcessStateSendingError
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -172,6 +172,12 @@ class ProcessStateSendingError extends BaseError {
   }
 }
 
+class DbRestoringError extends BaseError {
+  constructor (message = 'ERR_DB_HAS_NOT_BEEN_RESTORED') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -198,5 +204,6 @@ module.exports = {
   GetPublicDataError,
   DataConsistencyCheckerFindingError,
   DataConsistencyError,
-  ProcessStateSendingError
+  ProcessStateSendingError,
+  DbRestoringError
 }

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -193,6 +193,28 @@ class ProcessMessageManager {
 
     throw new DbRestoringError()
   }
+
+  async [PROCESS_STATES.RESPONSE_GET_BACKUP_FILES_METADATA] (err, state, data) {
+    if (err) {
+      this.logger.debug('[Backup files metadata have not been got]')
+      this.logger.error(err)
+
+      this.sendState(
+        PROCESS_MESSAGES.REQUEST_GET_BACKUP_FILES_METADATA,
+        { error: err }
+      )
+
+      return
+    }
+
+    const backupFilesMetadata = await this.dbBackupManager
+      .getBackupFilesMetadata()
+
+    this.sendState(
+      PROCESS_MESSAGES.REQUEST_GET_BACKUP_FILES_METADATA,
+      { backupFilesMetadata }
+    )
+  }
 }
 
 decorateInjectable(ProcessMessageManager, depsTypes)

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF,
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.Logger,
+  TYPES.Sync,
+  TYPES.TABLES_NAMES
+]
+class ProcessMessageManager {
+  constructor (
+    conf,
+    dao,
+    syncSchema,
+    logger,
+    sync,
+    TABLES_NAMES
+  ) {
+    this.conf = conf
+    this.dao = dao
+    this.syncSchema = syncSchema
+    this.logger = logger
+    this.sync = sync
+    this.TABLES_NAMES = TABLES_NAMES
+  }
+}
+
+decorateInjectable(ProcessMessageManager, depsTypes)
+
+module.exports = ProcessMessageManager

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -4,6 +4,7 @@ const {
   onMessage,
   sendState
 } = require('./utils')
+const PROCESS_STATES = require('./process.states')
 
 const { decorateInjectable } = require('../di/utils')
 
@@ -30,6 +31,22 @@ class ProcessMessageManager {
     this.logger = logger
     this.sync = sync
     this.TABLES_NAMES = TABLES_NAMES
+
+    this.PROCESS_STATES = PROCESS_STATES
+    this.PROCESS_STATES_VALUES = Object.values(PROCESS_STATES)
+  }
+
+  init () {
+    onMessage((err, state, data) => {
+      if (
+        !this.PROCESS_STATES_VALUES[state] ||
+        typeof this[state] !== 'function'
+      ) {
+        return
+      }
+
+      this[state](err, state, data)
+    }, this.logger)
   }
 
   sendState (...args) {
@@ -37,7 +54,22 @@ class ProcessMessageManager {
   }
 
   onMessage (...args) {
-    return onMessage(...args)
+    return onMessage(...args, this.logger)
+  }
+
+  async [PROCESS_STATES.CLEAR_ALL_TABLES] (err, state, data) {
+    if (err) {
+      sendState('all-tables-have-not-been-cleared')
+
+      return
+    }
+
+    await this.dao.dropAllTables({
+      exceptions: [
+        this.TABLES_NAMES.USERS,
+        this.TABLES_NAMES.SUB_ACCOUNTS
+      ]
+    })
   }
 }
 

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -14,27 +14,15 @@ const PROCESS_MESSAGES = require('./process.messages')
 const { decorateInjectable } = require('../di/utils')
 
 const depsTypes = (TYPES) => [
-  TYPES.CONF,
-  TYPES.DAO,
-  TYPES.SyncSchema,
   TYPES.Logger,
-  TYPES.Sync,
   TYPES.TABLES_NAMES
 ]
 class ProcessMessageManager {
   constructor (
-    conf,
-    dao,
-    syncSchema,
     logger,
-    sync,
     TABLES_NAMES
   ) {
-    this.conf = conf
-    this.dao = dao
-    this.syncSchema = syncSchema
     this.logger = logger
-    this.sync = sync
     this.TABLES_NAMES = TABLES_NAMES
 
     this.PROCESS_STATES = PROCESS_STATES
@@ -47,6 +35,10 @@ class ProcessMessageManager {
     )
 
     this._mainHandler = null
+  }
+
+  setDao (dao) {
+    this.dao = dao
   }
 
   init () {
@@ -81,15 +73,21 @@ class ProcessMessageManager {
       throw new ProcessStateSendingError()
     }
 
+    const job = {
+      promise: null,
+      resolve: () => {},
+      reject: () => {}
+    }
+
     const promise = new Promise((resolve, reject) => {
       const queue = this._promisesToWait.get(state)
+      job.resolve = resolve
+      job.reject = reject
 
-      queue.push({
-        promise,
-        resolve,
-        reject
-      })
+      queue.push(job)
     })
+
+    job.promise = promise
 
     return promise
   }

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const {
-  ProcessStateSendingError
-} = require('../errors')
+  onMessage,
+  sendState
+} = require('./utils')
 
 const { decorateInjectable } = require('../di/utils')
 
@@ -31,22 +32,12 @@ class ProcessMessageManager {
     this.TABLES_NAMES = TABLES_NAMES
   }
 
-  sendState (state, data) {
-    if (
-      !state ||
-      typeof state !== 'string'
-    ) {
-      throw new ProcessStateSendingError()
-    }
+  sendState (...args) {
+    return sendState(...args)
+  }
 
-    const payload = (
-      data &&
-      typeof data === 'object'
-    )
-      ? { state, data }
-      : { state }
-
-    process.send(payload)
+  onMessage (...args) {
+    return onMessage(...args)
   }
 }
 

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -194,14 +194,14 @@ class ProcessMessageManager {
     throw new DbRestoringError()
   }
 
-  async [PROCESS_STATES.RESPONSE_GET_BACKUP_FILES_METADATA] (err, state, data) {
+  async [PROCESS_STATES.REQUEST_GET_BACKUP_FILES_METADATA] (err, state, data) {
     if (err) {
       this.logger.debug('[Backup files metadata have not been got]')
       this.logger.error(err)
 
       this.sendState(
-        PROCESS_MESSAGES.REQUEST_GET_BACKUP_FILES_METADATA,
-        { error: err }
+        PROCESS_MESSAGES.RESPONSE_GET_BACKUP_FILES_METADATA,
+        { err }
       )
 
       return
@@ -211,7 +211,7 @@ class ProcessMessageManager {
       .getBackupFilesMetadata()
 
     this.sendState(
-      PROCESS_MESSAGES.REQUEST_GET_BACKUP_FILES_METADATA,
+      PROCESS_MESSAGES.RESPONSE_GET_BACKUP_FILES_METADATA,
       { backupFilesMetadata }
     )
   }

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -25,6 +25,9 @@ class ProcessMessageManager {
     this.logger = logger
     this.TABLES_NAMES = TABLES_NAMES
 
+    this.dao = null
+    this.dbBackupManager = null
+
     this.PROCESS_STATES = PROCESS_STATES
     this.PROCESS_MESSAGES = PROCESS_MESSAGES
     this.SET_PROCESS_STATES = new Set(Object.values(PROCESS_STATES))
@@ -37,8 +40,14 @@ class ProcessMessageManager {
     this._mainHandler = null
   }
 
-  setDao (dao) {
+  setDeps (deps = {}) {
+    const {
+      dao,
+      dbBackupManager
+    } = deps
+
     this.dao = dao
+    this.dbBackupManager = dbBackupManager
   }
 
   init () {

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const {
+  ProcessStateSendingError
+} = require('../errors')
+
 const { decorateInjectable } = require('../di/utils')
 
 const depsTypes = (TYPES) => [
@@ -25,6 +29,24 @@ class ProcessMessageManager {
     this.logger = logger
     this.sync = sync
     this.TABLES_NAMES = TABLES_NAMES
+  }
+
+  sendState (state, data) {
+    if (
+      !state ||
+      typeof state !== 'string'
+    ) {
+      throw new ProcessStateSendingError()
+    }
+
+    const payload = (
+      data &&
+      typeof data === 'object'
+    )
+      ? { state, data }
+      : { state }
+
+    process.send(payload)
   }
 }
 

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -175,6 +175,19 @@ class ProcessMessageManager {
     this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_BEEN_REMOVED)
   }
 
+  async [PROCESS_STATES.BACKUP_DB] (err, state, data) {
+    if (err) {
+      this.logger.debug('[DB has not been backuped]:', data)
+      this.logger.error(err)
+
+      this.sendState(PROCESS_MESSAGES.ERROR_BACKUP)
+
+      return
+    }
+
+    await this.dbBackupManager.backupDb()
+  }
+
   async [PROCESS_STATES.RESTORE_DB] (err, state, data) {
     if (err) {
       this.logger.debug('[DB has not been restored]:', data)

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const {
-  ProcessStateSendingError
+  ProcessStateSendingError,
+  DbRestoringError
 } = require('../errors')
 
 const {
@@ -172,6 +173,25 @@ class ProcessMessageManager {
 
     this.logger.debug('[All tables have been removed]')
     this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_BEEN_REMOVED)
+  }
+
+  async [PROCESS_STATES.RESTORE_DB] (err, state, data) {
+    if (err) {
+      this.logger.debug('[DB has not been restored]:', data)
+      this.logger.error(err)
+
+      this.sendState(PROCESS_MESSAGES.DB_HAS_NOT_BEEN_RESTORED)
+
+      return
+    }
+
+    const isDbRestored = await this.dbBackupManager.restoreDb(data)
+
+    if (isDbRestored) {
+      return
+    }
+
+    throw new DbRestoringError()
   }
 }
 

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -44,7 +44,7 @@ class ProcessMessageManager {
   }
 
   init () {
-    onMessage((err, state, data) => {
+    onMessage(async (err, state, data) => {
       if (
         !this.SET_PROCESS_STATES.has(state) ||
         typeof this[state] !== 'function'
@@ -52,7 +52,7 @@ class ProcessMessageManager {
         return
       }
 
-      this[state](err, state, data)
+      await this[state](err, state, data)
     }, this.logger)
   }
 
@@ -60,7 +60,7 @@ class ProcessMessageManager {
     if (!this.SET_PROCESS_MESSAGES.has(state)) {
       this.logger.error(new ProcessStateSendingError())
 
-      return
+      return false
     }
 
     return sendState(state, data)
@@ -72,7 +72,7 @@ class ProcessMessageManager {
 
   async [PROCESS_STATES.CLEAR_ALL_TABLES] (err, state, data) {
     if (err) {
-      sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_NOT_BEEN_CLEARED)
+      this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_NOT_BEEN_CLEARED)
 
       return
     }
@@ -83,6 +83,8 @@ class ProcessMessageManager {
         this.TABLES_NAMES.SUB_ACCOUNTS
       ]
     })
+
+    this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_BEEN_CLEARED)
   }
 }
 

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -41,18 +41,24 @@ class ProcessMessageManager {
     this.PROCESS_MESSAGES = PROCESS_MESSAGES
     this.SET_PROCESS_STATES = new Set(Object.values(PROCESS_STATES))
     this.SET_PROCESS_MESSAGES = new Set(Object.values(PROCESS_MESSAGES))
+
+    this._promisesToWait = new Map(
+      [...this.SET_PROCESS_STATES].map((state) => ([state, []]))
+    )
+
+    this._mainHandler = null
   }
 
   init () {
-    onMessage(async (err, state, data) => {
-      if (
-        !this.SET_PROCESS_STATES.has(state) ||
-        typeof this[state] !== 'function'
-      ) {
+    this._mainHandler = onMessage(async (err, state, data) => {
+      if (!this.SET_PROCESS_STATES.has(state)) {
         return
       }
+      if (typeof this[state] === 'function') {
+        await this[state](err, state, data)
+      }
 
-      await this[state](err, state, data)
+      this._processPromise(err, state, data)
     }, this.logger)
   }
 
@@ -70,6 +76,56 @@ class ProcessMessageManager {
     return onMessage(...args, this.logger)
   }
 
+  addStateToWait (state) {
+    if (!this.SET_PROCESS_STATES.has(state)) {
+      throw new ProcessStateSendingError()
+    }
+
+    const promise = new Promise((resolve, reject) => {
+      const queue = this._promisesToWait.get(state)
+
+      queue.push({
+        promise,
+        resolve,
+        reject
+      })
+    })
+
+    return promise
+  }
+
+  async processState (state, data) {
+    await this._mainHandler({ state, data })
+  }
+
+  _processPromise (err, state, data) {
+    const queue = this._promisesToWait.get(state)
+
+    if (
+      !Array.isArray(queue) ||
+      queue.length === 0
+    ) {
+      return
+    }
+
+    for (const [i, task] of queue.entries()) {
+      const {
+        resolve,
+        reject
+      } = task
+
+      queue.splice(i, 1)
+
+      if (err) {
+        reject(err)
+
+        continue
+      }
+
+      resolve(data)
+    }
+  }
+
   async [PROCESS_STATES.CLEAR_ALL_TABLES] (err, state, data) {
     if (err) {
       this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_NOT_BEEN_CLEARED)
@@ -85,6 +141,30 @@ class ProcessMessageManager {
     })
 
     this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_BEEN_CLEARED)
+  }
+
+  async [PROCESS_STATES.REMOVE_ALL_TABLES] (err, state, data) {
+    if (err) {
+      this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_NOT_BEEN_REMOVED)
+
+      return
+    }
+
+    await this.dao.disableForeignKeys()
+
+    try {
+      await this.dao.dropAllTables()
+      await this.dao.setCurrDbVer(0)
+    } catch (err) {
+      await this.dao.enableForeignKeys()
+
+      throw err
+    }
+
+    await this.dao.enableForeignKeys()
+
+    this.logger.debug('[All tables have been removed]')
+    this.sendState(PROCESS_MESSAGES.ALL_TABLE_HAVE_BEEN_REMOVED)
   }
 }
 

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -20,5 +20,6 @@ module.exports = {
   DB_HAS_NOT_BEEN_RESTORED: 'db-has-not-been-restored',
 
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
-  REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed'
+  REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed',
+  REQUEST_GET_BACKUP_FILES_METADATA: 'request:get-backup-files-metadata'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   READY_WORKER: 'ready:worker',
+  ERROR_WORKER: 'error:worker', // Uses in bfx-report
 
   READY_MIGRATIONS: 'ready:migrations',
   ERROR_MIGRATIONS: 'error:migrations',

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   READY_WORKER: 'ready:worker',
-  ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared'
+  ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
+  ERROR_MIGRATIONS: 'error:migrations'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -4,5 +4,7 @@ module.exports = {
   READY_WORKER: 'ready:worker',
   READY_MIGRATIONS: 'ready:migrations',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
-  ERROR_MIGRATIONS: 'error:migrations'
+  ERROR_MIGRATIONS: 'error:migrations',
+  ERROR_BACKUP: 'error:backup',
+  BACKUP_PROGRESS: 'backup:progress'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -11,7 +11,9 @@ module.exports = {
   ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',
   ALL_TABLE_HAVE_NOT_BEEN_REMOVED: 'all-tables-have-not-been-removed',
 
+  BACKUP_STARTED: 'backup:started',
   BACKUP_PROGRESS: 'backup:progress',
+  BACKUP_FINISHED: 'backup:finished',
   ERROR_BACKUP: 'error:backup',
 
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = {
+  READY_WORKER: 'ready:worker',
+  ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared'
+}

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -3,6 +3,7 @@
 module.exports = {
   READY_WORKER: 'ready:worker',
   READY_MIGRATIONS: 'ready:migrations',
+  ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
   ERROR_MIGRATIONS: 'error:migrations',
   ERROR_BACKUP: 'error:backup',

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   READY_WORKER: 'ready:worker',
+  READY_MIGRATIONS: 'ready:migrations',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
   ERROR_MIGRATIONS: 'error:migrations'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -2,14 +2,18 @@
 
 module.exports = {
   READY_WORKER: 'ready:worker',
+
   READY_MIGRATIONS: 'ready:migrations',
-  ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
-  ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',
-  ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
-  ALL_TABLE_HAVE_NOT_BEEN_REMOVED: 'all-tables-have-not-been-removed',
   ERROR_MIGRATIONS: 'error:migrations',
-  ERROR_BACKUP: 'error:backup',
+
+  ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
+  ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
+  ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',
+  ALL_TABLE_HAVE_NOT_BEEN_REMOVED: 'all-tables-have-not-been-removed',
+
   BACKUP_PROGRESS: 'backup:progress',
+  ERROR_BACKUP: 'error:backup',
+
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
   REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -21,5 +21,6 @@ module.exports = {
 
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
   REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed',
-  REQUEST_GET_BACKUP_FILES_METADATA: 'request:get-backup-files-metadata'
+
+  RESPONSE_GET_BACKUP_FILES_METADATA: 'response:get-backup-files-metadata'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -4,8 +4,12 @@ module.exports = {
   READY_WORKER: 'ready:worker',
   READY_MIGRATIONS: 'ready:migrations',
   ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
+  ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
+  ALL_TABLE_HAVE_NOT_BEEN_REMOVED: 'all-tables-have-not-been-removed',
   ERROR_MIGRATIONS: 'error:migrations',
   ERROR_BACKUP: 'error:backup',
-  BACKUP_PROGRESS: 'backup:progress'
+  BACKUP_PROGRESS: 'backup:progress',
+  REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
+  REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed'
 }

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -16,6 +16,9 @@ module.exports = {
   BACKUP_FINISHED: 'backup:finished',
   ERROR_BACKUP: 'error:backup',
 
+  DB_HAS_BEEN_RESTORED: 'db-has-been-restored',
+  DB_HAS_NOT_BEEN_RESTORED: 'db-has-not-been-restored',
+
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
   REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed'
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  CLEAR_ALL_TABLES: 'clear-all-tables'
+}

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -1,5 +1,8 @@
 'use strict'
 
 module.exports = {
-  CLEAR_ALL_TABLES: 'clear-all-tables'
+  CLEAR_ALL_TABLES: 'clear-all-tables',
+  REMOVE_ALL_TABLES: 'remove-all-tables',
+  RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done'
+
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -4,6 +4,8 @@ module.exports = {
   CLEAR_ALL_TABLES: 'clear-all-tables',
   REMOVE_ALL_TABLES: 'remove-all-tables',
   RESTORE_DB: 'restore-db',
+
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done',
-  RESPONSE_GET_BACKUP_FILES_METADATA: 'response:get-backup-files-metadata'
+
+  REQUEST_GET_BACKUP_FILES_METADATA: 'request:get-backup-files-metadata'
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -4,6 +4,7 @@ module.exports = {
   CLEAR_ALL_TABLES: 'clear-all-tables',
   REMOVE_ALL_TABLES: 'remove-all-tables',
   RESTORE_DB: 'restore-db',
+  BACKUP_DB: 'backup-db',
 
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done',
 

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -4,5 +4,6 @@ module.exports = {
   CLEAR_ALL_TABLES: 'clear-all-tables',
   REMOVE_ALL_TABLES: 'remove-all-tables',
   RESTORE_DB: 'restore-db',
-  RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done'
+  RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done',
+  RESPONSE_GET_BACKUP_FILES_METADATA: 'response:get-backup-files-metadata'
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -3,5 +3,6 @@
 module.exports = {
   CLEAR_ALL_TABLES: 'clear-all-tables',
   REMOVE_ALL_TABLES: 'remove-all-tables',
+  RESTORE_DB: 'restore-db',
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done'
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -4,5 +4,4 @@ module.exports = {
   CLEAR_ALL_TABLES: 'clear-all-tables',
   REMOVE_ALL_TABLES: 'remove-all-tables',
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done'
-
 }

--- a/workers/loc.api/process.message.manager/utils.js
+++ b/workers/loc.api/process.message.manager/utils.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const {
+  ProcessStateSendingError
+} = require('../errors')
+
+const onMessage = (params) => {
+  const {
+    messageHandler,
+    errorHandler
+  } = params ?? {}
+
+  const handler = async (mess) => {
+    try {
+      const {
+        state,
+        data
+      } = mess ?? {}
+
+      if (
+        !state ||
+        typeof state !== 'string'
+      ) {
+        return
+      }
+
+      await messageHandler(state, data)
+    } catch (err) {
+      this.logger.error(err)
+
+      errorHandler(err)
+    }
+  }
+
+  process.on('message', handler)
+
+  return handler
+}
+
+const sendState = (state, data) => {
+  if (
+    !state ||
+    typeof state !== 'string'
+  ) {
+    throw new ProcessStateSendingError()
+  }
+
+  const payload = (
+    data &&
+    typeof data === 'object'
+  )
+    ? { state, data }
+    : { state }
+
+  process.send(payload)
+}
+
+module.exports = {
+  onMessage,
+  sendState
+}

--- a/workers/loc.api/process.message.manager/utils.js
+++ b/workers/loc.api/process.message.manager/utils.js
@@ -1,5 +1,9 @@
 'use strict'
 
+if (typeof process.send !== 'function') {
+  process.send = () => {}
+}
+
 const {
   ProcessStateSendingError
 } = require('../errors')

--- a/workers/loc.api/process.message.manager/utils.js
+++ b/workers/loc.api/process.message.manager/utils.js
@@ -1,9 +1,5 @@
 'use strict'
 
-if (typeof process.send !== 'function') {
-  process.send = () => {}
-}
-
 const {
   ProcessStateSendingError
 } = require('../errors')
@@ -29,7 +25,7 @@ const onMessage = (messageHandler, logger) => {
         logger.error(err)
       }
 
-      messageHandler(err, state, data)
+      await messageHandler(err, state, data)
     }
   }
 
@@ -45,6 +41,9 @@ const sendState = (state, data) => {
   ) {
     throw new ProcessStateSendingError()
   }
+  if (typeof process.send !== 'function') {
+    return false
+  }
 
   const payload = (
     data &&
@@ -54,6 +53,8 @@ const sendState = (state, data) => {
     : { state }
 
   process.send(payload)
+
+  return true
 }
 
 module.exports = {

--- a/workers/loc.api/process.message.manager/utils.js
+++ b/workers/loc.api/process.message.manager/utils.js
@@ -4,31 +4,28 @@ const {
   ProcessStateSendingError
 } = require('../errors')
 
-const onMessage = (params) => {
-  const {
-    messageHandler,
-    errorHandler
-  } = params ?? {}
-
+const onMessage = (messageHandler, logger) => {
   const handler = async (mess) => {
-    try {
-      const {
-        state,
-        data
-      } = mess ?? {}
+    const {
+      state,
+      data
+    } = mess ?? {}
 
-      if (
-        !state ||
-        typeof state !== 'string'
-      ) {
-        return
+    if (
+      !state ||
+      typeof state !== 'string'
+    ) {
+      return
+    }
+
+    try {
+      await messageHandler(null, state, data)
+    } catch (err) {
+      if (logger) {
+        logger.error(err)
       }
 
-      await messageHandler(state, data)
-    } catch (err) {
-      this.logger.error(err)
-
-      errorHandler(err)
+      messageHandler(err, state, data)
     }
   }
 

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -64,7 +64,8 @@ const depsTypes = (TYPES) => [
   TYPES.DB,
   TYPES.TABLES_NAMES,
   TYPES.SyncSchema,
-  TYPES.DbMigratorFactory
+  TYPES.DbMigratorFactory,
+  TYPES.ProcessMessageManagerFactory
 ]
 class BetterSqliteDAO extends DAO {
   constructor (...args) {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -341,6 +341,32 @@ class BetterSqliteDAO extends DAO {
   /**
    * @override
    */
+  backupDb (params = {}) {
+    const {
+      filePath = `backup-${new Date().toISOString()}.db`,
+      progressFn,
+      isPaused = false
+    } = params ?? {}
+    return this.db.backup(filePath, {
+      progress ({ totalPages: t, remainingPages: r }) {
+        if (typeof progressFn === 'function') {
+          const progress = Math.round((t - r) / t * 100)
+
+          progressFn(progress)
+        }
+
+        /*
+         * If return 0 backup will be paused
+         * https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md#backupdestination-options---promise
+         */
+        return isPaused ? 0 : 100
+      }
+    })
+  }
+
+  /**
+   * @override
+   */
   async executeQueriesInTrans (
     sql,
     opts = {}

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -12,12 +12,14 @@ class DAO {
     db,
     TABLES_NAMES,
     syncSchema,
-    dbMigratorFactory
+    dbMigratorFactory,
+    processMessageManagerFactory
   ) {
     this.db = db
     this.TABLES_NAMES = TABLES_NAMES
     this.syncSchema = syncSchema
     this.dbMigratorFactory = dbMigratorFactory
+    this.processMessageManagerFactory = processMessageManagerFactory
   }
 
   _getModelsMap (params) {
@@ -47,6 +49,7 @@ class DAO {
     }
 
     await this.beforeMigrationHook()
+    this.processMessageManagerFactory().init()
 
     const dbMigrator = this.dbMigratorFactory()
     await dbMigrator.migrateFromCurrToSupportedVer()

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -70,6 +70,11 @@ class DAO {
   /**
    * @abstract
    */
+  async backupDb () { throw new ImplementationError() }
+
+  /**
+   * @abstract
+   */
   async executeQueriesInTrans () { throw new ImplementationError() }
 
   /**

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -16,13 +16,15 @@ class DbMigrator {
     TABLES_NAMES,
     syncSchema,
     logger,
-    dbBackupManager
+    dbBackupManager,
+    processMessageManager
   ) {
     this.migrationsFactory = migrationsFactory
     this.TABLES_NAMES = TABLES_NAMES
     this.syncSchema = syncSchema
     this.logger = logger
     this.dbBackupManager = dbBackupManager
+    this.processMessageManager = processMessageManager
   }
 
   setDao (dao) {
@@ -91,7 +93,9 @@ class DbMigrator {
         this.logger.debug(`[ERR_DB_MIGRATION_V${ver}_HAS_FAILED]`)
         this.logger.error(err)
 
-        process.send({ state: 'error:migrations' })
+        this.processMessageManager.sendState(
+          this.processMessageManager.PROCESS_MESSAGES.ERROR_MIGRATIONS
+        )
 
         throw new MigrationLaunchingError()
       }

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -102,7 +102,9 @@ class DbMigrator {
     }
 
     this.logger.debug('[Migrations completed successfully]')
-    process.send({ state: 'ready:migrations' })
+    this.processMessageManager.sendState(
+      this.processMessageManager.PROCESS_MESSAGES.READY_MIGRATIONS
+    )
   }
 
   /**

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -15,12 +15,14 @@ class DbMigrator {
     migrationsFactory,
     TABLES_NAMES,
     syncSchema,
-    logger
+    logger,
+    dbBackupManager
   ) {
     this.migrationsFactory = migrationsFactory
     this.TABLES_NAMES = TABLES_NAMES
     this.syncSchema = syncSchema
     this.logger = logger
+    this.dbBackupManager = dbBackupManager
   }
 
   setDao (dao) {
@@ -125,6 +127,7 @@ class DbMigrator {
     const isDown = currVer > supportedVer
     const versions = this.range(currVer, supportedVer)
 
+    await this.dbBackupManager.backupDb({ currVer, supportedVer })
     await this.migrate(versions, isDown)
   }
 }

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -11,7 +11,8 @@ const depsTypes = (TYPES) => [
   TYPES.MigrationsFactory,
   TYPES.TABLES_NAMES,
   TYPES.SyncSchema,
-  TYPES.Logger
+  TYPES.Logger,
+  TYPES.DBBackupManager
 ]
 class SqliteDbMigrator extends DbMigrator {
   /**

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -49,7 +49,8 @@ class SqliteDbMigrator extends DbMigrator {
           this.processMessageManager.PROCESS_STATES.REMOVE_ALL_TABLES
         )
         this.processMessageManager.sendState(
-          this.processMessageManager.PROCESS_MESSAGES.REQUEST_SHOULD_ALL_TABLES_BE_REMOVED
+          this.processMessageManager.PROCESS_MESSAGES.REQUEST_SHOULD_ALL_TABLES_BE_REMOVED,
+          { isNotDbRestored: !isDbRestored }
         )
 
         await rmDbPromise

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -12,7 +12,8 @@ const depsTypes = (TYPES) => [
   TYPES.TABLES_NAMES,
   TYPES.SyncSchema,
   TYPES.Logger,
-  TYPES.DBBackupManager
+  TYPES.DBBackupManager,
+  TYPES.ProcessMessageManager
 ]
 class SqliteDbMigrator extends DbMigrator {
   /**

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -67,21 +67,6 @@ class SqliteDbMigrator extends DbMigrator {
       throw err
     }
   }
-
-  async removeAllTables () {
-    await this.dao.disableForeignKeys()
-
-    try {
-      await this.dao.dropAllTables()
-      await this.dao.setCurrDbVer(0)
-    } catch (err) {
-      await this.dao.enableForeignKeys()
-
-      throw err
-    }
-
-    await this.dao.enableForeignKeys()
-  }
 }
 
 decorateInjectable(SqliteDbMigrator, depsTypes)

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -27,48 +27,44 @@ class SqliteDbMigrator extends DbMigrator {
         throw err
       }
 
-      const isDone = await this.dbBackupManager.restoreDb()
+      const responsePromise = this.processMessageManager.addStateToWait(
+        this.processMessageManager.PROCESS_STATES.RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE
+      )
+      this.processMessageManager.sendState(
+        this.processMessageManager.PROCESS_MESSAGES.REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE
+      )
+      const {
+        shouldRestore = false,
+        shouldRemove = false
+      } = (await responsePromise) ?? {}
 
-      if (isDone) {
+      if (shouldRestore) {
+        const isDbRestored = await this.dbBackupManager.restoreDb()
+
+        if (isDbRestored) {
+          return
+        }
+
+        const rmDbPromise = this.processMessageManager.addStateToWait(
+          this.processMessageManager.PROCESS_STATES.REMOVE_ALL_TABLES
+        )
+        this.processMessageManager.sendState(
+          this.processMessageManager.PROCESS_MESSAGES.REQUEST_SHOULD_ALL_TABLES_BE_REMOVED
+        )
+
+        await rmDbPromise
+
+        return
+      }
+      if (shouldRemove) {
+        await this.processMessageManager.processState(
+          this.processMessageManager.PROCESS_STATES.REMOVE_ALL_TABLES
+        )
+
         return
       }
 
-      // TODO: Need to collect whole process messaging to single module
-      await new Promise((resolve, reject) => {
-        const handler = async (mess) => {
-          try {
-            const { state } = { ...mess }
-
-            if (state === 'migration:dont-remove-all-tables') {
-              resolve()
-
-              return
-            }
-            if (state !== 'migration:remove-all-tables') {
-              return
-            }
-
-            await this.removeAllTables()
-            this.logger.debug('[All tables have been removed]')
-
-            process.send({ state: 'migration:all-tables-have-been-removed' })
-            resolve()
-          } catch (err) {
-            this.logger.error(err)
-
-            process.send({ state: 'migration:all-tables-have-not-been-removed' })
-            reject(err)
-          }
-        }
-
-        process.on('message', handler)
-        setTimeout(() => {
-          process.off('message', handler)
-          process.send({ state: 'migration:all-tables-have-not-been-removed' })
-          resolve()
-        }, 30000).unref()
-        process.send({ state: 'migration:should-all-tables-be-removed' })
-      })
+      throw err
     }
   }
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -77,6 +77,8 @@ class DBBackupManager {
       this.TABLES_NAMES.SCHEDULER,
       { isEnable: true }
     )
+
+    return true
   }
 
   async backupDb (params = {}) {

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const { mkdirSync } = require('fs')
+const { readdir } = require('fs/promises')
 const path = require('path')
+const moment = require('moment')
 
 const { decorateInjectable } = require('../../../di/utils')
 
@@ -45,7 +47,59 @@ class DBBackupManager {
       ? new Date(mts).toISOString()
       : new Date().toISOString()
 
-    return `backup-v${version}-${isoTS}.db`
+    return `backup_v${version}_${isoTS}.db`
+  }
+
+  async _getBackupFilesMetadata () {
+    const files = await readdir(
+      this._backupFolder,
+      { withFileTypes: true }
+    )
+    const filteredFiles = files.reduce((accum, dirent) => {
+      const { name } = dirent
+
+      if (
+        dirent.isFile() &&
+        name.startsWith('backup') &&
+        name.endsWith('.db')
+      ) {
+        let version = null
+        let mts = 0
+
+        const trimmedName = name.replace(/\.db$/i, '')
+        const chancks = trimmedName.split('_')
+
+        for (const chanck of chancks) {
+          const momentDate = moment(chanck, moment.ISO_8601, true)
+
+          if (/^v\d+$/i.test(chanck)) {
+            const trimmedChanck = chanck.replace(/^v/i, '')
+            const number = Number.parseInt(trimmedChanck)
+
+            version = Number.isInteger(number)
+              ? number
+              : null
+          }
+          if (momentDate.isValid()) {
+            mts = momentDate.valueOf()
+          }
+        }
+
+        if (!Number.isInteger(version)) {
+          return accum
+        }
+
+        accum.push({
+          name,
+          version,
+          mts
+        })
+      }
+
+      return accum
+    }, [])
+
+    return filteredFiles
   }
 }
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -116,8 +116,11 @@ class DBBackupManager {
           return accum
         }
 
+        const filePath = path.join(this._backupFolder, name)
+
         accum.push({
           name,
+          filePath,
           version,
           mts
         })

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -36,9 +36,10 @@ class DBBackupManager {
       this.conf.dbPathAbsolute,
       'backups'
     )
+    this._dbFileName = 'db-sqlite_sync_m0.db'
     this._dbDestination = path.join(
       this.conf.dbPathAbsolute,
-      'db-sqlite_sync_m0.db'
+      this._dbFileName
     )
 
     this._makeBackupsFolder()
@@ -252,8 +253,7 @@ class DBBackupManager {
 
       if (
         !dirent.isFile() ||
-        !normalizedName.endsWith('.db') ||
-        !normalizedName.startsWith('db-sqlite')
+        !normalizedName.startsWith(this._dbFileName)
       ) {
         continue
       }

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// const { promisify } = require('util')
+const { mkdirSync } = require('fs')
+const path = require('path')
+
 const { decorateInjectable } = require('../../../di/utils')
 
 const depsTypes = (TYPES) => [
@@ -13,6 +17,17 @@ class DBBackupManager {
   ) {
     this.conf = conf
     this.dao = dao
+
+    this._backupFolder = path.join(
+      this.conf.dbPathAbsolute,
+      'backups'
+    )
+
+    this._makeBackupsFolder()
+  }
+
+  _makeBackupsFolder () {
+    mkdirSync(this._backupFolder, { recursive: true })
   }
 
   // TODO:

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -56,8 +56,9 @@ class DBBackupManager {
 
     const backupFilesMetadata = await this.getBackupFilesMetadata()
     const suitableBackup = backupFilesMetadata.find((m) => (
-      (name && m.name === name) ||
-      m.version <= version
+      name
+        ? m.name === name
+        : m.version <= version
     ))
     const { filePath } = suitableBackup ?? {}
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -34,6 +34,13 @@ class DBBackupManager {
     this._makeBackupsFolder()
   }
 
+  // TODO:
+  async restoreDb (params) {
+    const {
+      version = this.syncSchema.SUPPORTED_DB_VERSION
+    } = params ?? {}
+  }
+
   async backupDb (params = {}) {
     const {
       currVer = await this.dao.getCurrDbVer()

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -60,7 +60,10 @@ class DBBackupManager {
         ? m.name === name
         : m.version <= version
     ))
-    const { filePath } = suitableBackup ?? {}
+    const {
+      filePath,
+      version: restoringVer
+    } = suitableBackup ?? {}
 
     if (!filePath) {
       return false
@@ -86,7 +89,8 @@ class DBBackupManager {
 
     this.logger.debug('[DB has been restored]:', filePath)
     this.processMessageManager.sendState(
-      this.processMessageManager.PROCESS_MESSAGES.DB_HAS_BEEN_RESTORED
+      this.processMessageManager.PROCESS_MESSAGES.DB_HAS_BEEN_RESTORED,
+      { isNotVerSupported: restoringVer !== this.syncSchema.SUPPORTED_DB_VERSION }
     )
 
     return true

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -39,6 +39,16 @@ class DBBackupManager {
     const {
       version = this.syncSchema.SUPPORTED_DB_VERSION
     } = params ?? {}
+
+    const backupFilesMetadata = await this._getBackupFilesMetadata()
+    const suitableBackup = backupFilesMetadata.find((m) => (
+      m.version === version
+    ))
+    const { filePath } = suitableBackup ?? {}
+
+    if (!filePath) {
+      return false
+    }
   }
 
   async backupDb (params = {}) {

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -57,11 +57,12 @@ class DBBackupManager {
     )
     const filteredFiles = files.reduce((accum, dirent) => {
       const { name } = dirent
+      const normalizedName = name.toLowerCase()
 
       if (
         dirent.isFile() &&
-        name.startsWith('backup') &&
-        name.endsWith('.db')
+        normalizedName.startsWith('backup') &&
+        normalizedName.endsWith('.db')
       ) {
         let version = null
         let mts = 0
@@ -70,7 +71,7 @@ class DBBackupManager {
         const chancks = trimmedName.split('_')
 
         for (const chanck of chancks) {
-          const momentDate = moment(chanck, moment.ISO_8601, true)
+          const momentDate = moment(chanck, moment.ISO_8601)
 
           if (/^v\d+$/i.test(chanck)) {
             const trimmedChanck = chanck.replace(/^v/i, '')

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -201,9 +201,14 @@ class DBBackupManager {
   }
 
   _getBackupFileName (version, mts) {
-    const isoTS = Number.isInteger(mts)
-      ? new Date(mts).toISOString()
-      : new Date().toISOString()
+    const date = Number.isInteger(mts)
+      ? new Date(mts)
+      : new Date()
+
+    // In Win OS, file name can't contain `:` character
+    const isoTS = date
+      .toISOString()
+      .replace(/:/g, '-')
 
     return `backup_v${version}_${isoTS}.db`
   }
@@ -229,7 +234,11 @@ class DBBackupManager {
         const chancks = trimmedName.split('_')
 
         for (const chanck of chancks) {
-          const momentDate = moment(chanck, moment.ISO_8601)
+          const dateFormats = [
+            moment.ISO_8601,
+            'YYYY-MM-DDThh-mm-ss.SSSZ'
+          ]
+          const momentDate = moment(chanck, dateFormats)
 
           if (/^v\d+$/i.test(chanck)) {
             const trimmedChanck = chanck.replace(/^v/i, '')

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -34,11 +34,9 @@ class DBBackupManager {
     this._makeBackupsFolder()
   }
 
-  // TODO: Store only two last backup files, need to manage it
   async backupDb (params = {}) {
     const {
-      currVer = await this.dao.getCurrDbVer(),
-      supportedVer = this.syncSchema.SUPPORTED_DB_VERSION
+      currVer = await this.dao.getCurrDbVer()
     } = params ?? {}
 
     try {
@@ -54,6 +52,7 @@ class DBBackupManager {
           process.send({ state: 'backup:progress', progress })
         }
       })
+      await this.manageDBBackupFiles()
 
       this.logger.debug('[DB backup has been created successfully]')
     } catch (err) {

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -4,6 +4,7 @@ const { mkdirSync } = require('fs')
 const { readdir } = require('fs/promises')
 const path = require('path')
 const moment = require('moment')
+const { orderBy } = require('lodash')
 
 const { decorateInjectable } = require('../../../di/utils')
 
@@ -125,7 +126,13 @@ class DBBackupManager {
       return accum
     }, [])
 
-    return filteredFiles
+    const orderedFiles = orderBy(
+      filteredFiles,
+      ['version', 'mts'],
+      ['desc', 'desc']
+    )
+
+    return orderedFiles
   }
 }
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -50,11 +50,13 @@ class DBBackupManager {
 
   async restoreDb (params) {
     const {
-      version = this.syncSchema.SUPPORTED_DB_VERSION
+      version = this.syncSchema.SUPPORTED_DB_VERSION,
+      name
     } = params ?? {}
 
-    const backupFilesMetadata = await this._getBackupFilesMetadata()
+    const backupFilesMetadata = await this.getBackupFilesMetadata()
     const suitableBackup = backupFilesMetadata.find((m) => (
+      (name && m.name === name) ||
       m.version <= version
     ))
     const { filePath } = suitableBackup ?? {}
@@ -142,7 +144,7 @@ class DBBackupManager {
    * for current supported DB schema
    */
   async manageDBBackupFiles () {
-    const backupFilesMetadata = await this._getBackupFilesMetadata()
+    const backupFilesMetadata = await this.getBackupFilesMetadata()
     const excludedFiles = []
     const removedFiles = []
 
@@ -201,7 +203,7 @@ class DBBackupManager {
     return `backup_v${version}_${isoTS}.db`
   }
 
-  async _getBackupFilesMetadata () {
+  async getBackupFilesMetadata () {
     const files = await readdir(
       this._backupFolder,
       { withFileTypes: true }

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -81,6 +81,11 @@ class DBBackupManager {
       { isEnable: true }
     )
 
+    this.logger.debug('[DB has been restored]:', filePath)
+    this.processMessageManager.sendState(
+      this.processMessageManager.PROCESS_MESSAGES.DB_HAS_BEEN_RESTORED
+    )
+
     return true
   }
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { decorateInjectable } = require('../../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF,
+  TYPES.DAO
+]
+class DBBackupManager {
+  constructor (
+    conf,
+    dao
+  ) {
+    this.conf = conf
+    this.dao = dao
+  }
+
+  // TODO:
+  backupDb () {}
+}
+
+decorateInjectable(DBBackupManager, depsTypes)
+
+module.exports = DBBackupManager

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// const { promisify } = require('util')
 const { mkdirSync } = require('fs')
 const path = require('path')
 
@@ -8,15 +7,18 @@ const { decorateInjectable } = require('../../../di/utils')
 
 const depsTypes = (TYPES) => [
   TYPES.CONF,
-  TYPES.DAO
+  TYPES.DAO,
+  TYPES.SyncSchema
 ]
 class DBBackupManager {
   constructor (
     conf,
-    dao
+    dao,
+    syncSchema
   ) {
     this.conf = conf
     this.dao = dao
+    this.syncSchema = syncSchema
 
     this._backupFolder = path.join(
       this.conf.dbPathAbsolute,
@@ -31,7 +33,12 @@ class DBBackupManager {
   }
 
   // TODO:
-  backupDb () {}
+  async backupDb (params = {}) {
+    const {
+      currVer = await this.dao.getCurrDbVer(),
+      supportedVer = this.syncSchema.SUPPORTED_DB_VERSION
+    } = params ?? {}
+  }
 }
 
 decorateInjectable(DBBackupManager, depsTypes)

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -28,16 +28,24 @@ class DBBackupManager {
     this._makeBackupsFolder()
   }
 
-  _makeBackupsFolder () {
-    mkdirSync(this._backupFolder, { recursive: true })
-  }
-
   // TODO:
   async backupDb (params = {}) {
     const {
       currVer = await this.dao.getCurrDbVer(),
       supportedVer = this.syncSchema.SUPPORTED_DB_VERSION
     } = params ?? {}
+  }
+
+  _makeBackupsFolder () {
+    mkdirSync(this._backupFolder, { recursive: true })
+  }
+
+  _getBackupFileName (version, mts) {
+    const isoTS = Number.isInteger(mts)
+      ? new Date(mts).toISOString()
+      : new Date().toISOString()
+
+    return `backup-v${version}-${isoTS}.db`
   }
 }
 

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -95,6 +95,10 @@ class DBBackupManager {
       const backupFileName = this._getBackupFileName(currVer)
       const filePath = path.join(this._backupFolder, backupFileName)
 
+      this.processMessageManager.sendState(
+        this.processMessageManager.PROCESS_MESSAGES.BACKUP_STARTED
+      )
+
       await this.dao.backupDb({
         filePath,
         progressFn: (progress) => {
@@ -107,6 +111,10 @@ class DBBackupManager {
         }
       })
       await this.manageDBBackupFiles()
+
+      this.processMessageManager.sendState(
+        this.processMessageManager.PROCESS_MESSAGES.BACKUP_FINISHED
+      )
 
       this.logger.debug('[DB backup has been created successfully]')
     } catch (err) {


### PR DESCRIPTION
This PR adds the ability to backup/restore DB. This feature is needed to have the ability to manage DB via `IPC` in the case when the worker is spawned like a child process in the electron env. Basic changes:
  - adds ability to backup DB
  - adds ability to restore DB
  - adds ability to startup DB backup before migration
  - adds ability to manage db backup files (to not have more than 3 files)
  - adds ability to manage DB via `IPC`
  - adds ability to restart DB driver to apply backup