### PR TITLE
Change rate limits for public endpoints

### DIFF
--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -41,7 +41,7 @@ class BfxApiRouter extends BaseBfxApiRouter {
       ['payInvoiceList', 90],
       ['accountTrades', 90],
       ['fundingTrades', 90],
-      ['trades', 90],
+      ['trades', 15],
       ['statusMessages', 90],
       ['candles', 90],
       ['orderTrades', 90],

--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -43,7 +43,7 @@ class BfxApiRouter extends BaseBfxApiRouter {
       ['fundingTrades', 90],
       ['trades', 15],
       ['statusMessages', 90],
-      ['candles', 90],
+      ['candles', 60],
       ['orderTrades', 90],
       ['orderHistory', 90],
       ['activeOrders', 90],


### PR DESCRIPTION
This PR changes Rate Limits for public endpoints:
- `trades` to 15
- `candles`  to 60
