### PR TITLE
Use inner max limit for internal public api calls

### DIFF
--- a/workers/loc.api/sync/data.inserter/helpers/get-method-arg-map.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-method-arg-map.js
@@ -4,7 +4,10 @@ module.exports = (
   schema,
   opts
 ) => {
-  const { maxLimit = null } = schema
+  const {
+    maxLimit = null,
+    additionalApiCallArgs
+  } = schema
   const {
     auth: reqAuth = {},
     limit = maxLimit,
@@ -32,8 +35,10 @@ module.exports = (
     : { apiKey, apiSecret, session: reqAuth }
 
   return {
+    ...additionalApiCallArgs,
     auth,
     params: {
+      ...additionalApiCallArgs?.params,
       ...params,
       limit,
       end,

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -69,6 +69,7 @@ const _methodCollMap = new Map([
       start: [],
       confName: 'publicTradesConf',
       isSyncRequiredAtLeastOnce: false,
+      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.PUBLIC_TRADES)
     }
@@ -259,6 +260,7 @@ const _methodCollMap = new Map([
       start: [],
       confName: 'tickersHistoryConf',
       isSyncRequiredAtLeastOnce: false,
+      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.TICKERS_HISTORY)
     }
@@ -387,6 +389,7 @@ const _methodCollMap = new Map([
       confName: 'candlesConf',
       isSyncDoneForCurrencyConv: false,
       isSyncRequiredAtLeastOnce: true,
+      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
       type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.CANDLES)
     }


### PR DESCRIPTION
This PR adds ability to use the inner max limit for public API calls:
https://github.com/bitfinexcom/bfx-report/blob/cc53f7744d703cee26a88d320367b90543c9f4d3/workers/loc.api/helpers/limit-param.helpers.js#L19
for syncing of the bfx_api_v2 to avoid the frequent occurrence of the rate limit error

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/262