### PR TITLE
Fix double response by ws when sing-in

### DIFF
--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -250,7 +250,7 @@ class WSTransport {
     )
   }
 
-  _sendToOne (socket, sid, action, err, result = null) {
+  _sendToOne (socket, action, err, result = null) {
     this.responder(
       () => {
         if (err) {
@@ -263,7 +263,7 @@ class WSTransport {
       {},
       (err, res) => {
         const _res = this.transport.format(
-          [sid, err, { ...res, action }]
+          [null, err, { ...res, action }]
         )
 
         socket.send(_res)
@@ -326,9 +326,9 @@ class WSTransport {
           continue
         }
 
-        this._sendToOne(socket, sid, action, null, res)
+        this._sendToOne(socket, action, null, res)
       } catch (err) {
-        this._sendToOne(socket, sid, action, err)
+        this._sendToOne(socket, action, err)
       }
     }
 


### PR DESCRIPTION
This PR fixes double response by WS when `sing-in`. No need to send request-id when the WS emits messages, without JSON-RPC

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report-express/pull/25