### PR TITLE
Fix win/loss vs account balance report

### DIFF
--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -641,6 +641,9 @@ class CsvJobData extends BaseCsvJobData {
     )
 
     const csvArgs = getCsvArgs(args)
+    const suffix = args?.params?.isVSPrevDayBalance
+      ? 'balance'
+      : 'deposits'
 
     const jobData = {
       userInfo,
@@ -648,7 +651,7 @@ class CsvJobData extends BaseCsvJobData {
       name: 'getWinLossVSAccountBalance',
       fileNamesMap: [[
         'getWinLossVSAccountBalance',
-        'win-loss-vs-account-balance'
+        `win-loss-percentage-gains-vs-${suffix}`
       ]],
       args: csvArgs,
       propNameForPagination: null,

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -477,7 +477,7 @@ class BalanceHistory {
       auth: _auth = {},
       params = {}
     } = {},
-    isSubCalc = false
+    opts = {}
   ) {
     const auth = await this.authenticator
       .verifyRequestUser({ auth: _auth })
@@ -488,6 +488,9 @@ class BalanceHistory {
       end = Date.now(),
       isUnrealizedProfitExcluded
     } = params ?? {}
+    const {
+      isSubCalc = false
+    } = opts ?? {}
 
     if (Number.isInteger(timeframe)) {
       return this._getWalletsGroupedByOneTimeframe(

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -171,12 +171,7 @@ module.exports = async (
     const isLastIter = i === 0
     const nextItem = data[i - 1]
 
-    if (
-      item &&
-      typeof item === 'object' &&
-      Number.isInteger(item[dateFieldName]) &&
-      typeof item[symbolFieldName] === 'string'
-    ) {
+    if (Number.isInteger(item?.[dateFieldName])) {
       subRes.unshift(item)
     }
 

--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -39,7 +39,8 @@ class Movements {
       exclude = ['user_id'],
       isExcludePrivate = true,
       isWithdrawals = false,
-      isDeposits = false
+      isDeposits = false,
+      isMovementsWithoutSATransferLedgers = false
     } = params ?? {}
 
     const user = await this.authenticator
@@ -83,8 +84,13 @@ class Movements {
         isExcludePrivate
       }
     )
+
+    if (isMovementsWithoutSATransferLedgers) {
+      return movementsPromise
+    }
+
     const ledgersOrder = this._getLedgersOrder(sort)
-    const ledgersPromise = this._getLedgers({
+    const ledgersPromise = this.getSubAccountsTransferLedgers({
       auth: user,
       start,
       end,
@@ -123,7 +129,7 @@ class Movements {
    * Consider the `SA(nameAccount1->nameAccount2)` transfers
    * as internal movements for win/loss and tax calculations
    */
-  _getLedgers (params = {}) {
+  getSubAccountsTransferLedgers (params = {}) {
     const {
       auth = {},
       start = 0,

--- a/workers/loc.api/sync/win.loss.vs.account.balance/index.js
+++ b/workers/loc.api/sync/win.loss.vs.account.balance/index.js
@@ -44,6 +44,7 @@ class WinLossVSAccountBalance {
     }
 
     const {
+      firstWalletsVals,
       walletsGroupedByTimeframe,
       withdrawalsGroupedByTimeframe,
       depositsGroupedByTimeframe,
@@ -59,7 +60,10 @@ class WinLossVSAccountBalance {
       },
       false,
       this._winLossVSAccountBalanceByTimeframe(
-        { isUnrealizedProfitExcluded }
+        {
+          isUnrealizedProfitExcluded,
+          firstWalletsVals
+        }
       ),
       true
     )
@@ -76,9 +80,9 @@ class WinLossVSAccountBalance {
   }
 
   _winLossVSAccountBalanceByTimeframe ({
-    isUnrealizedProfitExcluded
+    isUnrealizedProfitExcluded,
+    firstWalletsVals
   }) {
-    let firstWalletsVals = {}
     let firstPLVals = 0
     let prevMovementsRes = 0
 
@@ -92,7 +96,6 @@ class WinLossVSAccountBalance {
       const isFirst = (i + 1) === arr.length
 
       if (isFirst) {
-        firstWalletsVals = walletsGroupedByTimeframe
         firstPLVals = plGroupedByTimeframe
       }
 


### PR DESCRIPTION
This PR fixes win/loss vs account balance report. The issue is the following: for the win/loss report we have to consider the first wallets taken at start mts point instead of taking the first wallets of the current timeframe in this calculation:

```js
const realized = (wallets - movements) - firstWallets
```

The issue related to this one:
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/228