### PR TITLE
Fix sub-accounts fees for account summary

### DIFF
--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -8,6 +8,7 @@ const {
   getDateString,
   isNotSyncRequired,
   sumObjectsNumbers,
+  pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes
 } = require('./utils')
@@ -34,6 +35,7 @@ module.exports = {
   getAuthFromSubAccountAuth,
   getSubAccountAuthFromAuth,
   sumObjectsNumbers,
+  pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -10,6 +10,7 @@ const {
   sumObjectsNumbers,
   pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
+  pickAllLowerObjectsNumbers,
   sumArrayVolumes
 } = require('./utils')
 const {
@@ -37,5 +38,6 @@ module.exports = {
   sumObjectsNumbers,
   pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
+  pickAllLowerObjectsNumbers,
   sumArrayVolumes
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -80,6 +80,21 @@ const sumObjectsNumbers = (propName, objects = []) => {
   }, 0)
 }
 
+const pickLowerObjectsNumbers = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (!Number.isFinite(curr?.[propName])) {
+      return accum
+    }
+    if (!Number.isFinite(accum)) {
+      return curr[propName]
+    }
+
+    return curr[propName] < accum
+      ? curr[propName]
+      : accum
+  }, null)
+}
+
 const sumAllObjectsNumbers = (propName, objects = []) => {
   return objects.reduce((accum, curr) => {
     if (typeof curr?.[propName] !== 'object') {
@@ -165,6 +180,7 @@ module.exports = {
   getDateString,
   isNotSyncRequired,
   sumObjectsNumbers,
+  pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -95,6 +95,33 @@ const pickLowerObjectsNumbers = (propName, objects = []) => {
   }, null)
 }
 
+const pickAllLowerObjectsNumbers = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (typeof curr?.[propName] !== 'object') {
+      return accum
+    }
+
+    const entries = Object.entries(curr[propName])
+
+    return entries.reduce((accum, [key, val]) => {
+      if (!Number.isFinite(val)) {
+        return accum
+      }
+      if (!Number.isFinite(accum?.[key])) {
+        accum[key] = val
+
+        return accum
+      }
+
+      accum[key] = val < accum[key]
+        ? val
+        : accum[key]
+
+      return accum
+    }, accum)
+  }, {})
+}
+
 const sumAllObjectsNumbers = (propName, objects = []) => {
   return objects.reduce((accum, curr) => {
     if (typeof curr?.[propName] !== 'object') {
@@ -182,5 +209,6 @@ module.exports = {
   sumObjectsNumbers,
   pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
+  pickAllLowerObjectsNumbers,
   sumArrayVolumes
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -27,7 +27,8 @@ const {
   getAuthFromSubAccountAuth,
   sumObjectsNumbers,
   sumAllObjectsNumbers,
-  sumArrayVolumes
+  sumArrayVolumes,
+  pickLowerObjectsNumbers
 } = require('./helpers')
 
 const INITIAL_PROGRESS = 'SYNCHRONIZATION_HAS_NOT_STARTED_YET'
@@ -1097,23 +1098,23 @@ class FrameworkReportService extends ReportService {
           'trade_vol_30d', arrRes),
         fees_trading_30d: sumAllObjectsNumbers(
           'fees_trading_30d', arrRes),
-        fees_trading_total_30d: sumObjectsNumbers(
+        fees_trading_total_30d: pickLowerObjectsNumbers(
           'fees_trading_total_30d', arrRes),
         fees_funding_30d: sumAllObjectsNumbers(
           'fees_funding_30d', arrRes),
-        fees_funding_total_30d: sumObjectsNumbers(
+        fees_funding_total_30d: pickLowerObjectsNumbers(
           'fees_funding_total_30d', arrRes),
-        makerFee: sumObjectsNumbers(
+        makerFee: pickLowerObjectsNumbers(
           'makerFee', arrRes),
         derivMakerRebate: sumObjectsNumbers(
           'derivMakerRebate', arrRes),
-        takerFeeToCrypto: sumObjectsNumbers(
+        takerFeeToCrypto: pickLowerObjectsNumbers(
           'takerFeeToCrypto', arrRes),
-        takerFeeToStable: sumObjectsNumbers(
+        takerFeeToStable: pickLowerObjectsNumbers(
           'takerFeeToStable', arrRes),
-        takerFeeToFiat: sumObjectsNumbers(
+        takerFeeToFiat: pickLowerObjectsNumbers(
           'takerFeeToFiat', arrRes),
-        derivTakerFee: sumObjectsNumbers(
+        derivTakerFee: pickLowerObjectsNumbers(
           'derivTakerFee', arrRes),
         leoLev: sumObjectsNumbers(
           'leoLev', arrRes),

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -26,7 +26,7 @@ const {
   collObjToArr,
   getAuthFromSubAccountAuth,
   sumObjectsNumbers,
-  sumAllObjectsNumbers,
+  pickAllLowerObjectsNumbers,
   sumArrayVolumes,
   pickLowerObjectsNumbers
 } = require('./helpers')
@@ -1096,11 +1096,11 @@ class FrameworkReportService extends ReportService {
       const objRes = {
         trade_vol_30d: sumArrayVolumes(
           'trade_vol_30d', arrRes),
-        fees_trading_30d: sumAllObjectsNumbers(
+        fees_trading_30d: pickAllLowerObjectsNumbers(
           'fees_trading_30d', arrRes),
         fees_trading_total_30d: pickLowerObjectsNumbers(
           'fees_trading_total_30d', arrRes),
-        fees_funding_30d: sumAllObjectsNumbers(
+        fees_funding_30d: pickAllLowerObjectsNumbers(
           'fees_funding_30d', arrRes),
         fees_funding_total_30d: pickLowerObjectsNumbers(
           'fees_funding_total_30d', arrRes),


### PR DESCRIPTION
This PR fixes the fees of the sub-accounts for the `account summary` section. Fees should not be added up, should pick the lower of the accounts for each section