### PR TITLE
Add currency movement info endpoint

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -2437,6 +2437,50 @@ module.exports = (
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getMovementInfo method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMovementInfo',
+        params: {
+          id: 12345
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+
+    assert.containsAllKeys(res.body.result, [
+      'id',
+      'currency',
+      'currencyName',
+      'remark',
+      'mtsStarted',
+      'mtsUpdated',
+      'status',
+      'amount',
+      'fees',
+      'destinationAddress',
+      'memo',
+      'transactionId',
+      'note',
+      'bankFees',
+      'bankRouterId',
+      'externalBankMovId',
+      'externalBankMovStatus',
+      'externalBankMovDescription',
+      'externalBankAccInfo'
+    ])
+  })
+
   it('it should be successfully performed by the getLogins method', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1036,6 +1036,27 @@ class FrameworkReportService extends ReportService {
   /**
    * @override
    */
+  getMovementInfo (space, args, cb) {
+    return this._privResponder(async () => {
+      const res = await this._subAccountApiData
+        .getDataForSubAccount(
+          (args) => super.getMovementInfo(space, args),
+          args,
+          {
+            datePropName: 'mtsUpdated',
+            isNotPreparedResponse: true
+          }
+        )
+
+      return Array.isArray(res)
+        ? res.filter((sRes) => Number.isInteger(sRes?.id))[0] ?? {}
+        : res
+    }, 'getMovementInfo', args, cb)
+  }
+
+  /**
+   * @override
+   */
   getFundingOfferHistory (space, args, cb) {
     return this._privResponder(async () => {
       if (!await this.isSyncModeWithDbData(space, args)) {

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -162,12 +162,12 @@ class SubAccountApiData {
       limit = 10000,
       notThrowError,
       notCheckNextPage
-    } = { ...params }
+    } = params ?? {}
     const {
       datePropName,
       isThrownErrIfAllFail,
       isNotPreparedResponse
-    } = { ...opts }
+    } = opts ?? {}
 
     const errors = []
     const promises = argsArr.map(async (args) => {
@@ -198,16 +198,17 @@ class SubAccountApiData {
     }
 
     const mergedRes = resArr.reduce((accum, curr) => {
-      const { res } = Array.isArray(curr)
-        ? { res: curr }
-        : { ...curr }
+      const res = Array.isArray(curr)
+        ? curr
+        : curr?.res ?? curr ?? {}
 
-      if (
-        Array.isArray(res) &&
-        res.length !== 0
-      ) {
+      if (Array.isArray(res)) {
         accum.push(...res)
+
+        return accum
       }
+
+      accum.push(res)
 
       return accum
     }, [])
@@ -222,11 +223,10 @@ class SubAccountApiData {
       ? orderedRes.slice(0, limit)
       : orderedRes
 
-    const firstElem = { ...limitedRes[0] }
-    const mts = firstElem[datePropName]
+    const firstElem = limitedRes[0]
+    const mts = firstElem?.[datePropName]
     const isNotContainedSameMts = limitedRes.some((item) => {
-      const _item = { ...item }
-      const _mts = _item[datePropName]
+      const _mts = item?.[datePropName]
 
       return _mts !== mts
     })


### PR DESCRIPTION
This PR adds currency movement info endpoint to be able to fetch data for sub-account

---

Basic changes:
- adds `getMovementInfo` endpoint
- adds test coverage for `getMovementInfo` endpoint
- adds ability to fetch movement info for sub-account

---

Request example:
```jsonc
{
  "auth": {
    "token": "user-token"
  },
  "method": "getMovementInfo",
  "params": {
    "id": 12345678
  }
}
```

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "id": 12345678,
    "currency": "UST",
    "currencyName": "TETHERUSE",
    "remark": "0x123456789a12abc1abcde1234ab1a1234abcefg1, canceled by User",
    "mtsStarted": 1614066589000,
    "mtsUpdated": 1614066972000,
    "status": "CANCELED",
    "amount": -21.123,
    "fees": -12.321,
    "destinationAddress": "0x123456789a12abc1abcde1234ab1a1234abcefg1",
    "memo": null,
    "transactionId": null,
    "note": "test 1",
    "bankFees": 0,
    "bankRouterId": null,
    "externalBankMovId": null,
    "externalBankMovStatus": null,
    "externalBankMovDescription": null,
    "externalBankAccInfo": null,
    "_isDataFromApiV2": true
  },
  "id": null
}
```

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/297
