### PR TITLE
Remove cumulative weighted price and add cost/sale columns

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -614,7 +614,6 @@ module.exports = (
         'buyingAmount',
         'sellingWeightedPrice',
         'sellingAmount',
-        'cumulativeWeightedPrice',
         'cumulativeAmount',
         'firstTradeMts',
         'lastTradeMts'

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -612,8 +612,10 @@ module.exports = (
         'symbol',
         'buyingWeightedPrice',
         'buyingAmount',
+        'cost',
         'sellingWeightedPrice',
         'sellingAmount',
+        'sale',
         'cumulativeAmount',
         'firstTradeMts',
         'lastTradeMts'


### PR DESCRIPTION
This PR removes `cumulativeWeightedPrice` field and adds `cost`/`sale` columns to the weighted averages report

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/319
