### PR TITLE
Update nodejs to 18 in Docker containers

### DIFF
--- a/Dockerfile.express
+++ b/Dockerfile.express
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine
+FROM node:18.17.1-alpine3.18
 
 ENV BIND_HOST "0.0.0.0"
 

--- a/Dockerfile.grenache-grape
+++ b/Dockerfile.grenache-grape
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine
+FROM node:18.17.1-alpine3.18
 
 ENV BIND_HOST "0.0.0.0"
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine
+FROM node:18.17.1-alpine3.18
 
 WORKDIR /home/node/bfx-report-ui
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -13,7 +13,12 @@ RUN apk add --no-cache --virtual \
 
 COPY ./scripts/maintenance/index.html var/www/html/maintenance.html
 COPY ./bfx-report-ui/package*.json ./
-RUN npm i --no-audit
+COPY ./bfx-report-ui/scripts ./scripts
+COPY ./bfx-report-ui/.npmrc ./.npmrc
+
+RUN mkdir -p ./src/ui/PlatformLogo/files && \
+  mkdir -p ./public && \
+  npm i --no-audit
 
 COPY ./bfx-report-ui .
 COPY ./scripts/build-ui.sh /usr/local/bin/

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine
+FROM node:18.17.1-alpine3.18
 
 ARG GRC_VER="0.7.1"
 


### PR DESCRIPTION
This PR updates Nodejs to `v18` in Docker containers and fixes UI dependencies installation under container