### PR TITLE
Notify sync is being paused until connection is resumed by ws

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -141,7 +141,8 @@ module.exports = ({
           ['_privResponder', TYPES.PrivResponder],
           ['_syncCollsManager', TYPES.SyncCollsManager],
           ['_dataConsistencyChecker', TYPES.DataConsistencyChecker],
-          ['_winLossVSAccountBalance', TYPES.WinLossVSAccountBalance]
+          ['_winLossVSAccountBalance', TYPES.WinLossVSAccountBalance],
+          ['_getDataFromApi', TYPES.GetDataFromApi]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -331,7 +331,10 @@ module.exports = ({
       .toConstantValue(
         bindDepsToFn(
           fullTaxReportCsvWriter,
-          [TYPES.RService]
+          [
+            TYPES.RService,
+            TYPES.GetDataFromApi
+          ]
         )
       )
     bind(TYPES.FullTaxReport)

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -9,6 +9,9 @@ const EventEmitter = require('events')
 const { bindDepsToFn } = require(
   'bfx-report/workers/loc.api/di/helpers'
 )
+const {
+  getDataFromApi
+} = require('bfx-report/workers/loc.api/helpers')
 
 const TYPES = require('./types')
 
@@ -332,5 +335,14 @@ module.exports = ({
     rebind(TYPES.CsvJobData)
       .to(CsvJobData)
       .inSingletonScope()
+    rebind(TYPES.GetDataFromApi).toConstantValue(
+      bindDepsToFn(
+        getDataFromApi,
+        [
+          TYPES.SyncInterrupter,
+          TYPES.WSEventEmitter
+        ]
+      )
+    )
   })
 }

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -321,7 +321,10 @@ module.exports = ({
       .toConstantValue(
         bindDepsToFn(
           fullSnapshotReportCsvWriter,
-          [TYPES.RService]
+          [
+            TYPES.RService,
+            TYPES.GetDataFromApi
+          ]
         )
       )
     bind(TYPES.FullTaxReportCsvWriter)

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -46,12 +46,6 @@ class UpdateRecordError extends BaseError {
   }
 }
 
-class ImplementationError extends BaseError {
-  constructor (message = 'ERR_NOT_IMPLEMENTED') {
-    super(message)
-  }
-}
-
 class DAOInitializationError extends BaseError {
   constructor (message = 'ERR_DAO_NOT_INITIALIZED') {
     super(message)
@@ -194,7 +188,6 @@ module.exports = {
   AfterAllInsertsHookIsNotHookError,
   RemoveListElemsError,
   UpdateRecordError,
-  ImplementationError,
   DAOInitializationError,
   ServerAvailabilityError,
   ObjectMappingError,

--- a/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
@@ -6,13 +6,13 @@ const { stringify } = require('csv')
 const {
   write
 } = require('bfx-report/workers/loc.api/queue/write-data-to-stream/helpers')
-const {
-  getDataFromApi
-} = require('bfx-report/workers/loc.api/helpers')
 
 const nope = () => {}
 
-module.exports = (rService) => async (
+module.exports = (
+  rService,
+  getDataFromApi
+) => async (
   wStream,
   jobData
 ) => {
@@ -110,7 +110,8 @@ module.exports = (rService) => async (
 
   const res = await getDataFromApi({
     getData: rService[name].bind(rService),
-    args
+    args,
+    callerName: 'CSV_WRITER'
   })
 
   const {

--- a/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-snapshot-report-csv-writer.js
@@ -108,10 +108,10 @@ module.exports = (rService) => async (
     pipeline(rStream, wStream, nope)
   })
 
-  const res = await getDataFromApi(
-    rService[name].bind(rService),
+  const res = await getDataFromApi({
+    getData: rService[name].bind(rService),
     args
-  )
+  })
 
   const {
     positionsSnapshot,

--- a/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
@@ -6,13 +6,13 @@ const { stringify } = require('csv')
 const {
   write
 } = require('bfx-report/workers/loc.api/queue/write-data-to-stream/helpers')
-const {
-  getDataFromApi
-} = require('bfx-report/workers/loc.api/helpers')
 
 const nope = () => {}
 
-module.exports = (rService) => async (
+module.exports = (
+  rService,
+  getDataFromApi
+) => async (
   wStream,
   jobData
 ) => {
@@ -124,7 +124,8 @@ module.exports = (rService) => async (
 
   const res = await getDataFromApi({
     getData: rService[name].bind(rService),
-    args
+    args,
+    callerName: 'CSV_WRITER'
   })
   const {
     startingPositionsSnapshot,

--- a/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/full-tax-report-csv-writer.js
@@ -122,10 +122,10 @@ module.exports = (rService) => async (
     pipeline(rStream, wStream, nope)
   })
 
-  const res = await getDataFromApi(
-    rService[name].bind(rService),
+  const res = await getDataFromApi({
+    getData: rService[name].bind(rService),
     args
-  )
+  })
   const {
     startingPositionsSnapshot,
     endingPositionsSnapshot,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -592,10 +592,10 @@ class FrameworkReportService extends ReportService {
     return this._privResponder(() => {
       return this._subAccountApiData
         .getDataForSubAccount(
-          (args) => getDataFromApi(
-            (space, args) => super.getActivePositions(space, args),
+          (args) => getDataFromApi({
+            getData: (space, args) => super.getActivePositions(space, args),
             args
-          ),
+          }),
           args,
           {
             datePropName: 'mtsUpdate',
@@ -625,12 +625,12 @@ class FrameworkReportService extends ReportService {
     return responder(async () => {
       return this._positionsAudit
         .getPositionsAuditForSubAccount(
-          (args) => getDataFromApi(
-            (space, args) => {
+          (args) => getDataFromApi({
+            getData: (space, args) => {
               return super.getPositionsAudit(space, args)
             },
             args
-          ),
+          }),
           args,
           {
             checkParamsFn: (args) => checkParams(

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -10,7 +10,6 @@ const {
 } = require('bfx-report/workers/loc.api/errors')
 const {
   getTimezoneConf,
-  getDataFromApi,
   isENetError
 } = require('bfx-report/workers/loc.api/helpers')
 
@@ -592,9 +591,10 @@ class FrameworkReportService extends ReportService {
     return this._privResponder(() => {
       return this._subAccountApiData
         .getDataForSubAccount(
-          (args) => getDataFromApi({
+          (args) => this._getDataFromApi({
             getData: (space, args) => super.getActivePositions(space, args),
-            args
+            args,
+            callerName: 'ACTIVE_POSITIONS_GETTER'
           }),
           args,
           {
@@ -625,11 +625,12 @@ class FrameworkReportService extends ReportService {
     return responder(async () => {
       return this._positionsAudit
         .getPositionsAuditForSubAccount(
-          (args) => getDataFromApi({
+          (args) => this._getDataFromApi({
             getData: (space, args) => {
               return super.getPositionsAudit(space, args)
             },
-            args
+            args,
+            callerName: 'POSITIONS_AUDIT_GETTER'
           }),
           args,
           {

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -1,8 +1,11 @@
 'use strict'
 
 const {
-  DAOInitializationError,
   ImplementationError
+} = require('bfx-report/workers/loc.api/errors')
+
+const {
+  DAOInitializationError
 } = require('../../errors')
 
 const { decorateInjectable } = require('../../di/utils')

--- a/workers/loc.api/sync/dao/db-migrations/migration.js
+++ b/workers/loc.api/sync/dao/db-migrations/migration.js
@@ -2,7 +2,7 @@
 
 const {
   ImplementationError
-} = require('../../../errors')
+} = require('bfx-report/workers/loc.api/errors')
 
 class Migration {
   constructor (

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -5,9 +5,6 @@ const {
 } = require('lodash')
 const moment = require('moment')
 const {
-  getDataFromApi
-} = require('bfx-report/workers/loc.api/helpers')
-const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
@@ -41,7 +38,8 @@ const depsTypes = (TYPES) => [
   TYPES.FOREX_SYMBS,
   TYPES.CurrencyConverter,
   TYPES.SyncInterrupter,
-  TYPES.SyncCollsManager
+  TYPES.SyncCollsManager,
+  TYPES.GetDataFromApi
 ]
 class DataChecker {
   constructor (
@@ -53,7 +51,8 @@ class DataChecker {
     FOREX_SYMBS,
     currencyConverter,
     syncInterrupter,
-    syncCollsManager
+    syncCollsManager,
+    getDataFromApi
   ) {
     this.rService = rService
     this.dao = dao
@@ -64,6 +63,7 @@ class DataChecker {
     this.currencyConverter = currencyConverter
     this.syncInterrupter = syncInterrupter
     this.syncCollsManager = syncCollsManager
+    this.getDataFromApi = getDataFromApi
 
     this._methodCollMap = new Map()
 
@@ -745,11 +745,11 @@ class DataChecker {
       throw new FindMethodError()
     }
 
-    return getDataFromApi({
+    return this.getDataFromApi({
       getData: (space, args) => this.rService[methodApi]
         .bind(this.rService)(args),
       args,
-      interrupter: this.syncInterrupter
+      callerName: 'DATA_SYNCER'
     })
   }
 }

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -745,14 +745,12 @@ class DataChecker {
       throw new FindMethodError()
     }
 
-    return getDataFromApi(
-      (space, args) => this.rService[methodApi]
+    return getDataFromApi({
+      getData: (space, args) => this.rService[methodApi]
         .bind(this.rService)(args),
       args,
-      null,
-      null,
-      this.syncInterrupter
-    )
+      interrupter: this.syncInterrupter
+    })
   }
 }
 

--- a/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/data.inserter.hook.js
@@ -2,7 +2,7 @@
 
 const {
   ImplementationError
-} = require('../../../errors')
+} = require('bfx-report/workers/loc.api/errors')
 
 const { decorateInjectable } = require('../../../di/utils')
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -464,13 +464,13 @@ class DataInserter extends EventEmitter {
       throw new FindMethodError()
     }
 
-    return getDataFromApi(
-      methodApi,
+    return getDataFromApi({
+      getData: methodApi,
       args,
-      this.apiMiddleware.request.bind(this.apiMiddleware),
-      isCheckCall,
-      this.syncInterrupter
-    )
+      middleware: this.apiMiddleware.request.bind(this.apiMiddleware),
+      middlewareParams: isCheckCall,
+      interrupter: this.syncInterrupter
+    })
   }
 
   async _insertApiDataPublicArrObjTypeToDb (

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -6,9 +6,6 @@ const {
   cloneDeep
 } = require('lodash')
 const {
-  getDataFromApi
-} = require('bfx-report/workers/loc.api/helpers')
-const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')
 
@@ -59,7 +56,8 @@ const depsTypes = (TYPES) => [
   TYPES.DataChecker,
   TYPES.SyncInterrupter,
   TYPES.WSEventEmitter,
-  TYPES.SyncCollsManager
+  TYPES.SyncCollsManager,
+  TYPES.GetDataFromApi
 ]
 class DataInserter extends EventEmitter {
   constructor (
@@ -77,7 +75,8 @@ class DataInserter extends EventEmitter {
     dataChecker,
     syncInterrupter,
     wsEventEmitter,
-    syncCollsManager
+    syncCollsManager,
+    getDataFromApi
   ) {
     super()
 
@@ -96,6 +95,7 @@ class DataInserter extends EventEmitter {
     this.syncInterrupter = syncInterrupter
     this.wsEventEmitter = wsEventEmitter
     this.syncCollsManager = syncCollsManager
+    this.getDataFromApi = getDataFromApi
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -464,12 +464,12 @@ class DataInserter extends EventEmitter {
       throw new FindMethodError()
     }
 
-    return getDataFromApi({
+    return this.getDataFromApi({
       getData: methodApi,
       args,
       middleware: this.apiMiddleware.request.bind(this.apiMiddleware),
       middlewareParams: isCheckCall,
-      interrupter: this.syncInterrupter
+      callerName: 'DATA_SYNCER'
     })
   }
 

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -1,13 +1,29 @@
 'use strict'
 
+const AbstractWSEventEmitter = require(
+  'bfx-report/workers/loc.api/abstract.ws.event.emitter'
+)
+
 const { decorateInjectable } = require('../di/utils')
 
 const depsTypes = (TYPES) => [
   TYPES.WSTransport
 ]
-class WSEventEmitter {
+class WSEventEmitter extends AbstractWSEventEmitter {
   constructor (wsTransport) {
+    super()
+
     this.wsTransport = wsTransport
+  }
+
+  /**
+   * @override
+   */
+  emit (handler, action) {
+    return this.wsTransport.sendToActiveUsers(
+      handler,
+      action
+    )
   }
 
   isInvalidAuth (auth = {}, { _id, email } = {}) {
@@ -20,7 +36,7 @@ class WSEventEmitter {
   emitProgress (
     handler = () => {}
   ) {
-    return this.wsTransport.sendToActiveUsers(
+    return this.emit(
       handler,
       'emitProgress'
     )
@@ -29,7 +45,7 @@ class WSEventEmitter {
   emitSyncingStep (
     handler = () => {}
   ) {
-    return this.wsTransport.sendToActiveUsers(
+    return this.emit(
       handler,
       'emitSyncingStep'
     )
@@ -57,7 +73,7 @@ class WSEventEmitter {
   async emitRedirectingRequestsStatusToApi (
     handler = () => {}
   ) {
-    return this.wsTransport.sendToActiveUsers(
+    return this.emit(
       handler,
       'emitRedirectingRequestsStatusToApi'
     )


### PR DESCRIPTION
This PR adds the ability to send events by WS to notify users when fetching data from `bfx_api_v2` is paused due broken internet connection. Available two WS events:
  - `emitENetError` when connection is broken, response example:

```jsonc
{
  "jsonrpc": "2.0",
  "result": "DATA_SYNCER",
  "id": null,
  "action": "emitENetError"
}
```

- `emitENetResumed` when connection is resumed, response example:

```jsonc
{
  "jsonrpc": "2.0",
  "result": "DATA_SYNCER",
  "id": null,
  "action": "emitENetResumed"
}
```

In those two events available the following `result`s, that return caller name:
  - `DATA_SYNCER` - appears when data syncs from api_v2 to DB
  - `CSV_WRITER` - appears when CSV file generates from api_v2
  - `ACTIVE_POSITIONS_GETTER` - appears when UI fetches `active positions` data from api_v2 for sub-account
  - `POSITIONS_AUDIT_GETTER` - appears when UI fetches `positions audit` data from api_v2 for sub-account

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/266