### PR TITLE
Return timestamp when last sync was launched

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -126,6 +126,26 @@ module.exports = (
 
   getSyncProgressTestCase(agent, { basePath, auth })
 
+  it('it should be successfully performed by the signIn method, lastSyncMts is integer', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'signIn',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isOk(Number.isInteger(res.body.result.lastSyncMts))
+  })
+
   it('it should be successfully performed by the getBalanceHistory method', async function () {
     this.timeout(5000)
 

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -163,6 +163,7 @@ module.exports = (
     assert.isNotOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
     assert.isNull(res.body.result.authTokenTTLSec)
     assert.isNull(res.body.result.localUsername)
+    assert.isNull(res.body.result.lastSyncMts)
 
     auth.token = res.body.result.token
   })
@@ -260,6 +261,8 @@ module.exports = (
     assert.isBoolean(res.body.result.shouldNotSyncOnStartupAfterUpdate)
     assert.isOk(res.body.result.shouldNotSyncOnStartupAfterUpdate)
     assert.isNumber(res.body.result.authTokenTTLSec)
+    assert.isNull(res.body.result.localUsername)
+    assert.isNull(res.body.result.lastSyncMts)
   })
 
   it('it should not be successfully performed by the signIn method', async function () {
@@ -546,6 +549,26 @@ module.exports = (
   })
 
   getSyncProgressTestCase(agent, { basePath, auth })
+
+  it('it should be successfully performed by the signIn method, lastSyncMts is integer', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'signIn',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isOk(Number.isInteger(res.body.result.lastSyncMts))
+  })
 
   it('it should be successfully performed by the haveCollsBeenSyncedAtLeastOnce method, returns true', async function () {
     this.timeout(60000)

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -130,13 +130,17 @@ class FrameworkReportService extends ReportService {
         })
       }
 
+      const lastFinishedSyncQueueJob = await this._dao
+        .getLastFinishedSyncQueueJob(_id)
+
       return {
         email,
         isSubAccount,
         token,
         shouldNotSyncOnStartupAfterUpdate,
         authTokenTTLSec,
-        localUsername
+        localUsername,
+        lastSyncMts: lastFinishedSyncQueueJob?.updatedAt ?? null
       }
     }, 'signIn', args, cb)
   }

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -46,6 +46,8 @@ const {
   INDEX_FIELD_NAME,
   UNIQUE_INDEX_FIELD_NAME
 } = require('../schema/const')
+const ALLOWED_COLLS = require('../schema/allowed.colls')
+const SYNC_QUEUE_STATES = require('../sync.queue/sync.queue.states')
 const DB_WORKER_ACTIONS = require(
   './sqlite-worker/db-worker-actions/db-worker-actions.const'
 )
@@ -1265,8 +1267,8 @@ class BetterSqliteDAO extends DAO {
 
     const _sort = getOrderQuery([['updatedAt', -1]])
     const where = `WHERE
-      collName = '_ALL' AND
-      state = 'FINISHED' AND
+      collName = '${ALLOWED_COLLS.ALL}' AND
+      state = '${SYNC_QUEUE_STATES.FINISHED_JOB_STATE}' AND
       (ownerUserId = $ownerUserId  OR isOwnerScheduler = 1)`
     const params = { ownerUserId: userId }
 

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -169,6 +169,11 @@ class DAO {
    * @abstract
    */
   async removeElemsLeaveLastNRecords () { throw new ImplementationError() }
+
+  /**
+   * @abstract
+   */
+  async getLastFinishedSyncQueueJob () { throw new ImplementationError() }
 }
 
 decorateInjectable(DAO)


### PR DESCRIPTION
This PR adds ability to return the timestamp when the last sync was launched to add this info to the layouts of the new design

---

Basic changes:
- Implements dao `getLastFinishedSyncQueueJob` method
- Returns mts when last sync was launched in response payload of `signIn` method
- Adds test cases for `lastSyncMts` field

---

Request example:
```jsonc
{
  "method": "signIn",
  "auth": {
    "email": "user@email.com",
    "isSubAccount": false
  }
}
```

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "email": "user@email.com",
    "isSubAccount": false,
    "token": "e4afe3e3-1c96-450d-b8ec-5a604f664893",
    "shouldNotSyncOnStartupAfterUpdate": false,
    "authTokenTTLSec": null,
    "localUsername": null,
    "lastSyncMts": 1686902405802 // added field
  },
  "id": null
}
```