### PR TITLE
Add proxy endpoints for login/verify links

### DIFF
--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -47,8 +47,17 @@ const getMockDataOpts = () => ({
   ...getBaseMockDataOpts(),
   candles: { limit: 500 },
   generate_token: null,
-  delete_token: null
+  delete_token: null,
+  login: null,
+  login_verify: null
 })
+
+const getExtraMockMethods = () => (new Map([
+  ['post', {
+    '/v2/login': 'login',
+    '/v2/login/verify': 'login_verify'
+  }]
+]))
 
 const createMockRESTv2SrvWithDate = (
   start = Date.now(),
@@ -57,7 +66,8 @@ const createMockRESTv2SrvWithDate = (
   opts = getMockDataOpts(),
   {
     _getMockData = getMockData,
-    _setDataTo = setDataTo
+    _setDataTo = setDataTo,
+    extraMockMethods = getExtraMockMethods()
   } = {}
 ) => {
   return _createMockRESTv2SrvWithDate(
@@ -67,7 +77,8 @@ const createMockRESTv2SrvWithDate = (
     opts,
     {
       _getMockData,
-      _setDataTo
+      _setDataTo,
+      extraMockMethods
     }
   )
 }

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -7,6 +7,25 @@ const _ms = Date.now()
 module.exports = new Map([
   ...mockData,
   [
+    'login',
+    [
+      '12345678-8888-4321-1234-8cb090a01360',
+      [
+        [
+          'otp',
+          true
+        ]
+      ]
+    ]
+  ],
+  [
+    'login_verify',
+    [
+      'pub:api:88888888-4444-4444-4444-121212121212-caps:s:o:f:w:wd:a-write',
+      '2023-03-21T12:00:00.000Z'
+    ]
+  ],
+  [
     'generate_token',
     ['pub:api:88888888-4444-4444-4444-121212121212-caps:s:o:f:w:wd:a-write']
   ],

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -110,6 +110,31 @@ module.exports = (
     assert.isBoolean(res.body.result[1][0][1])
   })
 
+  it('it should be successfully performed by the verifyOnBFX method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth: {
+          loginToken: '12345678-8888-4321-1234-8cb090a01360',
+          token: '123456',
+          verifyMethod: 'otp'
+        },
+        method: 'verifyOnBFX',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isString(res.body.result[0])
+    assert.isString(res.body.result[1])
+  })
+
   it('it should be successfully performed by the signIn method', async function () {
     this.timeout(5000)
 

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -83,6 +83,33 @@ module.exports = (
     assert.isOk(res.body.result)
   })
 
+  it('it should be successfully performed by the loginToBFX method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth: {
+          login: 'user-name',
+          password: 'user-pwd'
+        },
+        method: 'loginToBFX',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isString(res.body.result[0])
+    assert.isArray(res.body.result[1])
+    assert.isArray(res.body.result[1][0])
+    assert.isString(res.body.result[1][0][0])
+    assert.isBoolean(res.body.result[1][0][1])
+  })
+
   it('it should be successfully performed by the signIn method', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -115,6 +115,7 @@ const Crypto = require('../sync/crypto')
 const Authenticator = require('../sync/authenticator')
 const privResponder = require('../responder')
 const ProcessMessageManager = require('../process.message.manager')
+const HTTPRequest = require('../http.request')
 
 decorate(injectable(), EventEmitter)
 
@@ -157,7 +158,8 @@ module.exports = ({
           ['_dataConsistencyChecker', TYPES.DataConsistencyChecker],
           ['_winLossVSAccountBalance', TYPES.WinLossVSAccountBalance],
           ['_weightedAveragesReport', TYPES.WeightedAveragesReport],
-          ['_getDataFromApi', TYPES.GetDataFromApi]
+          ['_getDataFromApi', TYPES.GetDataFromApi],
+          ['_httpRequest', TYPES.HTTPRequest]
         ]
       })
     rebind(TYPES.RServiceDepsSchemaAliase)
@@ -196,6 +198,9 @@ module.exports = ({
     bind(TYPES.GRC_BFX_OPTS).toConstantValue(grcBfxOpts)
     bind(TYPES.ProcessMessageManager)
       .to(ProcessMessageManager)
+      .inSingletonScope()
+    bind(TYPES.HTTPRequest)
+      .to(HTTPRequest)
       .inSingletonScope()
     bind(TYPES.WSTransport)
       .to(WSTransport)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -69,5 +69,6 @@ module.exports = {
   SyncUserStepData: Symbol.for('SyncUserStepData'),
   SyncUserStepDataFactory: Symbol.for('SyncUserStepDataFactory'),
   WeightedAveragesReport: Symbol.for('WeightedAveragesReport'),
-  WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter')
+  WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter'),
+  HTTPRequest: Symbol.for('HTTPRequest')
 }

--- a/workers/loc.api/http.request/helpers.js
+++ b/workers/loc.api/http.request/helpers.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const {
+  AuthError
+} = require('bfx-report/workers/loc.api/errors')
+
+const isAuthApiError = (err) => {
+  return /ERR_AUTH_API/.test(err.toString())
+}
+
+const makeRequestToBFX = async (requestFn) => {
+  try {
+    return await requestFn()
+  } catch (err) {
+    if (isAuthApiError(err)) {
+      throw new AuthError()
+    }
+
+    throw err
+  }
+}
+
+module.exports = {
+  isAuthApiError,
+  makeRequestToBFX
+}

--- a/workers/loc.api/http.request/index.js
+++ b/workers/loc.api/http.request/index.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const { RESTv2 } = require('bfx-api-node-rest')
+
+const {
+  makeRequestToBFX
+} = require('./helpers')
+
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.CONF
+]
+class HTTPRequest {
+  constructor (
+    conf
+  ) {
+    this.conf = conf
+
+    this._TEST_REST_URL = 'http://localhost:9999'
+    this._isTestEnv = process.env.NODE_ENV === 'test'
+
+    this._transportCache = new Map()
+    this.getRequest() // Init default cache
+  }
+
+  getRequest (opts = {}) {
+    const key = JSON.stringify(opts)
+
+    const _opts = {
+      transform: true,
+      url: this._isTestEnv
+        ? this._TEST_REST_URL
+        : this.conf?.restUrl,
+      ...opts
+    }
+
+    if (this._transportCache.has(key)) {
+      return this._transportCache.get(key)
+    }
+
+    const rest = new ExpandedRESTv2(_opts)
+    this._transportCache.set(key, rest)
+
+    return rest
+  }
+}
+
+class ExpandedRESTv2 extends RESTv2 {
+  async login (body) {
+    return makeRequestToBFX(() => this
+      ._makePublicPostRequest('/login', body))
+  }
+
+  async verify (body) {
+    return makeRequestToBFX(() => this
+      ._makePublicPostRequest('/login/verify', body))
+  }
+}
+
+decorateInjectable(HTTPRequest, depsTypes)
+
+module.exports = HTTPRequest

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -90,6 +90,13 @@ class FrameworkReportService extends ReportService {
     }, 'loginToBFX', args, cb)
   }
 
+  verifyOnBFX (space, args, cb) {
+    return this._responder(() => {
+      return this._httpRequest.getRequest()
+        .verify(args?.params)
+    }, 'verifyOnBFX', args, cb)
+  }
+
   signUp (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.signUp(args)

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -83,6 +83,13 @@ class FrameworkReportService extends ReportService {
     }
   }
 
+  loginToBFX (space, args, cb) {
+    return this._responder(() => {
+      return this._httpRequest.getRequest()
+        .login(args?.params)
+    }, 'loginToBFX', args, cb)
+  }
+
   signUp (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.signUp(args)


### PR DESCRIPTION
This PR adds `login/verify` proxy endpoints to resolve the `CORS` issue for the dev mode of the BFX `username/pwd` auth for the following links:
- https://api-pub.bitfinex.com/v2/login
- https://api-pub.bitfinex.com/v2/login/verify

---

`loginToBFX` request example
```jsonc
{
  "method": "loginToBFX",
  "params": {
    "login": "user-name",
    "password": "user-pwd"
  }
}
```

`loginToBFX` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": [
    "12345678-8888-4321-1234-8cb090a01360",
    [
      [
        "otp",
        true
      ]
    ]
  ],
  "id": null
}
```

`loginToBFX` response example if wrong login
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 401,
    "message": "Unauthorized",
    "data": null
  },
  "id": null
}
```

`verifyOnBFX` request example
```jsonc
{
  "method": "verifyOnBFX",
  "params": {
    "loginToken": "12345678-8888-4321-1234-8cb090a01360",
    "token": "123456",
    "verifyMethod": "otp"
  }
}
```

`verifyOnBFX` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": [
    "pub:api:12345678-9999-5555-1234-5499998e10ff-caps:s:o:f:w:wd:a-write",
    "2023-03-21T12:00:00.000Z"
  ],
  "id": null
}
```

`verifyOnBFX` response example if wrong token
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 401,
    "message": "Unauthorized",
    "data": null
  },
  "id": null
}
```

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/286