### PR TITLE
Fix removing/adding sub-account issue

### DIFF
--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -747,22 +747,22 @@ class Authenticator {
 
   async createUser (data, params) {
     const {
-      email,
-      isSubAccount = false,
-      isSubUser = false
-    } = { ...data }
-    const {
       isNotInTrans,
       withoutWorkerThreads
     } = { ...params }
 
-    await this.dao.insertElemToDb(
+    const { lastInsertRowid } = await this.dao.insertElemToDb(
       this.TABLES_NAMES.USERS,
       data,
       { withoutWorkerThreads }
     )
+
+    if (!Number.isInteger(lastInsertRowid)) {
+      throw new AuthError()
+    }
+
     const user = await this.getUser(
-      { email, isSubAccount, isSubUser },
+      { _id: lastInsertRowid },
       { isNotInTrans, withoutWorkerThreads }
     )
 

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -95,6 +95,10 @@ class BetterSqliteDAO extends DAO {
     await this.startDb()
 
     this.db = this.getConnection()
+
+    await this.beforeMigrationHook()
+    await this._walCheckpoint()
+    await this._vacuum()
   }
 
   query (args, opts) {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -267,14 +267,14 @@ class BetterSqliteDAO extends DAO {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: 'foreign_keys = ON'
-    })
+    }, { withoutWorkerThreads: true })
   }
 
   disableForeignKeys () {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: 'foreign_keys = OFF'
-    })
+    }, { withoutWorkerThreads: true })
   }
 
   async dropAllTables (opts = {}) {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -532,7 +532,7 @@ class BetterSqliteDAO extends DAO {
       INTO ${name}(${projection})
       VALUES (${placeholders})`
 
-    await this.query({
+    return await this.query({
       action: MAIN_DB_WORKER_ACTIONS.RUN,
       sql,
       params

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v27.js
@@ -38,7 +38,7 @@ class MigrationV27 extends AbstractMigration {
   /**
    * @override
    */
-  async after () {
+  async afterUp () {
     await this.processMessageManager.processState(
       this.processMessageManager.PROCESS_STATES.PREPARE_DB
     )

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
@@ -6,6 +6,11 @@ class MigrationV28 extends AbstractMigration {
   /**
    * @override
    */
+  before () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
   up () {
     const sqlArr = [
       `UPDATE users SET isNotProtected = 1
@@ -23,6 +28,11 @@ class MigrationV28 extends AbstractMigration {
 
     this.addSql(sqlArr)
   }
+
+  /**
+   * @override
+   */
+  after () { return this.dao.enableForeignKeys() }
 }
 
 module.exports = MigrationV28

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
@@ -23,7 +23,16 @@ class MigrationV28 extends AbstractMigration {
         ) AND username LIKE '%-sub-user-' || (
           SELECT id FROM users WHERE isSubAccount = 1 AND _id = sa.masterUserId
         )
-      )`
+      )`,
+
+      `UPDATE ledgers AS up SET subUserId = (
+        SELECT subUserId FROM subAccounts AS sa WHERE masterUserId = up.user_id AND (
+          SELECT 1 FROM users AS WHERE _id = up.subUserId AND email = (
+            SELECT email FROM users WHERE _id = sa.subUserId
+          )
+        )
+      )
+        WHERE subUserId IS NOT NULL`
     ]
 
     this.addSql(sqlArr)

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+
+class MigrationV28 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      `UPDATE users SET isNotProtected = 1
+      WHERE isSubUser = 1 AND isNotProtected != 1 AND username LIKE '%-sub-user-' || (
+        SELECT id FROM users WHERE isSubAccount = 1 AND isNotProtected = 1
+      )`
+    ]
+
+    this.addSql(sqlArr)
+  }
+}
+
+module.exports = MigrationV28

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
@@ -9,8 +9,15 @@ class MigrationV28 extends AbstractMigration {
   up () {
     const sqlArr = [
       `UPDATE users SET isNotProtected = 1
-      WHERE isSubUser = 1 AND isNotProtected != 1 AND username LIKE '%-sub-user-' || (
-        SELECT id FROM users WHERE isSubAccount = 1 AND isNotProtected = 1
+        WHERE isSubUser = 1 AND isNotProtected != 1 AND username LIKE '%-sub-user-' || (
+          SELECT id FROM users WHERE isSubAccount = 1 AND isNotProtected = 1
+        )`,
+      `UPDATE subAccounts AS sa SET subUserId = (
+        SELECT _id FROM users WHERE isSubUser = 1 AND email = (
+          SELECT email FROM users WHERE _id = sa.subUserId
+        ) AND username LIKE '%-sub-user-' || (
+          SELECT id FROM users WHERE isSubAccount = 1 AND _id = sa.masterUserId
+        )
       )`
     ]
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v28.js
@@ -39,7 +39,20 @@ class MigrationV28 extends AbstractMigration {
       )`,
 
       ...this._getRemappingSubUserIdSQL([
-        'ledregs'
+        'ledregs',
+        'trades',
+        'fundingTrades',
+        'orders',
+        'movements',
+        'fundingOfferHistory',
+        'fundingLoanHistory',
+        'fundingCreditHistory',
+        'positionsHistory',
+        'positionsSnapshot',
+        'logins',
+        'changeLogs',
+        'payInvoiceList',
+        'completedOnFirstSyncColls'
       ])
     ]
 

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 27
+const SUPPORTED_DB_VERSION = 28
 
 const TABLES_NAMES = require('./tables-names')
 const {

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -380,7 +380,13 @@ class SubAccount {
         throw new SubAccountUpdatingError()
       }
 
-      const { _id, email, token, subUsers } = subAccountUser
+      const {
+        _id,
+        email,
+        token,
+        subUsers,
+        isNotProtected
+      } = subAccountUser
 
       const masterUser = subUsers.find((subUser) => {
         const { email: _email } = { ...subUser }
@@ -473,7 +479,8 @@ class SubAccount {
             {
               auth: {
                 ...auth,
-                password: subAccountUser.password
+                password: subAccountUser.password,
+                isNotProtected
               }
             },
             {


### PR DESCRIPTION
This PR fixes sub-account removing/adding issue. Basic changes:
  - Fixes passing `isNotProtected` flag to sub-users being created
  - Fixes adding sub-users to sub-account
  - Fixes DB preparation after restarting DB when backup applied
  - Fixes v27 DB migration
  - Adds v28 DB migration to remap:
    - incorrect `isNotProtected` user flag
    - wrong sub-user ids in sub-accounts
    - wrong sub-user ids for all dependent tables