### PR TITLE
Remove lodash usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "csv": "5.5.3",
     "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
     "inversify": "6.0.1",
+    "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "lodash": "4.17.21",
     "moment": "2.29.4",
     "uuid": "9.0.0",

--- a/test/1-api-sync-mode-sqlite.spec.js
+++ b/test/1-api-sync-mode-sqlite.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 const request = require('supertest')
 
 const {

--- a/test/2-additional-api-sync-mode-sqlite.spec.js
+++ b/test/2-additional-api-sync-mode-sqlite.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 const request = require('supertest')
 
 const {

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 
 const BaseCsvJobData = require(
   'bfx-report/workers/loc.api/generate-csv/csv.job.data'

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const {
   paramsSchemaForCsv,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick } = require('lib-js-util-base')
 
 const {
   AuthError

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1,10 +1,8 @@
 'use strict'
 
 const {
+  omit,
   isEmpty
-} = require('lodash')
-const {
-  omit
 } = require('lib-js-util-base')
 const {
   AuthError,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const {
-  omit,
   isEmpty
 } = require('lodash')
+const {
+  omit
+} = require('lib-js-util-base')
 const {
   AuthError,
   BadRequestError

--- a/workers/loc.api/sync/authenticator/helpers/pick-props.js
+++ b/workers/loc.api/sync/authenticator/helpers/pick-props.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick } = require('lib-js-util-base')
 
 module.exports = (
   data,

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
-const { pick, isNil } = require('lodash')
+const { isNil } = require('lodash')
+const { pick } = require('lib-js-util-base')
 const {
   AuthError,
   ArgsParamsError

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const { v4: uuidv4 } = require('uuid')
-const { isNil } = require('lodash')
-const { pick } = require('lib-js-util-base')
+const { pick, isNil } = require('lib-js-util-base')
 const {
   AuthError,
   ArgsParamsError

--- a/workers/loc.api/sync/balance.history/index.js
+++ b/workers/loc.api/sync/balance.history/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty } = require('lodash')
+const { isEmpty } = require('lib-js-util-base')
 const moment = require('moment')
 
 const {

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const {
-  pick,
   isEmpty,
   orderBy
 } = require('lodash')
 const {
-  omit
+  omit,
+  pick
 } = require('lib-js-util-base')
 const {
   prepareResponse

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -2,10 +2,12 @@
 
 const {
   pick,
-  omit,
   isEmpty,
   orderBy
 } = require('lodash')
+const {
+  omit
+} = require('lib-js-util-base')
 const {
   prepareResponse
 } = require('bfx-report/workers/loc.api/helpers')

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const {
-  isEmpty,
   orderBy
 } = require('lodash')
 const {
   omit,
-  pick
+  pick,
+  isEmpty
 } = require('lib-js-util-base')
 const {
   prepareResponse

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -4,7 +4,7 @@ const { mkdirSync } = require('fs')
 const { readdir, rm, copyFile } = require('fs/promises')
 const path = require('path')
 const moment = require('moment')
-const { orderBy, uniqBy } = require('lodash')
+const { orderBy } = require('lodash')
 
 const { decorateInjectable } = require('../../../di/utils')
 
@@ -163,7 +163,7 @@ class DBBackupManager {
         if (
           i === 0 ||
           (
-            uniqBy(excludedFiles, 'version').filter((m) => (
+            this._getFirstUniqFilesByVer(excludedFiles).filter((m) => (
               m.version !== version
             )).length < 2 &&
             excludedFiles.filter((m) => (
@@ -194,6 +194,17 @@ class DBBackupManager {
       removedFiles,
       excludedFiles
     }
+  }
+
+  _getFirstUniqFilesByVer (metadata) {
+    return metadata.reduce((accum, curr) => {
+      if (!accum.uKeys.has(curr?.version)) {
+        accum.res.push(curr)
+        accum.uKeys.add(curr?.version)
+      }
+
+      return accum
+    }, { res: [], uKeys: new Set() }).res
   }
 
   _makeBackupsFolder () {

--- a/workers/loc.api/sync/dao/helpers/filter-model-name-map.js
+++ b/workers/loc.api/sync/dao/helpers/filter-model-name-map.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { upperFirst } = require('lodash')
 const {
   FILTER_MODELS_NAMES
 } = require('bfx-report/workers/loc.api/helpers')
 
 module.exports = Object.values(FILTER_MODELS_NAMES)
   .reduce((map, name) => {
-    const key = `_get${upperFirst(name)}`
+    const baseName = `${name[0].toUpperCase()}${name.slice(1)}`
+    const key = `_get${baseName}`
 
     map.set(key, name)
 

--- a/workers/loc.api/sync/dao/helpers/get-order-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-order-query.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty } = require('lodash')
+const { isEmpty } = require('lib-js-util-base')
 
 module.exports = (sort = []) => {
   if (

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 const FILTER_CONDITIONS = require(
   'bfx-report/workers/loc.api/helpers/filter.conditions'
 )

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const {
-  isEmpty,
   min
 } = require('lodash')
+const { isEmpty } = require('lib-js-util-base')
 const moment = require('moment')
 
 const SyncTempTablesManager = require('../sync.temp.tables.manager')

--- a/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
+++ b/workers/loc.api/sync/data.inserter/helpers/get-sync-coll-name.js
@@ -1,11 +1,13 @@
 'use strict'
 
-const { snakeCase } = require('lodash')
-
+/*
+ * Converts 'getFundingOfferHistory' name to 'FUNDING_OFFER_HISTORY'
+ */
 module.exports = (method) => {
-  const name = method.replace(/^[^A-Z]+/, '')
-  const snakeCaseName = snakeCase(name)
-  const upperCaseName = snakeCaseName.toUpperCase()
-
-  return upperCaseName
+  return method
+    .replace(/^[^A-Z]+/, '')
+    .replace(/[A-Z]/g, (match, offset) => (
+      `${offset > 0 ? '_' : ''}${match.toLowerCase()}`
+    ))
+    .toUpperCase()
 }

--- a/workers/loc.api/sync/data.inserter/helpers/search-close-price-and-sum-amount.js
+++ b/workers/loc.api/sync/data.inserter/helpers/search-close-price-and-sum-amount.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 
 const _isContainedPosStatus = (positions, status) => {
   return positions.every(pos => (

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -2,7 +2,7 @@
 
 const {
   pick
-} = require('lodash')
+} = require('lib-js-util-base')
 
 const normalizeApiData = (
   data = [],

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -4,9 +4,9 @@ const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
 
 const {
-  orderBy,
-  merge
+  orderBy
 } = require('lodash')
+const { merge } = require('lib-js-util-base')
 
 const SyncTempTablesManager = require('../sync.temp.tables.manager')
 const DataInserterHook = require('./data.inserter.hook')

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -6,7 +6,7 @@ const setImmediatePromise = promisify(setImmediate)
 const EventEmitter = require('events')
 const {
   cloneDeep
-} = require('lodash')
+} = require('lib-js-util-base')
 const {
   FindMethodError
 } = require('bfx-report/workers/loc.api/errors')

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const {
-  isEmpty,
   merge,
   min,
   max
 } = require('lodash')
 const {
-  omit
+  omit,
+  isEmpty
 } = require('lib-js-util-base')
 
 const {

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -3,10 +3,12 @@
 const {
   isEmpty,
   merge,
-  omit,
   min,
   max
 } = require('lodash')
+const {
+  omit
+} = require('lib-js-util-base')
 
 const {
   MIN_START_MTS

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const {
-  merge,
   min,
   max
 } = require('lodash')
 const {
   omit,
-  isEmpty
+  isEmpty,
+  merge
 } = require('lib-js-util-base')
 
 const {

--- a/workers/loc.api/sync/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/helpers/calc-grouped-data.js
@@ -2,7 +2,8 @@
 
 const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
-const { pick, omit } = require('lodash')
+const { pick } = require('lodash')
+const { omit } = require('lib-js-util-base')
 
 const getBackIterable = require('../helpers/get-back-iterable')
 

--- a/workers/loc.api/sync/helpers/calc-grouped-data.js
+++ b/workers/loc.api/sync/helpers/calc-grouped-data.js
@@ -2,8 +2,7 @@
 
 const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
-const { pick } = require('lodash')
-const { omit } = require('lib-js-util-base')
+const { omit, pick } = require('lib-js-util-base')
 
 const getBackIterable = require('../helpers/get-back-iterable')
 

--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { orderBy, merge } = require('lodash')
+const { orderBy } = require('lodash')
+const { merge } = require('lib-js-util-base')
 
 const { decorateInjectable } = require('../../di/utils')
 

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
-const { omit } = require('lib-js-util-base')
+const { omit, cloneDeep } = require('lib-js-util-base')
 
 const {
   CONSTR_FIELD_NAME,

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -14,6 +14,14 @@ const cloneSchema = (map, omittedFields = []) => {
     const normalizedSchema = omit(schema, omittedFields)
     const clonedSchema = cloneDeep(normalizedSchema)
 
+    for (const [propName, value] of Object.entries(schema)) {
+      if (typeof value !== 'function') {
+        continue
+      }
+
+      clonedSchema[propName] = value
+    }
+
     return [key, clonedSchema]
   })
 

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { cloneDeep, omit } = require('lodash')
+const { cloneDeep } = require('lodash')
+const { omit } = require('lib-js-util-base')
 
 const {
   CONSTR_FIELD_NAME,

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const {
-  orderBy,
-  isEmpty
+  orderBy
 } = require('lodash')
+const {
+  isEmpty
+} = require('lib-js-util-base')
 const {
   prepareResponse
 } = require('bfx-report/workers/loc.api/helpers')

--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events')
-const { isEmpty } = require('lodash')
+const { isEmpty } = require('lib-js-util-base')
 
 const COLLS_TYPES = require('../schema/colls.types')
 

--- a/workers/loc.api/sync/total.fees.report/index.js
+++ b/workers/loc.api/sync/total.fees.report/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { merge } = require('lodash')
+const { merge } = require('lib-js-util-base')
 
 const {
   TotalFeesParamsFlagError

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const uuid = require('uuid')
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 const { PeerRPCServer } = require('grenache-nodejs-ws')
 
 const {


### PR DESCRIPTION
This PR removes lodash `uniqBy`, `snakeCase`, `upperFirst` utils usage and uses `omit`, `pick`, `isEmpty`, `isNil`, `cloneDeep`, `merge` utils from the `lib-js-util-base`.
It's the next part of the removal of the `lodash` lib