### PR TITLE
Fix sub-account updating for pwd protected account

### DIFF
--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -417,6 +417,10 @@ class SubAccount {
         subUser?.email === email
       ))
 
+      if (subAccountUser?.password) {
+        masterUser.password = subAccountUser.password
+      }
+
       const addingSubUsersAuth = [
         ...addingSubUsers,
         masterUser


### PR DESCRIPTION
This PR fixes sub-account updating for password-protected account
It's necessary to pass the password to the master account if it's passed in the request