### PR TITLE
Pass selected authToken TTL

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -581,9 +581,11 @@ module.exports = (
 
       assert.isObject(res.body)
       assert.propertyVal(res.body, 'id', 5)
-      assert.isArray(res.body.result)
+      assert.isObject(res.body.result)
+      assert.isArray(res.body.result.res)
+      assert.isBoolean(res.body.result.nextPage)
 
-      const resItem = res.body.result[0]
+      const resItem = res.body.result.res[0]
 
       assert.isObject(resItem)
       assert.containsAllKeys(resItem, [

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -165,7 +165,7 @@ module.exports = (
     auth.token = res.body.result.token
   })
 
-  it('it should be successfully performed by the updateUser method', async function () {
+  it('it should be successfully performed by the updateUser method for shouldNotSyncOnStartupAfterUpdate field', async function () {
     this.timeout(5000)
 
     const res = await agent
@@ -186,6 +186,53 @@ module.exports = (
     assert.propertyVal(res.body, 'id', 5)
     assert.isBoolean(res.body.result)
     assert.isOk(res.body.result)
+  })
+
+  it('it should be successfully performed by the updateUser method for authTokenTTLSec field', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'updateUser',
+        params: {
+          authTokenTTLSec: 7 * 24 * 60 * 60
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
+  })
+
+  it('it should not be successfully performed by the updateUser method for authTokenTTLSec field', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'updateUser',
+        params: {
+          authTokenTTLSec: 8 * 24 * 60 * 60
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Auth token TTL has been set to disallowed value')
+    assert.propertyVal(res.body, 'id', 5)
   })
 
   it('it should be successfully performed by the signIn method by token', async function () {

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -161,6 +161,7 @@ module.exports = (
     assert.isString(res.body.result.token)
     assert.isBoolean(res.body.result.shouldNotSyncOnStartupAfterUpdate)
     assert.isNotOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
+    assert.isNull(res.body.result.authTokenTTLSec)
 
     auth.token = res.body.result.token
   })
@@ -257,6 +258,7 @@ module.exports = (
     assert.strictEqual(res.body.result.token, auth.token)
     assert.isBoolean(res.body.result.shouldNotSyncOnStartupAfterUpdate)
     assert.isOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
+    assert.isNumber(res.body.result.authTokenTTLSec)
   })
 
   it('it should not be successfully performed by the signIn method', async function () {

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -239,8 +239,12 @@ class AuthTokenGenerationError extends AuthError {
 }
 
 class AuthTokenTTLSettingError extends ArgsParamsError {
-  constructor (message = 'AUTH_TOKEN_TTL_HAS_BEEN_SET_TO_DISALLOWED_VALUE') {
-    super(message)
+  constructor (args) {
+    const _args = getErrorArgs(args, 'AUTH_TOKEN_TTL_HAS_BEEN_SET_TO_DISALLOWED_VALUE')
+
+    super(_args)
+
+    this.statusMessage = 'Auth token TTL has been set to disallowed value'
   }
 }
 

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -238,6 +238,12 @@ class AuthTokenGenerationError extends AuthError {
   }
 }
 
+class AuthTokenTTLSettingError extends ArgsParamsError {
+  constructor (message = 'AUTH_TOKEN_TTL_HAS_BEEN_SET_TO_DISALLOWED_VALUE') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -273,5 +279,6 @@ module.exports = {
   SyncQueueIDSettingError,
   LastSyncedInfoGettingError,
   SyncInfoUpdatingError,
-  AuthTokenGenerationError
+  AuthTokenGenerationError,
+  AuthTokenTTLSettingError
 }

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -111,7 +111,8 @@ class FrameworkReportService extends ReportService {
         isSubAccount,
         token,
         shouldNotSyncOnStartupAfterUpdate,
-        isSyncOnStartupRequired
+        isSyncOnStartupRequired,
+        authTokenTTLSec
       } = await this._authenticator.signIn(
         args,
         { isReturnedUser: true }
@@ -132,7 +133,8 @@ class FrameworkReportService extends ReportService {
         email,
         isSubAccount,
         token,
-        shouldNotSyncOnStartupAfterUpdate
+        shouldNotSyncOnStartupAfterUpdate,
+        authTokenTTLSec
       }
     }, 'signIn', args, cb)
   }

--- a/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
+++ b/workers/loc.api/sync/authenticator/helpers/pick-session-props.js
@@ -24,6 +24,7 @@ module.exports = (session, isReturnedPassword) => {
     'token',
     'shouldNotSyncOnStartupAfterUpdate',
     'isSyncOnStartupRequired',
+    'authTokenTTLSec',
     ...passwordProp
   ]
   const { subUsers: reqSubUsers } = { ...session }

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -986,7 +986,8 @@ class Authenticator {
       args?.params,
       [
         'shouldNotSyncOnStartupAfterUpdate',
-        'isSyncOnStartupRequired'
+        'isSyncOnStartupRequired',
+        'authTokenTTLSec'
       ]
     )
     const {

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -994,7 +994,8 @@ class Authenticator {
 
     const {
       _id,
-      email: emailFromDb
+      email: emailFromDb,
+      authToken
     } = await this.verifyUser(
       {
         auth: {
@@ -1010,6 +1011,22 @@ class Authenticator {
         doNotQueueQuery
       }
     )
+
+    if (Object.keys(freshUserData).length === 0) {
+      return false
+    }
+    if (
+      (
+        !authToken &&
+        !isNil(freshUserData?.authTokenTTLSec)
+      ) ||
+      (
+        authToken &&
+        this._isAuthTokenTTLInvalid(freshUserData?.authTokenTTLSec)
+      )
+    ) {
+      throw new AuthTokenTTLSettingError()
+    }
 
     const res = await this.dao.updateCollBy(
       this.TABLES_NAMES.USERS,

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
-const { pick } = require('lodash')
+const { pick, isNil } = require('lodash')
 const {
   AuthError
 } = require('bfx-report/workers/loc.api/errors')
@@ -125,11 +125,7 @@ class Authenticator {
     }
     if (
       auth?.authToken &&
-      (
-        !Number.isInteger(authTokenTTLSec) ||
-        authTokenTTLSec < this.minAuthTokenTTLSec ||
-        authTokenTTLSec > this.maxAuthTokenTTLSec
-      )
+      this._isAuthTokenTTLInvalid(authTokenTTLSec)
     ) {
       throw new AuthTokenTTLSettingError()
     }
@@ -1415,6 +1411,17 @@ class Authenticator {
     }
 
     return false
+  }
+
+  _isAuthTokenTTLInvalid (authTokenTTLSec) {
+    return (
+      !isNil(authTokenTTLSec) &&
+      (
+        !Number.isInteger(authTokenTTLSec) ||
+        authTokenTTLSec < this.minAuthTokenTTLSec ||
+        authTokenTTLSec > this.maxAuthTokenTTLSec
+      )
+    )
   }
 }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -290,7 +290,8 @@ class Authenticator {
       apiSecret,
       password,
       shouldNotSyncOnStartupAfterUpdate,
-      isSyncOnStartupRequired
+      isSyncOnStartupRequired,
+      authTokenTTLSec
     } = user ?? {}
 
     let newAuthToken = null
@@ -419,7 +420,8 @@ class Authenticator {
       isSubAccount: isSubAccountFromDb,
       token: createdToken,
       shouldNotSyncOnStartupAfterUpdate,
-      isSyncOnStartupRequired
+      isSyncOnStartupRequired,
+      authTokenTTLSec
     }
   }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -123,10 +123,7 @@ class Authenticator {
     ) {
       throw new AuthError()
     }
-    if (
-      auth?.authToken &&
-      this._isAuthTokenTTLInvalid(authTokenTTLSec)
-    ) {
+    if (this._isAuthTokenTTLInvalid(authTokenTTLSec)) {
       throw new AuthTokenTTLSettingError()
     }
     const authToken = auth?.authToken
@@ -994,8 +991,7 @@ class Authenticator {
 
     const {
       _id,
-      email: emailFromDb,
-      authToken
+      email: emailFromDb
     } = await this.verifyUser(
       {
         auth: {
@@ -1015,16 +1011,7 @@ class Authenticator {
     if (Object.keys(freshUserData).length === 0) {
       return false
     }
-    if (
-      (
-        !authToken &&
-        !isNil(freshUserData?.authTokenTTLSec)
-      ) ||
-      (
-        authToken &&
-        this._isAuthTokenTTLInvalid(freshUserData?.authTokenTTLSec)
-      )
-    ) {
+    if (this._isAuthTokenTTLInvalid(freshUserData?.authTokenTTLSec)) {
       throw new AuthTokenTTLSettingError()
     }
 

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -18,7 +18,8 @@ const {
   UserRemovingError,
   UserRemovingDuringSyncError,
   UserWasPreviouslyStoredInDbError,
-  AuthTokenGenerationError
+  AuthTokenGenerationError,
+  AuthTokenTTLSettingError
 } = require('../../errors')
 const {
   generateSubUserName,
@@ -130,7 +131,7 @@ class Authenticator {
         authTokenTTLSec > this.maxAuthTokenTTLSec
       )
     ) {
-      throw new AuthError() // TODO:
+      throw new AuthTokenTTLSettingError()
     }
     const authToken = auth?.authToken
       ? await this.generateAuthToken({

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v34.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v34.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const AbstractMigration = require('./abstract.migration')
+const { getSqlArrToModifyColumns } = require('./helpers')
+
+const {
+  ID_PRIMARY_KEY
+} = require('./helpers/const')
+
+class MigrationV34 extends AbstractMigration {
+  /**
+   * @override
+   */
+  up () {
+    const sqlArr = [
+      'ALTER TABLE users ADD COLUMN authTokenTTLSec INT'
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  beforeDown () { return this.dao.disableForeignKeys() }
+
+  /**
+   * @override
+   */
+  down () {
+    const sqlArr = [
+      ...getSqlArrToModifyColumns(
+        'users',
+        {
+          _id: ID_PRIMARY_KEY,
+          id: 'BIGINT',
+          email: 'VARCHAR(255)',
+          apiKey: 'VARCHAR(255)',
+          apiSecret: 'VARCHAR(255)',
+          authToken: 'VARCHAR(255)',
+          active: 'INT',
+          isDataFromDb: 'INT',
+          timezone: 'VARCHAR(255)',
+          username: 'VARCHAR(255)',
+          passwordHash: 'VARCHAR(255)',
+          isNotProtected: 'INT',
+          isSubAccount: 'INT',
+          isSubUser: 'INT',
+          shouldNotSyncOnStartupAfterUpdate: 'INT',
+          isSyncOnStartupRequired: 'INT',
+          createdAt: 'BIGINT',
+          updatedAt: 'BIGINT'
+        }
+      )
+    ]
+
+    this.addSql(sqlArr)
+  }
+
+  /**
+   * @override
+   */
+  afterDown () { return this.dao.enableForeignKeys() }
+}
+
+module.exports = MigrationV34

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -8,7 +8,7 @@
  * e.g. `migration.v1.js`, where `v1` is `SUPPORTED_DB_VERSION`
  */
 
-const SUPPORTED_DB_VERSION = 33
+const SUPPORTED_DB_VERSION = 34
 
 const TABLES_NAMES = require('./tables-names')
 const {

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -65,6 +65,7 @@ const _models = new Map([
       isSubUser: 'INT',
       shouldNotSyncOnStartupAfterUpdate: 'INT',
       isSyncOnStartupRequired: 'INT',
+      authTokenTTLSec: 'INT',
       createdAt: 'BIGINT',
       updatedAt: 'BIGINT',
 


### PR DESCRIPTION
This PR adds ability to set the selected TTL of the bfx auth token

---

The flow:
- on sign-up `authTokenTTLSec` param can be passed to specify the auth token TTL to override the default value 24h, available values between 24h and 7 days
  - `signUp` request
  ```jsonc
  {
    "method": "signUp",
    "auth": {
      "authToken": "pub:api:12345678-1234-4321-5678-12ab3ba45ab6-caps:s:o:f:w:wd:a-write",
      "isNotProtected": true
    },
    "params": {
      "authTokenTTLSec": 604800
    }
  }
  ```
  - if the value is out of the allowed range an error would be thrown, `signUp` response:
  ```jsonc
  {
    "jsonrpc": "2.0",
    "error": {
      "code": 400,
      "message": "Auth token TTL has been set to disallowed value",
      "data": null
    },
    "id": null
  }
  ```
- the next time, the auth token TTL can be fetched with `signIn` call, response example:
  ```jsonc
  {
    "jsonrpc": "2.0",
    "result": {
      "email": "user@email.com",
      "isSubAccount": false,
      "token": "12345678-1234-4321-5678-a1b234567890",
      "shouldNotSyncOnStartupAfterUpdate": false,
      "authTokenTTLSec": 604800
    },
    "id": null
  }
  ```
- to modify the auth token TTL may be used the `updateUser` endpoint
  -  `updateUser` request
  ```jsonc
  {
      "auth": {
        "token": "12345678-1234-4321-5678-a1b234567890"
      },
      "method": "updateUser",
      "params": {
        "authTokenTTLSec": 601200
      }
  }
  ```
  - `updateUser` response
  ```jsonc
  {
    "jsonrpc": "2.0",
    "result": true,
    "id": null
  }
  ```
- if the value is out of the allowed range an error would be thrown:
  ```jsonc
  {
    "jsonrpc": "2.0",
    "error": {
      "code": 400,
      "message": "Auth token TTL has been set to disallowed value",
      "data": null
    },
    "id": null
  }
  ```

---

Basic changes:
- adds ability to override the default value 24h of the bfx auth token ttl
- adds ability to set `authTokenTTLSec` on sign-up
- adds ability to return `authTokenTTLSec` when sign-in
- adds ability to modify `authTokenTTLSec` field by `updateUser` method
- adds `v34` DB migration
- adds corresponding test coverage
- fixes `getWeightedAveragesReport` test case