### PR TITLE
Add orders metadata to csv

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -2394,7 +2394,9 @@ module.exports = (
       'priceAuxLimit',
       'notify',
       'placedId',
-      'amountExecuted'
+      'amountExecuted',
+      'routing',
+      'meta'
     ])
   })
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v29.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v29.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+class MigrationV29 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE orders ADD COLUMN routing VARCHAR(255)',
+      'ALTER TABLE orders ADD COLUMN meta TEXT'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'orders',
+        {
+          _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+          id: 'BIGINT',
+          gid: 'BIGINT',
+          cid: 'BIGINT',
+          symbol: 'VARCHAR(255)',
+          mtsCreate: 'BIGINT',
+          mtsUpdate: 'BIGINT',
+          amount: 'DECIMAL(22,12)',
+          amountOrig: 'DECIMAL(22,12)',
+          type: 'VARCHAR(255)',
+          typePrev: 'VARCHAR(255)',
+          flags: 'INT',
+          status: 'VARCHAR(255)',
+          price: 'DECIMAL(22,12)',
+          priceAvg: 'DECIMAL(22,12)',
+          priceTrailing: 'DECIMAL(22,12)',
+          priceAuxLimit: 'DECIMAL(22,12)',
+          notify: 'INT',
+          placedId: 'BIGINT',
+          _lastAmount: 'DECIMAL(22,12)',
+          amountExecuted: 'DECIMAL(22,12)',
+          subUserId: 'INT',
+          user_id: 'INT NOT NULL',
+          __constraints__: [
+            `CONSTRAINT #{tableName}_fk_user_id
+            FOREIGN KEY (user_id)
+            REFERENCES users(_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE`,
+            `CONSTRAINT #{tableName}_fk_subUserId
+            FOREIGN KEY (subUserId)
+            REFERENCES users(_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE`
+          ]
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV29

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v29.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v29.js
@@ -10,7 +10,10 @@ class MigrationV29 extends AbstractMigration {
   up () {
     const sqlArr = [
       'ALTER TABLE orders ADD COLUMN routing VARCHAR(255)',
-      'ALTER TABLE orders ADD COLUMN meta TEXT'
+      'ALTER TABLE orders ADD COLUMN meta TEXT',
+      'DELETE FROM orders',
+      `DELETE FROM completedOnFirstSyncColls
+        WHERE collName = '_getOrders'`
     ]
 
     this.addSql(sqlArr)

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 28
+const SUPPORTED_DB_VERSION = 29
 
 const TABLES_NAMES = require('./tables-names')
 const {
@@ -255,6 +255,8 @@ const _models = new Map([
       placedId: 'BIGINT',
       _lastAmount: 'DECIMAL(22,12)',
       amountExecuted: 'DECIMAL(22,12)',
+      routing: 'VARCHAR(255)',
+      meta: 'TEXT', // JSON
       subUserId: 'INT',
       user_id: 'INT NOT NULL',
 


### PR DESCRIPTION
This PR adds orders metadata to csv export. Basic changes:
  - Adds orders metadata to sync
  - Adds ones to the corresponding test case
  - Adds v29 db migration
  - Empties orders table via migration to sync from scratch with metadata
  
  **Depends** on this PR:
    - https://github.com/bitfinexcom/bfx-report/pull/264
