### PR TITLE
Add support to db migration for temp tables

### DIFF
--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -441,7 +441,7 @@ class CurrencyConverter {
       return candle?.close
     }
 
-    const tempTableNames = await SyncTempTablesManager._getTempTableNamesByPattern(
+    const tempTableNames = await SyncTempTablesManager.getTempTableNamesByPattern(
       this.candlesSchema.name,
       { dao: this.dao }
     )

--- a/workers/loc.api/sync/dao/db-migrations/db.migrator.js
+++ b/workers/loc.api/sync/dao/db-migrations/db.migrator.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const SyncTempTablesManager = require(
+  '../../data.inserter/sync.temp.tables.manager'
+)
 const {
   DbMigrationVerCorrectnessError,
   DbVersionTypeError,
@@ -135,6 +138,7 @@ class DbMigrator {
 
     await this.dbBackupManager.backupDb({ currVer, supportedVer })
     await this.migrate(versions, isDown)
+    await SyncTempTablesManager.cleanUpAllTempDBStructure({ dao: this.dao })
     await this.dao.updateUsersSyncOnStartupRequiredState()
   }
 }

--- a/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
@@ -134,7 +134,7 @@ class SyncTempTablesManager {
     return `${BASE_NAME_PREFIX}${id}_`
   }
 
-  static async _getTempTableNamesByPattern (pattern, deps, opts) {
+  static async getTempTableNamesByPattern (pattern, deps, opts) {
     const { dao } = deps ?? {}
     const { doNotQueueQuery } = opts ?? {}
 

--- a/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
@@ -105,6 +105,19 @@ class SyncTempTablesManager {
     })
   }
 
+  static async cleanUpAllTempDBStructure (deps) {
+    const { dao } = deps ?? {}
+
+    await dao.executeQueriesInTrans(async () => {
+      await dao.dropAllTables({
+        expectations: [BASE_NAME_PREFIX],
+        isNotStrictEqual: true,
+        isNotInTrans: true,
+        doNotQueueQuery: true
+      })
+    })
+  }
+
   getCurrNamePrefix (id) {
     const syncQueueId = id ?? this.syncQueueId
 

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -574,7 +574,7 @@ class SubAccount {
           { doNotQueueQuery: true }
         )
 
-        const tempTableNames = await SyncTempTablesManager._getTempTableNamesByPattern(
+        const tempTableNames = await SyncTempTablesManager.getTempTableNamesByPattern(
           this.TABLES_NAMES.LEDGERS,
           { dao: this.dao },
           { doNotQueueQuery: true }


### PR DESCRIPTION
This PR adds support to db migration for temp tables

---

Basic changes:
- adds ability to clean up all `temp` db structure
- adds support to db migration for `temp` tables, `temp` tables will be removed for the non-completed sync if db schema is changed
- marks `_getTempTableNamesByPattern` method of `SyncTempTablesManager` as public for consistency, minor refactoring here

---

Related to this issue:
- https://github.com/bitfinexcom/bfx-report-electron/issues/217
