### PR TITLE
Add ability to auto start sync after auto-update of electron app

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -107,8 +107,33 @@ module.exports = (
     assert.strictEqual(res.body.result.email, email)
     assert.strictEqual(res.body.result.isSubAccount, isSubAccount)
     assert.isString(res.body.result.token)
+    assert.isBoolean(res.body.result.shouldNotSyncOnStartupAfterUpdate)
+    assert.isNotOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
 
     auth.token = res.body.result.token
+  })
+
+  it('it should be successfully performed by the updateUser method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'updateUser',
+        params: {
+          shouldNotSyncOnStartupAfterUpdate: true
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
   })
 
   it('it should be successfully performed by the signIn method by token', async function () {
@@ -131,6 +156,8 @@ module.exports = (
     assert.strictEqual(res.body.result.email, email)
     assert.strictEqual(res.body.result.isSubAccount, isSubAccount)
     assert.strictEqual(res.body.result.token, auth.token)
+    assert.isBoolean(res.body.result.shouldNotSyncOnStartupAfterUpdate)
+    assert.isOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
   })
 
   it('it should not be successfully performed by the signIn method', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -355,6 +355,7 @@ module.exports = (
       assert.isString(user.email)
       assert.isBoolean(user.isSubAccount)
       assert.isBoolean(user.isNotProtected)
+      assert.isBoolean(user.isRestrictedToBeAddedToSubAccount)
       assert.isArray(user.subUsers)
 
       user.subUsers.forEach((subUser) => {

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -113,6 +113,14 @@ class SubAccountUpdatingError extends AuthError {
   }
 }
 
+class UserUpdatingError extends AuthError {
+  constructor (message = 'ERR_USER_UPDATE_HAS_BEEN_FAILED') {
+    super(message)
+
+    this.statusMessage = 'User update has been failed'
+  }
+}
+
 class UserRemovingError extends AuthError {
   constructor (message = 'ERR_USER_REMOVE_HAS_BEEN_FAILED') {
     super(message)
@@ -235,6 +243,7 @@ module.exports = {
   MigrationLaunchingError,
   SubAccountCreatingError,
   SubAccountUpdatingError,
+  UserUpdatingError,
   UserRemovingError,
   UserWasPreviouslyStoredInDbError,
   SubAccountLedgersBalancesRecalcError,

--- a/workers/loc.api/process.message.manager/index.js
+++ b/workers/loc.api/process.message.manager/index.js
@@ -278,6 +278,28 @@ class ProcessMessageManager {
       { backupFilesMetadata }
     )
   }
+
+  async [PROCESS_STATES.REQUEST_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE] (err, state, data) {
+    if (err) {
+      this.logger.debug('[Users sync on startup required state has not been updated]')
+      this.logger.error(err)
+
+      this.sendState(
+        PROCESS_MESSAGES.RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE,
+        { err }
+      )
+
+      return
+    }
+
+    const isDone = await this.dao
+      .updateUsersSyncOnStartupRequiredState()
+
+    this.sendState(
+      PROCESS_MESSAGES.RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE,
+      { isDone }
+    )
+  }
 }
 
 decorateInjectable(ProcessMessageManager, depsTypes)

--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -26,5 +26,7 @@ module.exports = {
   REQUEST_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'request:migration-has-failed:what-should-be-done',
   REQUEST_SHOULD_ALL_TABLES_BE_REMOVED: 'request:should-all-tables-be-removed',
 
-  RESPONSE_GET_BACKUP_FILES_METADATA: 'response:get-backup-files-metadata'
+  RESPONSE_GET_BACKUP_FILES_METADATA: 'response:get-backup-files-metadata',
+
+  RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE: 'response:update-users-sync-on-startup-required-state'
 }

--- a/workers/loc.api/process.message.manager/process.states.js
+++ b/workers/loc.api/process.message.manager/process.states.js
@@ -9,5 +9,7 @@ module.exports = {
 
   RESPONSE_MIGRATION_HAS_FAILED_WHAT_SHOULD_BE_DONE: 'response:migration-has-failed:what-should-be-done',
 
-  REQUEST_GET_BACKUP_FILES_METADATA: 'request:get-backup-files-metadata'
+  REQUEST_GET_BACKUP_FILES_METADATA: 'request:get-backup-files-metadata',
+
+  REQUEST_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE: 'request:update-users-sync-on-startup-required-state'
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -104,7 +104,7 @@ class FrameworkReportService extends ReportService {
       )
 
       if (
-        shouldNotSyncOnStartupAfterUpdate &&
+        !shouldNotSyncOnStartupAfterUpdate &&
         isSyncOnStartupRequired
       ) {
         await this._sync.start({

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -189,6 +189,12 @@ class FrameworkReportService extends ReportService {
     }, 'removeUser', args, cb)
   }
 
+  updateUser (space, args, cb) {
+    return this._responder(() => {
+      return this._authenticator.updateUser(args)
+    }, 'updateUser', args, cb)
+  }
+
   createSubAccount (space, args, cb) {
     return this._responder(() => {
       checkParams(args, 'paramsSchemaForCreateSubAccount')

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -90,8 +90,36 @@ class FrameworkReportService extends ReportService {
   }
 
   signIn (space, args, cb) {
-    return this._responder(() => {
-      return this._authenticator.signIn(args)
+    return this._responder(async () => {
+      const {
+        _id,
+        email,
+        isSubAccount,
+        token,
+        shouldNotSyncOnStartupAfterUpdate,
+        isSyncOnStartupRequired
+      } = await this._authenticator.signIn(
+        args,
+        { isReturnedUser: true }
+      )
+
+      if (
+        shouldNotSyncOnStartupAfterUpdate &&
+        isSyncOnStartupRequired
+      ) {
+        await this._sync.start({
+          syncColls: this._ALLOWED_COLLS.ALL,
+          isSolveAfterRedirToApi: true,
+          ownerUserId: _id
+        })
+      }
+
+      return {
+        email,
+        isSubAccount,
+        token,
+        shouldNotSyncOnStartupAfterUpdate
+      }
     }, 'signIn', args, cb)
   }
 

--- a/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
+++ b/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
@@ -22,6 +22,8 @@ module.exports = (session, isReturnedPassword) => {
     'isSubUser',
     'subUsers',
     'token',
+    'shouldNotSyncOnStartupAfterUpdate',
+    'isSyncOnStartupRequired',
     ...passwordProp
   ]
   const { subUsers: reqSubUsers } = { ...session }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -1003,8 +1003,8 @@ class Authenticator {
       : this.getUserSessionByEmail({ email, isSubAccount })?.token
 
     if (
-      existedToken &&
-      typeof existedToken === 'string'
+      !existedToken ||
+      typeof existedToken !== 'string'
     ) {
       return true
     }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -264,7 +264,9 @@ class Authenticator {
       authToken,
       apiKey,
       apiSecret,
-      password
+      password,
+      shouldNotSyncOnStartupAfterUpdate,
+      isSyncOnStartupRequired
     } = user ?? {}
 
     let newAuthToken = null
@@ -391,7 +393,9 @@ class Authenticator {
       ...returnedUser,
       email: emailFromApi,
       isSubAccount: isSubAccountFromDb,
-      token: createdToken
+      token: createdToken,
+      shouldNotSyncOnStartupAfterUpdate,
+      isSyncOnStartupRequired
     }
   }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -14,6 +14,7 @@ const {
   isSubAccountApiKeys
 } = require('../../helpers')
 const {
+  UserUpdatingError,
   UserRemovingError,
   UserWasPreviouslyStoredInDbError,
   AuthTokenGenerationError
@@ -991,7 +992,7 @@ class Authenticator {
     )
 
     if (res && res.changes < 1) {
-      throw new AuthError()
+      throw new UserUpdatingError()
     }
 
     const existedToken = (
@@ -1005,11 +1006,13 @@ class Authenticator {
       existedToken &&
       typeof existedToken === 'string'
     ) {
-      return
+      return true
     }
 
     const session = this.userSessions.get(existedToken)
     Object.assign(session, freshUserData)
+
+    return true
   }
 
   setUserSession (user) {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -956,6 +956,30 @@ class BetterSqliteDAO extends DAO {
   /**
    * @override
    */
+  async updateUsersSyncOnStartupRequiredState (opts) {
+    const {
+      doNotQueueQuery = false,
+      withWorkerThreads = false
+    } = opts ?? {}
+
+    await this.updateCollBy(
+      this.TABLES_NAMES.USERS,
+      {
+        $or: {
+          $isNull: 'shouldNotSyncOnStartupAfterUpdate',
+          $eq: { shouldNotSyncOnStartupAfterUpdate: 0 }
+        }
+      },
+      { isSyncOnStartupRequired: 1 },
+      { withWorkerThreads, doNotQueueQuery }
+    )
+
+    return true
+  }
+
+  /**
+   * @override
+   */
   getElemsInCollBy (
     collName,
     {

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -138,6 +138,11 @@ class DAO {
   /**
    * @abstract
    */
+  async updateUsersSyncOnStartupRequiredState () { throw new ImplementationError() }
+
+  /**
+   * @abstract
+   */
   async updateCollBy () { throw new ImplementationError() }
 
   /**

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -135,6 +135,7 @@ class DbMigrator {
 
     await this.dbBackupManager.backupDb({ currVer, supportedVer })
     await this.migrate(versions, isDown)
+    await this.dao.updateUsersSyncOnStartupRequiredState()
   }
 }
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v33.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v33.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+const {
+  ID_PRIMARY_KEY
+} = require('./helpers/const')
+
+class MigrationV33 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE users ADD COLUMN shouldNotSyncOnStartupAfterUpdate INT',
+      'ALTER TABLE users ADD COLUMN isSyncOnStartupRequired INT',
+
+      'UPDATE users SET shouldNotSyncOnStartupAfterUpdate = 0',
+      'UPDATE users SET isSyncOnStartupRequired = 0'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'users',
+        {
+          _id: ID_PRIMARY_KEY,
+          id: 'BIGINT',
+          email: 'VARCHAR(255)',
+          apiKey: 'VARCHAR(255)',
+          apiSecret: 'VARCHAR(255)',
+          authToken: 'VARCHAR(255)',
+          active: 'INT',
+          isDataFromDb: 'INT',
+          timezone: 'VARCHAR(255)',
+          username: 'VARCHAR(255)',
+          passwordHash: 'VARCHAR(255)',
+          isNotProtected: 'INT',
+          isSubAccount: 'INT',
+          isSubUser: 'INT',
+          createdAt: 'BIGINT',
+          updatedAt: 'BIGINT'
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV33

--- a/workers/loc.api/sync/dao/helpers/users/normalize-user-data.js
+++ b/workers/loc.api/sync/dao/helpers/users/normalize-user-data.js
@@ -7,8 +7,10 @@ const _normalize = (userData) => {
     isSubAccount,
     isSubUser,
     haveSubUsers,
-    isNotProtected
-  } = { ...userData }
+    isNotProtected,
+    shouldNotSyncOnStartupAfterUpdate,
+    isSyncOnStartupRequired
+  } = userData ?? {}
 
   return {
     ...userData,
@@ -17,7 +19,9 @@ const _normalize = (userData) => {
     isSubAccount: !!isSubAccount,
     isSubUser: !!isSubUser,
     haveSubUsers: !!haveSubUsers,
-    isNotProtected: !!isNotProtected
+    isNotProtected: !!isNotProtected,
+    shouldNotSyncOnStartupAfterUpdate: !!shouldNotSyncOnStartupAfterUpdate,
+    isSyncOnStartupRequired: !!isSyncOnStartupRequired
   }
 }
 

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -290,10 +290,10 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
     const dataInserter = this.getDataInserter()
     const auth = dataInserter
       ? dataInserter.getAuth()
-      : await getAuthFromDb(
-        this.authenticator,
-        { shouldGetEveryone: true }
-      )
+      : (await getAuthFromDb(
+          this.authenticator,
+          { shouldGetEveryone: true }
+        )).syncAuth
 
     if (
       !auth ||

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -49,6 +49,7 @@ const depsTypes = (TYPES) => [
   TYPES.ApiMiddleware,
   TYPES.SyncSchema,
   TYPES.ALLOWED_COLLS,
+  TYPES.TABLES_NAMES,
   TYPES.Authenticator,
   TYPES.ConvertCurrencyHook,
   TYPES.RecalcSubAccountLedgersBalancesHook,
@@ -66,6 +67,7 @@ class DataInserter extends EventEmitter {
     apiMiddleware,
     syncSchema,
     ALLOWED_COLLS,
+    TABLES_NAMES,
     authenticator,
     convertCurrencyHook,
     recalcSubAccountLedgersBalancesHook,
@@ -83,6 +85,7 @@ class DataInserter extends EventEmitter {
     this.apiMiddleware = apiMiddleware
     this.syncSchema = syncSchema
     this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.TABLES_NAMES = TABLES_NAMES
     this.authenticator = authenticator
     this.convertCurrencyHook = convertCurrencyHook
     this.recalcSubAccountLedgersBalancesHook = recalcSubAccountLedgersBalancesHook
@@ -96,6 +99,7 @@ class DataInserter extends EventEmitter {
 
     this._asyncProgressHandlers = []
     this._auth = null
+    this._sessionAuth = null
     this._allowedCollsNames = getAllowedCollsNames(
       this.ALLOWED_COLLS
     )
@@ -166,13 +170,15 @@ class DataInserter extends EventEmitter {
       return
     }
 
-    this._auth = await getAuthFromDb(
+    const { sessionAuth, syncAuth } = await getAuthFromDb(
       this.authenticator,
       {
         ownerUserId: this.ownerUserId,
         isOwnerScheduler: this.isOwnerScheduler
       }
     )
+    this._auth = syncAuth
+    this._sessionAuth = sessionAuth
 
     if (
       !this._auth ||
@@ -923,7 +929,42 @@ class DataInserter extends EventEmitter {
           isNotInTrans: true,
           doNotQueueQuery: true
         })
+
+      await this._setUserSyncState()
     })
+  }
+
+  async _setUserSyncState () {
+    const didNotAllCollsSync = this.syncColls
+      .some((collName) => collName === this.ALLOWED_COLLS.ALL)
+
+    if (
+      didNotAllCollsSync ||
+      !(this._sessionAuth instanceof Map) ||
+      this._sessionAuth.size === 0
+    ) {
+      return
+    }
+
+    const userIds = [...this._sessionAuth].reduce((accum, curr) => {
+      const { _id, isSyncOnStartupRequired } = curr ?? {}
+
+      if (isSyncOnStartupRequired) {
+        accum.push(_id)
+      }
+
+      return accum
+    }, [])
+
+    if (userIds.length === 0) {
+      return
+    }
+
+    await this.dao.updateCollBy(
+      this.TABLES_NAMES.USERS,
+      { $in: { _id: userIds } },
+      { isSyncOnStartupRequired: false }
+    )
   }
 
   _addAfterAllInsertsHooks (hook, opts) {

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -930,13 +930,13 @@ class DataInserter extends EventEmitter {
           doNotQueueQuery: true
         })
 
-      await this._setUserSyncState()
+      await this._setUserSyncState({ doNotQueueQuery: true })
     })
   }
 
-  async _setUserSyncState () {
+  async _setUserSyncState (opts) {
     const didNotAllCollsSync = this.syncColls
-      .some((collName) => collName === this.ALLOWED_COLLS.ALL)
+      .every((collName) => collName !== this.ALLOWED_COLLS.ALL)
 
     if (
       didNotAllCollsSync ||
@@ -946,8 +946,8 @@ class DataInserter extends EventEmitter {
       return
     }
 
-    const userIds = [...this._sessionAuth].reduce((accum, curr) => {
-      const { _id, isSyncOnStartupRequired } = curr ?? {}
+    const userIds = [...this._sessionAuth].reduce((accum, [key, val]) => {
+      const { _id, isSyncOnStartupRequired } = val ?? {}
 
       if (isSyncOnStartupRequired) {
         accum.push(_id)
@@ -963,7 +963,8 @@ class DataInserter extends EventEmitter {
     await this.dao.updateCollBy(
       this.TABLES_NAMES.USERS,
       { $in: { _id: userIds } },
-      { isSyncOnStartupRequired: false }
+      { isSyncOnStartupRequired: 0 },
+      opts
     )
   }
 

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -63,6 +63,8 @@ const _models = new Map([
       isNotProtected: 'INT',
       isSubAccount: 'INT',
       isSubUser: 'INT',
+      shouldNotSyncOnStartupAfterUpdate: 'INT',
+      isSyncOnStartupRequired: 'INT',
       createdAt: 'BIGINT',
       updatedAt: 'BIGINT',
 

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 32
+const SUPPORTED_DB_VERSION = 33
 
 const TABLES_NAMES = require('./tables-names')
 const {


### PR DESCRIPTION
This PR adds ability to auto-start sync after the auto-update of the electron app. The idea is to have a configurable option (by default turned on) to force sync after the auto-update or DB migration due to changes in the DB schema, the aim is to bring data consistency after significant updates. But the user can turn the option off via the settings menu.

---

The flow:
- in the user table, there's `shouldNotSyncOnStartupAfterUpdate` flag used to turn on/off the option
- in the user table, there's `isSyncOnStartupRequired` flag used to request sync
- if the auto-update or DB migration takes place, `isSyncOnStartupRequired=true` will be set
- and then after sign-in for each user the sync will be force pushed
- and then after sync `isSyncOnStartupRequired=flase` will be reset
- for the electron app adds the ability to request sync via ipc channel for covering auto-update point

---

Basic changes:
- adds ability to auto-start sync after the DB migration
- adds ability to auto-start sync after the auto-update via ipc channel
- adds v33 DB migration
- adds corresponding test coverage
- adds ability to turn on/off the option, for it should be used:
  - to get current state:
    - `singIn` request:
    ```jsonc
    {
      "method": "signIn",
      "auth": {
        "token": "f19ab177-29e7-4c58-bfa0-36e9707a6977"
      }
    }
    ```
    - `signIn` response:
    ```jsonc
    {
      "jsonrpc": "2.0",
      "result": {
        "email": "user@email.com",
        "isSubAccount": false,
        "token": "f19ab177-29e7-4c58-bfa0-36e9707a6977",
        "shouldNotSyncOnStartupAfterUpdate": false // the flag
      },
      "id": null
    }
    ```
  - to change the opt flag:
    - `updateUser` request:
    ```jsonc
    {
      "method": "updateUser",
      "auth": {
        "token": "f19ab177-29e7-4c58-bfa0-36e9707a6977"
      },
      "params": {
        "shouldNotSyncOnStartupAfterUpdate": true
      }
    }
    ```
    - `updateUser` response:
    ```jsonc
    {
      "jsonrpc": "2.0",
      "result": true,
      "id": null
    }
    ```
