### PR TITLE
Fix getUsers endpoint response

### DIFF
--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -811,14 +811,7 @@ class Authenticator {
       })
 
     const _users = await this.dao.getUsers(filter, opts)
-    const users = pickProps(
-      _users,
-      projection,
-      {
-        isAppliedProjectionToSubUser,
-        subUsersProjection
-      }
-    ).map((user) => {
+    const remapedUsers = _users.map((user) => {
       if (
         user &&
         typeof user === 'object'
@@ -831,6 +824,14 @@ class Authenticator {
 
       return user
     })
+    const users = pickProps(
+      remapedUsers,
+      projection,
+      {
+        isAppliedProjectionToSubUser,
+        subUsersProjection
+      }
+    )
 
     if (
       !password ||


### PR DESCRIPTION
This PR fixes the `getUsers` endpoint response, `isRestrictedToBeAddedToSubAccount` flag doesn't show the correct state, it should be `true` in a case when the user signed in with the BFX auth token (using BFX username/pwd)