### PR TITLE
Add ability to sign out by email

### DIFF
--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -27,7 +27,8 @@ const agent = request.agent(app)
 
 const {
   apiSyncModeSqliteTestCases,
-  signUpTestCase
+  signUpTestCase,
+  removeUserTestCases
 } = require('./test-cases')
 
 let wrkReportServiceApi = null
@@ -94,4 +95,6 @@ describe('Sync mode API with SQLite', () => {
 
   signUpTestCase(agent, params)
   apiSyncModeSqliteTestCases(agent, params)
+  signUpTestCase(agent, params)
+  removeUserTestCases(agent, params)
 })

--- a/test/4-sub-account.spec.js
+++ b/test/4-sub-account.spec.js
@@ -32,7 +32,8 @@ const agent = request.agent(app)
 const {
   apiSyncModeSqliteTestCases,
   additionalApiSyncModeSqliteTestCases,
-  signUpTestCase
+  signUpTestCase,
+  removeUserTestCases
 } = require('./test-cases')
 
 let wrkReportServiceApi = null
@@ -428,6 +429,11 @@ describe('Sub-account', () => {
       before(beforeFn)
 
       additionalApiSyncModeSqliteTestCases(agent, params)
+    })
+    describe('Removing sub-account API', () => {
+      before(beforeFn)
+
+      removeUserTestCases(agent, params)
     })
   })
 })

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -3354,7 +3354,7 @@ module.exports = (
     assert.isNotOk(res.body.result)
   })
 
-  it('it should be successfully performed by the removeUser method', async function () {
+  it('it should be successfully performed by the removeUser method with token', async function () {
     this.timeout(5000)
 
     const res = await agent

--- a/test/test-cases/index.js
+++ b/test/test-cases/index.js
@@ -8,10 +8,12 @@ const additionalApiSyncModeSqliteTestCases = require(
 )
 const signUpTestCase = require('./sign-up-test-case')
 const getSyncProgressTestCase = require('./get-sync-progress-test-case')
+const removeUserTestCases = require('./remove-user-test-cases')
 
 module.exports = {
   apiSyncModeSqliteTestCases,
   additionalApiSyncModeSqliteTestCases,
   signUpTestCase,
-  getSyncProgressTestCase
+  getSyncProgressTestCase,
+  removeUserTestCases
 }

--- a/test/test-cases/remove-user-test-cases.js
+++ b/test/test-cases/remove-user-test-cases.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const { assert } = require('chai')
+
+module.exports = (
+  agent,
+  params = {}
+) => {
+  const {
+    basePath,
+    auth: {
+      email,
+      password,
+      isSubAccount
+    }
+  } = params
+  const auth = { token: '' }
+
+  it('it should be successfully performed by the signIn method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth: {
+          email,
+          password,
+          isSubAccount
+        },
+        method: 'signIn',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.strictEqual(res.body.result.email, email)
+    assert.strictEqual(res.body.result.isSubAccount, isSubAccount)
+    assert.isString(res.body.result.token)
+
+    auth.token = res.body.result.token
+  })
+
+  it('it should be successfully performed by the removeUser method with email', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth: {
+          email,
+          password,
+          isSubAccount
+        },
+        method: 'removeUser',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should not be successfully performed by the verifyUser method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'verifyUser',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(401)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 401)
+    assert.propertyVal(res.body.error, 'message', 'Unauthorized')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+}

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -879,10 +879,16 @@ class Authenticator {
   removeUserSession (user) {
     const { token } = user ?? {}
     const tokenKey = this._getTokenKeyByEmailField(user)
+    const _token = (
+      token &&
+      typeof token === 'string'
+    )
+      ? token
+      : this.userTokenMapByEmail.get(tokenKey)
 
     this.userTokenMapByEmail.delete(tokenKey)
 
-    return this.userSessions.delete(token)
+    return this.userSessions.delete(_token)
   }
 
   async decryptApiKeys (password, users) {

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -513,7 +513,6 @@ class Authenticator {
       return returnedUser
     }
 
-    // TODO:
     const existedToken = this.getUserSessionByEmail(
       { email, isSubAccount }
     ).token
@@ -534,7 +533,6 @@ class Authenticator {
     }
   }
 
-  // TODO:
   async verifyUser (args, opts) {
     const {
       email,
@@ -860,18 +858,9 @@ class Authenticator {
     return pickSessionProps(session, isReturnedPassword)
   }
 
-  getUserSessionByEmail (args, isReturnedPassword) {
-    const {
-      email,
-      isSubAccount = false
-    } = args ?? {}
-    const keyVal = [...this.userSessions].find(([, session]) => {
-      return (
-        email === session.email &&
-        isSubAccount === session.isSubAccount
-      )
-    })
-    const session = Array.isArray(keyVal) ? keyVal[1] : {}
+  getUserSessionByEmail (user, isReturnedPassword) {
+    const tokenKey = this._getTokenKeyByEmailField(user)
+    const session = this.userTokenMapByEmail.get(tokenKey)
 
     return pickSessionProps(session, isReturnedPassword)
   }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -52,6 +52,7 @@ class Authenticator {
      * It may only work for one grenache worker instance
      */
     this.userSessions = new Map()
+    this.userTokenMapByEmail = new Map()
   }
 
   async signUp (args, opts) {
@@ -508,6 +509,7 @@ class Authenticator {
       return returnedUser
     }
 
+    // TODO:
     const existedToken = this.getUserSessionByEmail(
       { email, isSubAccount }
     ).token
@@ -528,6 +530,7 @@ class Authenticator {
     }
   }
 
+  // TODO:
   async verifyUser (args, opts) {
     const {
       email,
@@ -836,9 +839,13 @@ class Authenticator {
   }
 
   setUserSession (user) {
-    const { token } = user ?? {}
+    const {
+      token
+    } = user ?? {}
+    const tokenKey = this._getTokenKeyByEmailField(user)
 
     this.userSessions.set(token, { ...user })
+    this.userTokenMapByEmail.set(tokenKey, token)
   }
 
   getUserSessionByToken (token, isReturnedPassword) {
@@ -904,6 +911,18 @@ class Authenticator {
     })
 
     return isArray ? res : res[0]
+  }
+
+  _getTokenKeyByEmailField (user) {
+    const {
+      email,
+      isSubAccount
+    } = user ?? {}
+    const suffix = isSubAccount
+      ? ':sub-account'
+      : ''
+
+    return `${email}${suffix}`
   }
 }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -362,7 +362,11 @@ class Authenticator {
       throw new AuthError()
     }
 
-    this.removeUserSessionByToken(token)
+    this.removeUserSession({
+      email,
+      isSubAccount,
+      token
+    })
 
     if (isSchedulerEnabled) {
       await this.dao.updateRecordOf(
@@ -833,15 +837,17 @@ class Authenticator {
       throw new UserRemovingError()
     }
 
-    this.removeUserSessionByToken(token)
+    this.removeUserSession({
+      email,
+      isSubAccount,
+      token
+    })
 
     return true
   }
 
   setUserSession (user) {
-    const {
-      token
-    } = user ?? {}
+    const { token } = user ?? {}
     const tokenKey = this._getTokenKeyByEmailField(user)
 
     this.userSessions.set(token, { ...user })
@@ -880,7 +886,12 @@ class Authenticator {
     return new Map(sessionsMap)
   }
 
-  removeUserSessionByToken (token) {
+  removeUserSession (user) {
+    const { token } = user ?? {}
+    const tokenKey = this._getTokenKeyByEmailField(user)
+
+    this.userTokenMapByEmail.delete(tokenKey)
+
     return this.userSessions.delete(token)
   }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -303,7 +303,7 @@ class Authenticator {
       typeof token === 'string'
     )
       ? token
-      : this.getUserSessionByEmail({ email, isSubAccount }).token
+      : this.getUserSessionByEmail({ email, isSubAccount })?.token
     const createdToken = (
       existedToken &&
       typeof existedToken === 'string'
@@ -515,7 +515,7 @@ class Authenticator {
 
     const existedToken = this.getUserSessionByEmail(
       { email, isSubAccount }
-    ).token
+    )?.token
     const createdToken = (
       existedToken &&
       typeof existedToken === 'string'
@@ -607,7 +607,7 @@ class Authenticator {
         token,
         isReturnedPassword
       )
-      const { apiKey, apiSecret } = { ...session }
+      const { apiKey, apiSecret } = session ?? {}
 
       if (
         !apiKey ||
@@ -860,7 +860,8 @@ class Authenticator {
 
   getUserSessionByEmail (user, isReturnedPassword) {
     const tokenKey = this._getTokenKeyByEmailField(user)
-    const session = this.userTokenMapByEmail.get(tokenKey)
+    const token = this.userTokenMapByEmail.get(tokenKey)
+    const session = this.userSessions.get(token)
 
     return pickSessionProps(session, isReturnedPassword)
   }


### PR DESCRIPTION
This PR adds ability for users to sign out by email property. Basic changes:
  - adds ability for users to sign out by `email` property
  - covers sign-out by `email` when removing users
  - increases performance for sing-in by `email`, adds a better way to fetch users from the session
  - adds corresponding test coverage