### PR TITLE
Add USD equivalents columns to CSV export

### DIFF
--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -73,6 +73,35 @@ class CsvJobData extends BaseCsvJobData {
     return jobData
   }
 
+  async getLedgersCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    const _jobData = await super.getLedgersCsvJobData(
+      args,
+      uId,
+      uInfo
+    )
+
+    const jobData = {
+      ..._jobData,
+      columnsCsv: this._addColumnsBySchema(
+        _jobData.columnsCsv,
+        {
+          amount: {
+            amountUsd: 'AMOUNT USD'
+          },
+          balance: {
+            balanceUsd: 'BALANCE USD'
+          }
+        }
+      )
+    }
+
+    return jobData
+  }
+
   async getWalletsCsvJobData (
     args,
     uId,


### PR DESCRIPTION
This PR adds `amount/balance` USD equivalents columns to the `ledgers` CSV export. This request was got from issue https://github.com/bitfinexcom/bfx-report-electron/issues/114