### PR TITLE
Fix `database is locked` sqlite error

### DIFF
--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -72,7 +72,7 @@ class Authenticator {
       isNotSetSession = false,
       isNotInTrans = false,
       masterUserId,
-      withoutWorkerThreads = false
+      withoutWorkerThreads = true
     } = { ...params }
 
     if (
@@ -199,7 +199,7 @@ class Authenticator {
       isReturnedUser,
       isNotInTrans,
       isNotSetSession,
-      withoutWorkerThreads
+      withoutWorkerThreads = true
     } = { ...params }
 
     const user = await this.verifyUser(
@@ -380,7 +380,7 @@ class Authenticator {
       isReturnedUser = false,
       isNotInTrans = false,
       isSubUser = false,
-      withoutWorkerThreads = false
+      withoutWorkerThreads = true
     } = { ...params }
 
     if (

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -515,7 +515,7 @@ class BetterSqliteDAO extends DAO {
   ) {
     const {
       isReplacedIfExists,
-      withoutWorkerThreads
+      withoutWorkerThreads = true
     } = { ...opts }
 
     const keys = Object.keys(obj)
@@ -861,7 +861,7 @@ class BetterSqliteDAO extends DAO {
     opts
   ) {
     const {
-      withoutWorkerThreads
+      withoutWorkerThreads = true
     } = { ...opts }
     const {
       where,
@@ -939,7 +939,7 @@ class BetterSqliteDAO extends DAO {
     const res = await this.query({
       action: DB_WORKER_ACTIONS.UPDATE_RECORD_OF,
       params: { data, name }
-    })
+    }, { withoutWorkerThreads: true })
     const { changes } = { ...res }
 
     if (changes < 1) {
@@ -967,7 +967,7 @@ class BetterSqliteDAO extends DAO {
     }
 
     const {
-      withoutWorkerThreads
+      withoutWorkerThreads = true
     } = { ...opts }
     const {
       where,
@@ -1014,7 +1014,7 @@ class BetterSqliteDAO extends DAO {
       action: MAIN_DB_WORKER_ACTIONS.RUN,
       sql,
       params
-    })
+    }, { withoutWorkerThreads: true })
   }
 }
 

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -170,7 +170,7 @@ class BetterSqliteDAO extends DAO {
       action: DB_WORKER_ACTIONS.RUN_IN_TRANS,
       sql,
       params: { transVersion: 'exclusive' }
-    })
+    }, { withoutWorkerThreads: true })
   }
 
   _createTriggerIfNotExists () {
@@ -181,7 +181,7 @@ class BetterSqliteDAO extends DAO {
       action: DB_WORKER_ACTIONS.RUN_IN_TRANS,
       sql,
       params: { transVersion: 'exclusive' }
-    })
+    }, { withoutWorkerThreads: true })
   }
 
   _createIndexisIfNotExists () {
@@ -192,7 +192,7 @@ class BetterSqliteDAO extends DAO {
       action: DB_WORKER_ACTIONS.RUN_IN_TRANS,
       sql,
       params: { transVersion: 'exclusive' }
-    })
+    }, { withoutWorkerThreads: true })
   }
 
   async _getTablesNames () {
@@ -291,7 +291,7 @@ class BetterSqliteDAO extends DAO {
       action: DB_WORKER_ACTIONS.RUN_IN_TRANS,
       sql,
       params: { transVersion: 'exclusive' }
-    })
+    }, { withoutWorkerThreads: true })
 
     await this._walCheckpoint()
     await this._vacuum()

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -796,8 +796,14 @@ class BetterSqliteDAO extends DAO {
       limit: _limit,
       limitVal
     } = getLimitQuery({ limit })
+    const delimiter = (
+      groupProj.length > 0 &&
+      _projection.length > 0
+    )
+      ? ', '
+      : ''
 
-    const sql = `SELECT ${distinct}${groupProj}${_projection} FROM ${_subQuery}
+    const sql = `SELECT ${distinct}${groupProj}${delimiter}${_projection} FROM ${_subQuery}
       ${where}
       ${group}
       ${_sort}

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -236,6 +236,12 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _tryToExecuteRollback () {
+    try {
+      this.db.prepare('ROLLBACK').run()
+    } catch (err) {}
+  }
+
   _vacuum () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.RUN,
@@ -307,6 +313,10 @@ class BetterSqliteDAO extends DAO {
     await this._enableWALJournalMode()
     await this._setCacheSize()
     await this._setAnalysisLimit()
+
+    // In case if the app is closed with non-finished transaction
+    // try to execute `ROLLBACK` sql query to avoid locking the DB
+    this._tryToExecuteRollback()
   }
 
   /**

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v3.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v3.js
@@ -92,7 +92,10 @@ class MigrationV3 extends AbstractMigration {
 
     await this.dao.executeQueriesInTrans(
       sql,
-      { beforeTransFn: () => this.dao.enableForeignKeys() }
+      {
+        beforeTransFn: () => this.dao.enableForeignKeys(),
+        withoutWorkerThreads: true
+      }
     )
     await this.dao.disableForeignKeys()
   }

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v5.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v5.js
@@ -10,7 +10,10 @@ class MigrationV5 extends AbstractMigration {
   async before () {
     await this.dao.executeQueriesInTrans(
       'DELETE FROM users',
-      { beforeTransFn: () => this.dao.enableForeignKeys() }
+      {
+        beforeTransFn: () => this.dao.enableForeignKeys(),
+        withoutWorkerThreads: true
+      }
     )
     await this.dao.disableForeignKeys()
   }

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
@@ -50,8 +50,14 @@ module.exports = (args, methodColl, opts) => {
     exclude,
     isExcludePrivate
   )
+  const delimiter = (
+    groupProj.length > 0 &&
+    projection.length > 0
+  )
+    ? ', '
+    : ''
 
-  const sql = `SELECT ${groupProj}${projection} FROM ${subQuery}
+  const sql = `SELECT ${groupProj}${delimiter}${projection} FROM ${subQuery}
     ${where}
     ${group}
     ${sort}


### PR DESCRIPTION
This PR fixes the issue related to `database is locked` sqlite error:
  - https://github.com/bitfinexcom/bfx-report-electron/issues/146
  - https://github.com/bitfinexcom/bfx-report-electron/issues/147

Basic changes:
  - Execute transaction without worker threads
  - Execute write sql queries without worker threads
  - Execute rollback sql query to avoid locking db on startup
  - Fix projection delimiter for sql grouping
