### PR TITLE
Add last/first trades mts into weighted averages test case

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -615,7 +615,9 @@ module.exports = (
         'sellingWeightedPrice',
         'sellingAmount',
         'cumulativeWeightedPrice',
-        'cumulativeAmount'
+        'cumulativeAmount',
+        'firstTradeMts',
+        'lastTradeMts'
       ])
     }
   })


### PR DESCRIPTION
This PR adds last/first trades mts into the `weighted averages` test case for the framework mode

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/315
