### PR TITLE
Fix sub account recalc

### DIFF
--- a/workers/loc.api/di/factories/migrations-factory.js
+++ b/workers/loc.api/di/factories/migrations-factory.js
@@ -30,7 +30,8 @@ module.exports = (ctx) => {
       TYPES.DAO,
       TYPES.TABLES_NAMES,
       TYPES.SyncSchema,
-      TYPES.Logger
+      TYPES.Logger,
+      TYPES.ProcessMessageManager
     ]
     const deps = depTypes.map((type) => {
       return ctx.container.get(type)

--- a/workers/loc.api/di/factories/process-message-manager-factory.js
+++ b/workers/loc.api/di/factories/process-message-manager-factory.js
@@ -8,21 +8,20 @@ module.exports = (ctx) => {
   )
 
   return () => {
-    const dao = ctx.container.get(
-      TYPES.DAO
-    )
-    const dbBackupManager = ctx.container.get(
-      TYPES.DBBackupManager
-    )
+    const depTypes = [
+      TYPES.DAO,
+      TYPES.DBBackupManager,
+      TYPES.RecalcSubAccountLedgersBalancesHook
+    ]
+    const deps = depTypes.map((type) => {
+      return ctx.container.get(type)
+    })
 
     if (dbDriver === 'better-sqlite') {
       const processMessageManager = ctx.container.get(
         TYPES.ProcessMessageManager
       )
-      processMessageManager.setDeps({
-        dao,
-        dbBackupManager
-      })
+      processMessageManager.setDeps(...deps)
 
       return processMessageManager
     }

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -97,11 +97,20 @@ class ProcessMessageManager {
       promise: null,
       index: null,
       hasTriggered: false,
+      hasClosed: false,
 
       resolve: () => {},
       reject: () => {},
       close: (err, data) => {
-        queue.splice(job.index, 1)
+        if (job.hasClosed) {
+          return
+        }
+        if (Number.isInteger(job.index)) {
+          queue.splice(job.index, 1)
+          job.index = null
+        }
+
+        job.hasClosed = true
 
         if (err) {
           job.reject(err)

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -20,6 +20,9 @@ module.exports = {
   DB_HAS_BEEN_RESTORED: 'db-has-been-restored',
   DB_HAS_NOT_BEEN_RESTORED: 'db-has-not-been-restored',
 
+  DB_HAS_NOT_BEEN_PREPARED: 'db-has-not-been-prepared',
+  DB_HAS_BEEN_PREPARED: 'db-has-been-prepared',
+
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
   REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed',
 

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -5,6 +5,7 @@ module.exports = {
   REMOVE_ALL_TABLES: 'remove-all-tables',
   RESTORE_DB: 'restore-db',
   BACKUP_DB: 'backup-db',
+  PREPARE_DB: 'prepare-db',
 
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done',
 

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -52,7 +52,7 @@ class DAO {
     const processMessageManager = this.processMessageManagerFactory()
       .init()
     const pmmJob = processMessageManager.addStateToWait(
-      processMessageManager.SET_PROCESS_STATES.PREPARE_DB
+      processMessageManager.PROCESS_STATES.PREPARE_DB
     )
 
     const dbMigrator = this.dbMigratorFactory()
@@ -62,10 +62,6 @@ class DAO {
       pmmJob.close(null)
     }
 
-    /*
-     * This is needed to wait for the end of database preparation
-     * when starting this process in migrations
-     */
     await pmmJob.promise
   }
 

--- a/workers/loc.api/sync/dao/db-migrations/migration.js
+++ b/workers/loc.api/sync/dao/db-migrations/migration.js
@@ -10,13 +10,15 @@ class Migration {
     dao,
     TABLES_NAMES,
     syncSchema,
-    logger
+    logger,
+    processMessageManager
   ) {
     this.version = version
     this.dao = dao
     this.TABLES_NAMES = TABLES_NAMES
     this.syncSchema = syncSchema
     this.logger = logger
+    this.processMessageManager = processMessageManager
   }
 
   getVersion () {

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
@@ -12,7 +12,7 @@ class MigrationV27 extends AbstractMigration {
      * to apply the fix for sub-accounts recalculation hook after sync
     */
     const sqlArr = [
-      `UPDATE ledgers SET _isBalanceRecalced = 0
+      `UPDATE ledgers SET _isBalanceRecalced = NULL
         WHERE subUserId IS NOT NULL`
     ]
 
@@ -28,7 +28,7 @@ class MigrationV27 extends AbstractMigration {
      * to apply the fix for sub-accounts recalculation hook after sync
     */
     const sqlArr = [
-      `UPDATE ledgers SET _isBalanceRecalced = 0
+      `UPDATE ledgers SET _isBalanceRecalced = NULL
         WHERE subUserId IS NOT NULL`
     ]
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+
+class MigrationV27 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    /*
+     * Force balance recalculation for sub-accounts
+     * to apply the fix for sub-accounts recalculation hook after sync
+    */
+    const sqlArr = [
+      `UPDATE ledgers SET _isBalanceRecalced = 0
+        WHERE subUserId IS NOT NULL`
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  down () {
+    /*
+     * Force balance recalculation for sub-accounts
+     * to apply the fix for sub-accounts recalculation hook after sync
+    */
+    const sqlArr = [
+      `UPDATE ledgers SET _isBalanceRecalced = 0
+        WHERE subUserId IS NOT NULL`
+    ]
+
+    this.addSql(sqlArr)
+  }
+}
+
+module.exports = MigrationV27

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
@@ -34,6 +34,15 @@ class MigrationV27 extends AbstractMigration {
 
     this.addSql(sqlArr)
   }
+
+  /**
+   * @override
+   */
+  async after () {
+    await this.processMessageManager.processState(
+      this.processMessageManager.PROCESS_STATES.PREPARE_DB
+    )
+  }
 }
 
 module.exports = MigrationV27

--- a/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite.db.migrator.js
@@ -27,7 +27,7 @@ class SqliteDbMigrator extends DbMigrator {
         throw err
       }
 
-      const responsePromise = this.processMessageManager.addStateToWait(
+      const { promise: responsePromise } = this.processMessageManager.addStateToWait(
         this.processMessageManager.PROCESS_STATES.RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE
       )
       this.processMessageManager.sendState(
@@ -45,7 +45,7 @@ class SqliteDbMigrator extends DbMigrator {
           return
         }
 
-        const rmDbPromise = this.processMessageManager.addStateToWait(
+        const { promise: rmDbPromise } = this.processMessageManager.addStateToWait(
           this.processMessageManager.PROCESS_STATES.REMOVE_ALL_TABLES
         )
         this.processMessageManager.sendState(

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -269,6 +269,10 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
       !(auth instanceof Map) ||
       auth.size === 0
     ) {
+      if (!dataInserter) {
+        return
+      }
+
       throw new SubAccountLedgersBalancesRecalcError()
     }
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -158,7 +158,7 @@ class DataInserter extends EventEmitter {
       return
     }
 
-    this._auth = getAuthFromDb(this.authenticator)
+    this._auth = await getAuthFromDb(this.authenticator)
 
     if (
       !this._auth ||

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -99,7 +99,7 @@ class DataInserter extends EventEmitter {
 
     this._asyncProgressHandlers = []
     this._auth = null
-    this._syncedSubUsers = []
+    this._syncedSubUsers = new Set()
     this._allowedCollsNames = getAllowedCollsNames(
       this.ALLOWED_COLLS
     )
@@ -314,21 +314,10 @@ class DataInserter extends EventEmitter {
     const {
       _id: userId,
       subUser,
-      subUsers,
       isSubAccount
-    } = { ...auth }
-    const { _id: subUserId } = { ...subUser }
-    const isLastSubUser = (
-      isSubAccount &&
-      subUsers.every((subUser) => {
-        const { _id } = { ...subUser }
-
-        return [
-          ...this._syncedSubUsers,
-          subUserId
-        ].some((suId) => _id === suId)
-      })
-    )
+    } = auth ?? {}
+    const { _id: subUserId } = subUser ?? {}
+    const isLastSubUser = this._isLastSubUser(auth)
 
     let count = 0
     let progress = 0
@@ -387,7 +376,7 @@ class DataInserter extends EventEmitter {
     await this.prepareData({ methodCollMap }, { isLastSubUser })
 
     if (isSubAccount) {
-      this._syncedSubUsers.push(subUserId)
+      this._setSyncedSubUser(userId, subUserId)
     }
 
     return progress
@@ -967,6 +956,42 @@ class DataInserter extends EventEmitter {
 
   _getMethodCollMap () {
     return new Map(this._methodCollMap)
+  }
+
+  _isLastSubUser (auth = {}) {
+    const {
+      _id: userId,
+      subUser,
+      subUsers,
+      isSubAccount
+    } = auth ?? {}
+    const { _id: subUserId } = subUser ?? {}
+    const restSubUsers = subUsers.filter((user) => (
+      user?._id !== subUserId
+    ))
+    const currSubUser = this._getSyncedSubUser(userId, subUserId)
+
+    return (
+      isSubAccount &&
+      !this._syncedSubUsers.has(currSubUser) &&
+      restSubUsers.every((subUser) => (
+        this._syncedSubUsers
+          .has(this._getSyncedSubUser(userId, subUser?._id))
+      ))
+    )
+  }
+
+  _setSyncedSubUser (userId, subUserId) {
+    if (!(this._syncedSubUsers instanceof Set)) {
+      this._syncedSubUsers = new Set()
+    }
+
+    this._syncedSubUsers
+      .add(this._getSyncedSubUser(userId, subUserId))
+  }
+
+  _getSyncedSubUser (userId, subUserId) {
+    return `${userId}-${subUserId}`
   }
 }
 

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 26
+const SUPPORTED_DB_VERSION = 27
 
 const TABLES_NAMES = require('./tables-names')
 const {


### PR DESCRIPTION
This PR fixes sub-account recalculation. Basic changes:
  - fixes sub-account recalc launch after db syncing, there is a problem when having multiple sub-accounts with the same sub-users
  - forces balance recalculation for sub-accounts using db migration to apply the fix for sub-accounts recalculation hook after sync
  