### PR TITLE
Fix WebSocket GRENACHE_WS_IS_CLOCED error

### DIFF
--- a/workers/loc.api/sync/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/helpers/calc-grouped-data.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { promisify } = require('util')
+const setImmediatePromise = promisify(setImmediate)
 const { pick, omit } = require('lodash')
 
 const getBackIterable = require('../helpers/get-back-iterable')
@@ -133,6 +135,8 @@ const _getReducer = (
   calcDataItem
 ) => {
   return async (asyncAccum, item, i, arr) => {
+    await setImmediatePromise()
+
     const accum = await asyncAccum
     const res = await calcDataItem(item, i, arr, accum)
 

--- a/workers/loc.api/sync/helpers/group-by-timeframe.js
+++ b/workers/loc.api/sync/helpers/group-by-timeframe.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { promisify } = require('util')
+const setImmediatePromise = promisify(setImmediate)
+
 const getStartMtsByTimeframe = require(
   './get-start-mts-by-timeframe'
 )
@@ -167,6 +170,8 @@ module.exports = async (
   const subRes = []
 
   for (let i = data.length - 1; i >= 0; i -= 1) {
+    await setImmediatePromise()
+
     const item = data[i]
     const isLastIter = i === 0
     const nextItem = data[i - 1]

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -79,14 +79,15 @@ class Trades {
   }
 
   _calcAmounts (data = []) {
-    return data.map((trade = {}) => {
+    return data.map((trade) => {
+      const _trade = trade ?? {}
       const {
         execAmount,
         execPrice,
         fee,
         feeCurrency,
         symbol
-      } = { ...trade }
+      } = _trade
       const symb = splitSymbolPairs(symbol)[1]
       const isFeeInUsd = feeCurrency === 'USD'
       const isPriceInUsd = symb === 'USD'
@@ -127,30 +128,27 @@ class Trades {
         ? _feeForCurrConv * execPrice
         : _feeForCurrConv
 
-      return {
-        ...trade,
-        calcAmount,
-        feeUsd,
-        feeForCurrConv
-      }
-    }, {})
+      _trade.calcAmount = calcAmount
+      _trade.feeUsd = feeUsd
+      _trade.feeForCurrConv = feeForCurrConv
+
+      return _trade
+    })
   }
 
   _calcTrades (fieldName) {
     return (data = []) => data.reduce((accum, trade = {}) => {
-      const _trade = { ...trade }
-      const value = _trade[fieldName]
+      const value = trade?.[fieldName]
 
       if (!Number.isFinite(value)) {
-        return { ...accum }
+        return accum
       }
 
-      return {
-        ...accum,
-        USD: Number.isFinite(accum.USD)
-          ? accum.USD + value
-          : value
-      }
+      accum.USD = Number.isFinite(accum?.USD)
+        ? accum.USD + value
+        : value
+
+      return accum
     }, {})
   }
 
@@ -170,13 +168,12 @@ class Trades {
           symb !== 'USD' ||
           !Number.isFinite(amount)
         ) {
-          return { ...accum }
+          return accum
         }
 
-        return {
-          ...accum,
-          [symb]: amount
-        }
+        accum[symb] = amount
+
+        return accum
       }, {})
 
       return res
@@ -193,7 +190,7 @@ class Trades {
       start = 0,
       end = Date.now(),
       symbol: symbs
-    } = { ...params }
+    } = params ?? {}
     const _symbol = Array.isArray(symbs)
       ? symbs
       : [symbs]
@@ -245,15 +242,13 @@ class Trades {
     if (
       Array.isArray(groupedTrades) &&
       groupedTrades.length > 0 &&
-      groupedTrades[groupedTrades.length - 1] &&
-      typeof groupedTrades[groupedTrades.length - 1] === 'object' &&
-      Number.isInteger(groupedTrades[groupedTrades.length - 1].mts)
+      Number.isInteger(groupedTrades[groupedTrades.length - 1]?.mts)
     ) {
       return groupedTrades[groupedTrades.length - 1].mts
     }
 
-    const { params } = { ...args }
-    const { start = 0 } = { ...params }
+    const { params } = args ?? {}
+    const { start = 0 } = params ?? {}
 
     return start
   }
@@ -269,7 +264,7 @@ class Trades {
       start = 0,
       end = Date.now(),
       timeframe = 'day'
-    } = { ...params }
+    } = params ?? {}
     const {
       symbolFieldName: tradesSymbolFieldName
     } = this.tradesMethodColl


### PR DESCRIPTION
This PR fixes WebSocket `GRENACHE_WS_IS_CLOCED` error. The issue is related to blocking of the event loop during fetching `Traded Volume` report, WS gets an error and then reconnects. It's something similar to what we fixed using `setImmediate()` earlier when inserting data into db