### PR TITLE
Fix candles sync for currency converter

### DIFF
--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -589,7 +589,15 @@ class DataChecker {
       firstTempElemLedgers?.mts
     ])
 
-    return firstElemMts
+    /*
+     * To convert the first ledgers to USD
+     * it needs to provide some overlap of candles
+     */
+    const mts = moment.utc(firstElemMts)
+      .add(-5, 'days')
+      .valueOf()
+
+    return mts
   }
 
   async _getUniqueSymbsFromLedgers () {

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -142,6 +142,22 @@ class ConvertCurrencyHook extends DataInserterHook {
             _schema
           )
 
+        if (collName === this.ALLOWED_COLLS.LEDGERS) {
+          await this.dao.updateElemsInCollBy(
+            tableName,
+            convElems.map((item) => ({
+              ...item,
+              _isBalanceRecalced: null
+            })),
+            ['_id'],
+            [...updatedFieldNames, '_isBalanceRecalced']
+          )
+
+          _id = elems[elems.length - 1]._id
+
+          continue
+        }
+
         await this.dao.updateElemsInCollBy(
           tableName,
           convElems,

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -52,6 +52,7 @@ const depsTypes = (TYPES) => [
   TYPES.TABLES_NAMES,
   TYPES.Authenticator,
   TYPES.ConvertCurrencyHook,
+  TYPES.ConvertCurrencyHook,
   TYPES.RecalcSubAccountLedgersBalancesHook,
   TYPES.RecalcSubAccountLedgersBalancesHook,
   TYPES.DataChecker,
@@ -70,6 +71,7 @@ class DataInserter extends EventEmitter {
     TABLES_NAMES,
     authenticator,
     convertCurrencyHook,
+    convertCurrencyHookWithoutTempTable,
     recalcSubAccountLedgersBalancesHook,
     recalcSubAccountLedgersBalancesHookWithoutTempTable,
     dataChecker,
@@ -88,6 +90,7 @@ class DataInserter extends EventEmitter {
     this.TABLES_NAMES = TABLES_NAMES
     this.authenticator = authenticator
     this.convertCurrencyHook = convertCurrencyHook
+    this.convertCurrencyHookWithoutTempTable = convertCurrencyHookWithoutTempTable
     this.recalcSubAccountLedgersBalancesHook = recalcSubAccountLedgersBalancesHook
     this.recalcSubAccountLedgersBalancesHookWithoutTempTable = recalcSubAccountLedgersBalancesHookWithoutTempTable
     this.dataChecker = dataChecker
@@ -143,6 +146,10 @@ class DataInserter extends EventEmitter {
      * This hook, without `syncQueueId`, covers sub-account recalc
      * for non-temp ledgers table in cases when sub-users being added/removed
      */
+    this._addAfterAllInsertsHooks(
+      this.convertCurrencyHookWithoutTempTable,
+      { syncQueueId: null }
+    )
     this._addAfterAllInsertsHooks(
       this.recalcSubAccountLedgersBalancesHookWithoutTempTable,
       { syncQueueId: null }


### PR DESCRIPTION
This PR fixes the `candles` sync for the currency converter

---

To convert the first ledgers to USD it needs to provide some overlap of candles:
- the first entries in the ledgers with their timestamps may not have corresponding entries in the candles
- in rare cases, this may result in missing several entries when converting to USD
- the idea is to provide a 5 day overlap of candles in relation to the first entries in the ledgers
- the ability to convert balances into USD is also added for already synchronized but not converted records (for ordinary users and sub-accounts)

![Screenshot from 2023-10-23 14-09-11](https://github.com/bitfinexcom/bfx-reports-framework/assets/16489235/2bfa644b-e187-4ff6-96c3-5391368e0531)

![Screenshot from 2023-10-23 14-10-07](https://github.com/bitfinexcom/bfx-reports-framework/assets/16489235/c3626a45-29e9-4e95-9679-b5e848ff1e93)
