### PR TITLE
Improve sync time estimation flow

### DIFF
--- a/test/test-cases/get-sync-progress-test-case.js
+++ b/test/test-cases/get-sync-progress-test-case.js
@@ -32,10 +32,21 @@ module.exports = (
       assert.propertyVal(res.body, 'id', 5)
       assert.isObject(res.body.result)
       assert.isNumber(res.body.result.progress)
-      assert.isNumber(res.body.result.syncStartedAt)
-      assert.isNumber(res.body.result.spentTime)
+
+      assert.isOk(
+        res.body.result.syncStartedAt === null ||
+        Number.isInteger(res.body.result.syncStartedAt)
+      )
+      assert.isOk(
+        res.body.result.spentTime === null ||
+        Number.isInteger(res.body.result.spentTime)
+      )
+      if (Number.isFinite(res.body.result.syncStartedAt)) {
+        Number.isInteger(res.body.result.spentTime)
+      }
 
       if (
+        !Number.isFinite(res.body.result.syncStartedAt) ||
         !Number.isFinite(res.body.result.progress) ||
         res.body.result.progress <= 0 ||
         res.body.result.progress > 100

--- a/workers/loc.api/sync/index.js
+++ b/workers/loc.api/sync/index.js
@@ -50,6 +50,8 @@ class Sync {
       }
     }
 
+    this.progress.deactivateSyncTimeEstimate()
+
     try {
       await this.redirectRequestsToApi({ isRedirected: false })
     } catch (err) {

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -131,7 +131,7 @@ class Progress extends EventEmitter {
       }
     }
 
-    const spentTime = nowMts - syncStartedAt
+    const spentTime = Math.floor(nowMts - syncStartedAt)
 
     if (
       !Number.isFinite(progress) ||
@@ -171,7 +171,7 @@ class Progress extends EventEmitter {
 
     if (!hasNotProgressChanged) {
       this._prevEstimatedLeftTime = nowMts
-      this._leftTime = (spentTime / progress) * (100 - progress)
+      this._leftTime = Math.floor((spentTime / progress) * (100 - progress))
 
       return this._leftTime
     }
@@ -181,7 +181,7 @@ class Progress extends EventEmitter {
       return this._leftTime
     }
 
-    const leftTime = this._leftTime - (nowMts - this._prevEstimatedLeftTime)
+    const leftTime = Math.floor(this._leftTime - (nowMts - this._prevEstimatedLeftTime))
     this._prevEstimatedLeftTime = nowMts
     this._leftTime = leftTime > 0
       ? leftTime


### PR DESCRIPTION
This PR improves the sync time estimation flow

---

Basic changes:
- Improves sync time estimation flow as follows:
  - in addition to existing emitting `WS` events when the next collection is syncing to not hold the previous time value (some collections can sync very long) adds an ability to emit the `progress` event every `1sec` with new values `spentTime` and `leftTime` for better UX (so that the user does not think that sync has stalled)
- Changes sync progress test case
- Returns sync estimated time values as an integer after calculation