### PR TITLE
Add dedicated flag to recognize account registering

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -458,6 +458,7 @@ module.exports = (
       assert.isBoolean(user.isSubAccount)
       assert.isBoolean(user.isNotProtected)
       assert.isBoolean(user.isRestrictedToBeAddedToSubAccount)
+      assert.isBoolean(user.isApiKeysAuth)
       assert.isArray(user.subUsers)
 
       user.subUsers.forEach((subUser) => {

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -194,7 +194,8 @@ class FrameworkReportService extends ReportService {
             'isSubAccount',
             'isNotProtected',
             'subUsers',
-            'isRestrictedToBeAddedToSubAccount'
+            'isRestrictedToBeAddedToSubAccount',
+            'isApiKeysAuth'
           ]
         }
       )

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -850,14 +850,22 @@ class Authenticator {
     const _users = await this.dao.getUsers(filter, opts)
     const remapedUsers = _users.map((user) => {
       if (
-        user &&
-        typeof user === 'object'
+        !user ||
+        typeof user !== 'object'
       ) {
-        user.isRestrictedToBeAddedToSubAccount = (
-          !!user.authToken ||
-          !!user.isSubAccount
-        )
+        return user
       }
+
+      user.isRestrictedToBeAddedToSubAccount = (
+        !!user.authToken ||
+        !!user.isSubAccount
+      )
+      user.isApiKeysAuth = !!(
+        user.apiKey &&
+        typeof user.apiKey === 'string' &&
+        user.apiSecret &&
+        typeof user.apiSecret === 'string'
+      )
 
       return user
     })


### PR DESCRIPTION
This PR adds a dedicated flag to recognize an account registering type: via API keys or without for the UI porpuses to cover user login flow like the screenshot:

<img width="747" alt="registering_type" src="https://user-images.githubusercontent.com/16489235/233935582-a358427a-28ba-41bb-b773-b737f6941e6c.png">

---

The `isApiKeysAuth` flag adds to the `getUsers` response:
- `getUsers` request example:
```jsonc
{
  "method": "getUsers"
}
```

- `getUsers` response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": [
    {
      "email": "user.one@email.com",
      "isSubAccount": false,
      "isNotProtected": true,
      "subUsers": [],
      "isRestrictedToBeAddedToSubAccount": true,
      "isApiKeysAuth": false // signed up with authToken
    },
    {
      "email": "user.two@email.com",
      "isSubAccount": false,
      "isNotProtected": true,
      "subUsers": [],
      "isRestrictedToBeAddedToSubAccount": false,
      "isApiKeysAuth": true // signed up with API keys
    }
  ],
  "id": null
}
```
