### PR TITLE
Send event by ws when csv is ready

### DIFF
--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -127,7 +127,8 @@ class FrameworkReportService extends ReportService {
             'email',
             'id',
             'isSubAccount',
-            'subUsers'
+            'subUsers',
+            '_id'
           ]
         }
       )

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -69,6 +69,24 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     })
   }
 
+  emitCsvGenerationCompletedToOne (
+    handler = () => {},
+    auth = {}
+  ) {
+    return this.emit(async (user, ...args) => {
+      if (
+        !Number.isInteger(auth?._id) ||
+        user?._id !== auth?._id
+      ) {
+        return { isNotEmitted: true }
+      }
+
+      return typeof handler === 'function'
+        ? await handler(user, ...args)
+        : handler
+    }, 'emitCsvGenerationCompletedToOne')
+  }
+
   emitBfxUnamePwdAuthRequiredToOne (
     handler = () => {},
     auth = {}

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -26,10 +26,13 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     )
   }
 
-  isInvalidAuth (auth = {}, { _id, email } = {}) {
+  isNotTargetUser (auth = {}, user = {}) {
+    // For the sync process user id need to take from the session object
+    const _id = auth?._id ?? auth?.session?._id
+
     return (
-      auth._id !== _id ||
-      auth.email !== email
+      !Number.isInteger(_id) ||
+      user?._id !== _id
     )
   }
 
@@ -56,10 +59,7 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     auth = {}
   ) {
     return this.emitSyncingStep(async (user, ...args) => {
-      if (
-        !Number.isInteger(auth?._id) ||
-        user?._id !== auth?._id
-      ) {
+      if (this.isNotTargetUser(auth, user)) {
         return { isNotEmitted: true }
       }
 
@@ -74,10 +74,7 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     auth = {}
   ) {
     return this.emit(async (user, ...args) => {
-      if (
-        !Number.isInteger(auth?._id) ||
-        user?._id !== auth?._id
-      ) {
+      if (this.isNotTargetUser(auth, user)) {
         return { isNotEmitted: true }
       }
 
@@ -92,13 +89,7 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     auth = {}
   ) {
     return this.emit(async (user, ...args) => {
-      // For the sync process user id need to take from the session object
-      const id = auth?._id ?? auth?.session?._id
-
-      if (
-        !Number.isInteger(id) ||
-        user?._id !== id
-      ) {
+      if (this.isNotTargetUser(auth, user)) {
         return { isNotEmitted: true }
       }
 


### PR DESCRIPTION
This PR adds ability to send `emitCsvGenerationCompletedToOne` event by the WS when csv reports generation is finished in the background queue, only for the framework mode. In the UI we can show a spinner on the export btn and the corresponding popup at an appropriate time after finishing generation (in some cases it can take a lot of time)

---

WS event:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "csvFilesMetadata": [
      {
        "name": "getLedgers",
        "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_ledgers_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.785Z.csv"
      },
      {
        "name": "getTrades",
        "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_trades_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.795Z.csv"
      },
      {
        "name": "getMovements",
        "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_movements_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.815Z.csv"
      }
    ]
  },
  "id": null,
  "action": "emitCsvGenerationCompletedToOne"
}

```

---

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/282