### PR TITLE
Disallow user removal when sync going

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -125,10 +125,18 @@ class UserUpdatingError extends AuthError {
 }
 
 class UserRemovingError extends AuthError {
-  constructor (message = 'ERR_USER_REMOVE_HAS_BEEN_FAILED') {
+  constructor (message = 'ERR_USER_REMOVAL_HAS_BEEN_FAILED') {
     super(message)
 
-    this.statusMessage = 'User remove has been failed'
+    this.statusMessage = 'User removal has been failed'
+  }
+}
+
+class UserRemovingDuringSyncError extends UserRemovingError {
+  constructor (message = 'USER_REMOVAL_HAS_BEEN_DISALLOWED_DURING_SYNC') {
+    super(message)
+
+    this.statusMessage = 'User removal has been disallowed during sync'
   }
 }
 
@@ -250,6 +258,7 @@ module.exports = {
   SubAccountUpdatingError,
   UserUpdatingError,
   UserRemovingError,
+  UserRemovingDuringSyncError,
   UserWasPreviouslyStoredInDbError,
   SubAccountLedgersBalancesRecalcError,
   DatePropNameError,

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -16,6 +16,7 @@ const {
 const {
   UserUpdatingError,
   UserRemovingError,
+  UserRemovingDuringSyncError,
   UserWasPreviouslyStoredInDbError,
   AuthTokenGenerationError
 } = require('../../errors')
@@ -24,6 +25,7 @@ const {
   pickProps,
   pickSessionProps
 } = require('./helpers')
+const Progress = require('../progress')
 
 const { decorateInjectable } = require('../../di/utils')
 
@@ -926,6 +928,12 @@ class Authenticator {
         }
       }
     )
+    const progress = await Progress
+      .getNonEstimatedProgress(this.dao, this.TABLES_NAMES)
+
+    if (progress < 100) {
+      throw new UserRemovingDuringSyncError()
+    }
 
     const res = await this.dao.removeElemsFromDb(
       this.TABLES_NAMES.USERS,

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -74,15 +74,22 @@ class Progress extends EventEmitter {
   }
 
   async getProgress () {
-    const progressObj = await this.dao
-      .getElemInCollBy(this.TABLES_NAMES.PROGRESS)
+    const progress = await this.constructor
+      .getNonEstimatedProgress(this.dao, this.TABLES_NAMES)
+    const estimatedSyncTime = this._estimateSyncTime({ progress })
+
+    return estimatedSyncTime
+  }
+
+  static async getNonEstimatedProgress (dao, TABLES_NAMES) {
+    const progressObj = await dao
+      .getElemInCollBy(TABLES_NAMES.PROGRESS)
 
     const progress = typeof progressObj?.value === 'string'
       ? tryParseJSON(progressObj.value, true)
       : 'SYNCHRONIZATION_HAS_NOT_STARTED_YET'
-    const estimatedSyncTime = this._estimateSyncTime({ progress })
 
-    return estimatedSyncTime
+    return progress
   }
 
   activateSyncTimeEstimate () {


### PR DESCRIPTION
This PR disallows user removal when sync going to prevent unexpected behavior

---

- `removeUser` request example:
```jsonc
{
    "auth": {
      "token": "1583c652-672a-49e7-8d5c-99825eb4e944"
    },
    "method": "removeUser"
}
```

- `removeUser` response example when sync going:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 401,
    "message": "User removal has been disallowed during sync",
    "data": null
  },
  "id": null
}
```