### PR TITLE
Resolve deprecation warning fs.rmdir due to migration nodejs to v16

### DIFF
--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -1,12 +1,8 @@
 'use strict'
 
-const { promisify } = require('util')
-const fs = require('fs')
 const path = require('path')
 const { omit } = require('lodash')
 const request = require('supertest')
-
-const rmdir = promisify(fs.rmdir)
 
 const {
   stopEnvironment
@@ -20,7 +16,8 @@ const {
   startEnvironment
 } = require('./helpers/helpers.boot')
 const {
-  emptyDB
+  emptyDB,
+  rmRf
 } = require('./helpers/helpers.core')
 const {
   createMockRESTv2SrvWithDate
@@ -81,7 +78,7 @@ describe('Sync mode API with SQLite', () => {
 
     mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 100)
 
-    await rmdir(csvDirPath, { recursive: true })
+    await rmRf(csvDirPath)
     await rmAllFiles(tempDirPath, ['README.md'])
     await rmDB(dbDirPath)
     const env = await startEnvironment(false, false, 1)
@@ -101,7 +98,7 @@ describe('Sync mode API with SQLite', () => {
     await stopEnvironment()
     await rmDB(dbDirPath)
     await rmAllFiles(tempDirPath, ['README.md'])
-    await rmdir(csvDirPath, { recursive: true })
+    await rmRf(csvDirPath)
 
     try {
       await mockRESTv2Srv.close()
@@ -119,7 +116,7 @@ describe('Sync mode API with SQLite', () => {
     before(async function () {
       this.timeout(20000)
 
-      await rmdir(csvDirPath, { recursive: true })
+      await rmRf(csvDirPath)
       await rmAllFiles(tempDirPath, ['README.md'])
     })
 

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -1,12 +1,8 @@
 'use strict'
 
-const { promisify } = require('util')
-const fs = require('fs')
 const path = require('path')
 const { omit } = require('lodash')
 const request = require('supertest')
-
-const rmdir = promisify(fs.rmdir)
 
 const {
   stopEnvironment
@@ -20,7 +16,8 @@ const {
   startEnvironment
 } = require('./helpers/helpers.boot')
 const {
-  emptyDB
+  emptyDB,
+  rmRf
 } = require('./helpers/helpers.core')
 const {
   createMockRESTv2SrvWithDate
@@ -80,7 +77,7 @@ describe('Additional sync mode API with SQLite', () => {
 
     mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 100)
 
-    await rmdir(csvDirPath, { recursive: true })
+    await rmRf(csvDirPath)
     await rmAllFiles(tempDirPath, ['README.md'])
     await rmDB(dbDirPath)
     const env = await startEnvironment(false, false, 1)
@@ -100,7 +97,7 @@ describe('Additional sync mode API with SQLite', () => {
     await stopEnvironment()
     await rmDB(dbDirPath)
     await rmAllFiles(tempDirPath, ['README.md'])
-    await rmdir(csvDirPath, { recursive: true })
+    await rmRf(csvDirPath)
 
     try {
       await mockRESTv2Srv.close()
@@ -116,7 +113,7 @@ describe('Additional sync mode API with SQLite', () => {
     before(async function () {
       this.timeout(20000)
 
-      await rmdir(csvDirPath, { recursive: true })
+      await rmRf(csvDirPath)
       await rmAllFiles(tempDirPath, ['README.md'])
     })
 

--- a/test/helpers/helpers.core.js
+++ b/test/helpers/helpers.core.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const fsPromises = require('fs/promises')
+
 const container = require('bfx-report/workers/loc.api/di')
 
 const {
@@ -73,9 +75,15 @@ const getRServiceProxy = (
   })
 }
 
+const rmRf = (path) => fsPromises.rm(path, {
+  recursive: true,
+  force: true
+})
+
 module.exports = {
   emptyDB,
   delay,
   getParamsArrToTestTimeframeGrouping,
-  getRServiceProxy
+  getRServiceProxy,
+  rmRf
 }


### PR DESCRIPTION
This PR removes the deprecation warning due to the migration Nodejs version to `v16.20`. The issue is to need to replace `fs.rmdir` method to `fs.rm` one:

```console
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```