### PR TITLE
Add rate limit router

### DIFF
--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const BaseBfxApiRouter = require(
+  'bfx-report/workers/loc.api/bfx.api.router'
+)
+
+const RateLimitChecker = require('./rate.limit.checker')
+
+const { decorateInjectable } = require('../di/utils')
+
+class BfxApiRouter extends BaseBfxApiRouter {
+  constructor () {
+    super()
+
+    this._rateLimitCheckerMaps = new Map()
+    this._rateLimitForMethodName = new Map([
+      ['generateToken', null],
+      ['invalidateAuthToken', null],
+      ['userInfo', 90],
+      ['symbols', 90],
+      ['futures', 90],
+      ['currencies', 90],
+      ['inactiveSymbols', 90],
+      ['conf', 90],
+      ['positionsSnapshot', 90],
+      ['getSettings', 90],
+      ['updateSettings', 90],
+      ['tickersHistory', 30],
+      ['positionsHistory', 90],
+      ['positions', 90],
+      ['positionsAudit', 90],
+      ['wallets', 90],
+      ['ledgers', 90],
+      ['payInvoiceList', 90],
+      ['accountTrades', 90],
+      ['fundingTrades', 90],
+      ['trades', 90],
+      ['statusMessages', 90],
+      ['candles', 90],
+      ['orderTrades', 90],
+      ['orderHistory', 90],
+      ['activeOrders', 90],
+      ['movements', 90],
+      ['movementInfo', 90],
+      ['fundingOfferHistory', 90],
+      ['fundingLoanHistory', 90],
+      ['fundingCreditHistory', 90],
+      ['accountSummary', 90],
+      ['logins', 90],
+      ['changeLogs', 90]
+    ])
+  }
+
+  /**
+   * @override
+   */
+  route (methodName, method) {
+    if (
+      !methodName ||
+      methodName.startsWith('_')
+    ) {
+      return method()
+    }
+
+    if (!this._rateLimitCheckerMaps.has(methodName)) {
+      const rateLimit = this._rateLimitForMethodName.get(methodName)
+
+      this._rateLimitCheckerMaps.set(
+        methodName,
+        new RateLimitChecker({ rateLimit })
+      )
+    }
+
+    const rateLimitChecker = this._rateLimitCheckerMaps.get(methodName)
+
+    if (rateLimitChecker.check()) {
+      // Cool down delay
+      return new Promise((resolve) => setTimeout(resolve, 60000))
+        .then(() => {
+          rateLimitChecker.add()
+
+          return method()
+        })
+    }
+
+    rateLimitChecker.add()
+
+    return method()
+  }
+}
+
+decorateInjectable(BfxApiRouter)
+
+module.exports = BfxApiRouter

--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -10,6 +10,8 @@ const { decorateInjectable } = require('../di/utils')
 
 const isTestEnv = process.env.NODE_ENV === 'test'
 
+const rateLimitCheckerMaps = new Map()
+
 class BfxApiRouter extends BaseBfxApiRouter {
   constructor () {
     super()
@@ -18,7 +20,6 @@ class BfxApiRouter extends BaseBfxApiRouter {
       ? 0
       : 60000
 
-    this._rateLimitCheckerMaps = new Map()
     this._rateLimitForMethodName = new Map([
       ['generateToken', null],
       ['invalidateAuthToken', null],
@@ -68,16 +69,16 @@ class BfxApiRouter extends BaseBfxApiRouter {
       return method()
     }
 
-    if (!this._rateLimitCheckerMaps.has(methodName)) {
+    if (!rateLimitCheckerMaps.has(methodName)) {
       const rateLimit = this._rateLimitForMethodName.get(methodName)
 
-      this._rateLimitCheckerMaps.set(
+      rateLimitCheckerMaps.set(
         methodName,
         new RateLimitChecker({ rateLimit })
       )
     }
 
-    const rateLimitChecker = this._rateLimitCheckerMaps.get(methodName)
+    const rateLimitChecker = rateLimitCheckerMaps.get(methodName)
 
     if (rateLimitChecker.check()) {
       // Cool down delay

--- a/workers/loc.api/bfx.api.router/rate.limit.checker.js
+++ b/workers/loc.api/bfx.api.router/rate.limit.checker.js
@@ -1,0 +1,37 @@
+'use strict'
+
+class RateLimitChecker {
+  constructor (conf) {
+    this.rateLimit = conf?.rateLimit ?? 10
+    this.msPeriod = conf?.msPeriod ?? 60000
+
+    this._calls = []
+  }
+
+  clearOldCalls (mts = Date.now()) {
+    const min = mts - this.msPeriod
+
+    while (this._calls[0] && this._calls[0] < min) {
+      this._calls.shift()
+    }
+  }
+
+  add () {
+    const mts = Date.now()
+
+    this.clearOldCalls(mts)
+    this._calls.push(mts)
+  }
+
+  getLength () {
+    this.clearOldCalls()
+
+    return this._calls.length
+  }
+
+  check () {
+    return this.getLength() >= this.rateLimit
+  }
+}
+
+module.exports = RateLimitChecker

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -10,7 +10,9 @@ const { bindDepsToFn } = require(
   'bfx-report/workers/loc.api/di/helpers'
 )
 const {
-  getDataFromApi
+  getREST,
+  getDataFromApi,
+  prepareApiResponse
 } = require('bfx-report/workers/loc.api/helpers')
 const responder = require('bfx-report/workers/loc.api/responder')
 
@@ -115,6 +117,7 @@ const Authenticator = require('../sync/authenticator')
 const privResponder = require('../responder')
 const ProcessMessageManager = require('../process.message.manager')
 const HTTPRequest = require('../http.request')
+const BfxApiRouter = require('../bfx.api.router')
 
 decorate(injectable(), EventEmitter)
 
@@ -393,6 +396,24 @@ module.exports = ({
           TYPES.SyncInterrupter,
           TYPES.WSEventEmitter
         ]
+      )
+    )
+    rebind(TYPES.BfxApiRouter)
+      .to(BfxApiRouter)
+      .inSingletonScope()
+    rebind(TYPES.GetREST).toConstantValue(
+      bindDepsToFn(
+        getREST,
+        [
+          TYPES.CONF,
+          TYPES.BfxApiRouter
+        ]
+      )
+    )
+    rebind(TYPES.PrepareApiResponse).toConstantValue(
+      bindDepsToFn(
+        prepareApiResponse,
+        [TYPES.GetREST]
       )
     )
   })

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -22,9 +22,9 @@ class ApiMiddlewareHandlerAfter {
   async [SYNC_API_METHODS.POSITIONS_HISTORY] (
     args,
     apiRes,
-    isCheckCall
+    opts
   ) {
-    if (isCheckCall) {
+    if (opts?.shouldNotApiMiddlewareBeLaunched) {
       return apiRes
     }
 

--- a/workers/loc.api/sync/data.inserter/api.middleware/index.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/index.js
@@ -27,9 +27,15 @@ class ApiMiddleware {
     return typeof this.apiMiddlewareHandlerAfter[method] === 'function'
   }
 
-  async request (method, args, isCheckCall = false) {
+  async request (method, args, opts) {
+    const { shouldNotApiMiddlewareBeLaunched } = opts ?? {}
     const apiRes = await this._requestToReportService(method, args)
-    const res = await this._after(method, args, apiRes, isCheckCall)
+
+    if (shouldNotApiMiddlewareBeLaunched) {
+      return apiRes
+    }
+
+    const res = await this._after(method, args, apiRes, opts)
 
     return res
   }
@@ -44,7 +50,7 @@ class ApiMiddleware {
     return fn(args)
   }
 
-  _after (method, args, apiRes, isCheckCall) {
+  _after (method, args, apiRes, opts) {
     if (!this._hasHandlerAfter(method)) {
       return apiRes
     }
@@ -53,7 +59,7 @@ class ApiMiddleware {
       this.apiMiddlewareHandlerAfter
     )
 
-    return fn(args, apiRes, isCheckCall)
+    return fn(args, apiRes, opts)
   }
 }
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -509,7 +509,8 @@ class DataInserter extends EventEmitter {
     const {
       name: collName,
       dateFieldName,
-      model
+      model,
+      shouldNotApiMiddlewareBeLaunched
     } = schema
 
     const _args = cloneDeep(args)
@@ -542,7 +543,8 @@ class DataInserter extends EventEmitter {
         isInterrupted
       } = await this._getDataFromApi(
         methodApi,
-        currIterationArgs
+        currIterationArgs,
+        shouldNotApiMiddlewareBeLaunched
       )
 
       if (isInterrupted) {
@@ -756,7 +758,8 @@ class DataInserter extends EventEmitter {
 
     const {
       name: collName,
-      projection
+      projection,
+      shouldNotApiMiddlewareBeLaunched
     } = schema
     const _projection = Array.isArray(projection)
       ? projection
@@ -766,7 +769,11 @@ class DataInserter extends EventEmitter {
     const args = this._getMethodArgMap(
       schema,
       { start: null, end: null })
-    const elemsFromApi = await this._getDataFromApi(methodApi, args)
+    const elemsFromApi = await this._getDataFromApi(
+      methodApi,
+      args,
+      shouldNotApiMiddlewareBeLaunched
+    )
 
     if (
       elemsFromApi &&
@@ -809,10 +816,15 @@ class DataInserter extends EventEmitter {
 
     const {
       name: collName,
-      model
+      model,
+      shouldNotApiMiddlewareBeLaunched
     } = schema ?? {}
 
-    const apiRes = await this._getDataFromApi(methodApi, args)
+    const apiRes = await this._getDataFromApi(
+      methodApi,
+      args,
+      shouldNotApiMiddlewareBeLaunched
+    )
     const isApiResObj = (
       apiRes &&
       typeof apiRes === 'object'
@@ -992,7 +1004,11 @@ class DataInserter extends EventEmitter {
     this._afterAllInsertsHooks.push(...hookArr)
   }
 
-  _getDataFromApi (methodApi, args, isCheckCall) {
+  _getDataFromApi (
+    methodApi,
+    args,
+    shouldNotApiMiddlewareBeLaunched
+  ) {
     if (!this.apiMiddleware.hasMethod(methodApi)) {
       throw new FindMethodError()
     }
@@ -1001,7 +1017,7 @@ class DataInserter extends EventEmitter {
       getData: methodApi,
       args,
       middleware: this.apiMiddleware.request.bind(this.apiMiddleware),
-      middlewareParams: isCheckCall,
+      middlewareParams: { shouldNotApiMiddlewareBeLaunched },
       callerName: 'DATA_SYNCER'
     })
   }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -886,8 +886,6 @@ class DataInserter extends EventEmitter {
         const { userId, subUserId } = this._getUserIds(auth)
         const updatesForOneUserPromises = []
 
-        updatesForOneUserPromises.push(setImmediatePromise())
-
         for (const [collName, schema] of methodCollMap) {
           if (
             !Array.isArray(schema?.start) ||
@@ -895,6 +893,8 @@ class DataInserter extends EventEmitter {
           ) {
             continue
           }
+
+          updatesForOneUserPromises.push(setImmediatePromise())
 
           const promise = this.syncUserStepManager.updateOrInsertSyncInfoForCurrColl({
             collName,

--- a/workers/loc.api/sync/schema/sync-schema.js
+++ b/workers/loc.api/sync/schema/sync-schema.js
@@ -175,6 +175,7 @@ const _methodCollMap = new Map([
       hasNewData: false,
       start: [],
       isSyncRequiredAtLeastOnce: false,
+      shouldNotApiMiddlewareBeLaunched: true,
       type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
       model: getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
     }

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -18,7 +18,17 @@ const {
 
 const { decorateInjectable } = require('../../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.GetDataFromApi
+]
+
 class SubAccountApiData {
+  constructor (
+    getDataFromApi
+  ) {
+    this.getDataFromApi = getDataFromApi
+  }
+
   _hasId (id) {
     return (
       Number.isInteger(id) ||
@@ -170,22 +180,27 @@ class SubAccountApiData {
     } = opts ?? {}
 
     const errors = []
-    const promises = argsArr.map(async (args) => {
-      try {
-        const res = await method(args)
+    const resArr = []
 
-        return res
+    for (const args of argsArr) {
+      try {
+        const res = await this.getDataFromApi({
+          getData: (space, args) => method(args),
+          args,
+          callerName: 'SUB_ACCOUNT_API_DATA'
+        })
+
+        resArr.push(res)
       } catch (err) {
         if (isThrownErrIfAllFail) {
           errors.push(err)
 
-          return
+          continue
         }
 
         throw err
       }
-    })
-    const resArr = await Promise.all(promises)
+    }
 
     if (
       errors.length > 0 &&
@@ -320,6 +335,6 @@ class SubAccountApiData {
   }
 }
 
-decorateInjectable(SubAccountApiData)
+decorateInjectable(SubAccountApiData, depsTypes)
 
 module.exports = SubAccountApiData


### PR DESCRIPTION
This PR adds `Rate Limit` router as part of the main logic being extended main [bfx-report#314](https://github.com/bitfinexcom/bfx-report/pull/314) repo

---

Basic changes:
- adds `RateLimitChecker` class
- implements `BfxApiRouter` with rate limit logic
- turns off api middleware processing for positions history to reduce redundant `positionsAudit` calls to facilitate sync
- uses bfx api router for fetching `sub-account` api data
- fixes stuck event loop to fix ws timeout on big data

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/314