### PR TITLE
Fix data consistency error message

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -166,6 +166,14 @@ class DataConsistencyError extends ConflictError {
   }
 }
 
+class DataConsistencyWhileSyncingError extends DataConsistencyError {
+  constructor (message = 'ERR_COLLECTIONS_DATA_IS_NOT_CONSISTENT_WHILE_SYNCING') {
+    super(message)
+
+    this.statusMessage = 'This particular endpoints are not available for the selected time frame while DB is being synced'
+  }
+}
+
 class ProcessStateSendingError extends BaseError {
   constructor (message = 'ERR_PROCESS_STATE_SENDING_IS_NOT_CORRECT') {
     super(message)
@@ -204,6 +212,7 @@ module.exports = {
   GetPublicDataError,
   DataConsistencyCheckerFindingError,
   DataConsistencyError,
+  DataConsistencyWhileSyncingError,
   ProcessStateSendingError,
   DbRestoringError
 }


### PR DESCRIPTION
This PR fixes data consistency error message, while DB is being synced, we should display the message that:
  - `This particular endpoints are not available for the selected time frame while DB is being synced`

![Screen Shot 2021-12-20 at 10 37 03 AM](https://user-images.githubusercontent.com/16489235/146739337-9a595b43-9262-4910-bba2-49611a14eb60.png)
 