### PR TITLE
Fix snapshots tickers

### DIFF
--- a/workers/loc.api/sync/full.snapshot.report/index.js
+++ b/workers/loc.api/sync/full.snapshot.report/index.js
@@ -29,11 +29,11 @@ class FullSnapshotReport {
       } = { ...wallet }
 
       if (
-        currency !== 'USD' &&
-        Number.isFinite(balance) &&
-        Number.isFinite(balanceUsd) &&
-        balance !== 0 &&
-        balanceUsd !== 0
+        currency === 'USD' ||
+        !Number.isFinite(balance) ||
+        !Number.isFinite(balanceUsd) ||
+        balance === 0 ||
+        balanceUsd === 0
       ) {
         return accum
       }


### PR DESCRIPTION
This PR fixes snapshots tickers. The issue is the following:
  - when taking a snapshot of wallets it's not showing the correspondent tickers as to represent crypto in fiat equivalent