### PR TITLE
Add endpoint for summary by asset

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -718,14 +718,20 @@ module.exports = (
         'balance',
         'balanceUsd',
         'valueChange30dUsd',
-        'result30dUsd'
+        'valueChange30dPerc',
+        'result30dUsd',
+        'result30dPerc',
+        'volume30dUsd'
       ])
     })
 
     assert.containsAllKeys(res.body.result.total, [
       'balanceUsd',
       'valueChange30dUsd',
-      'result30dUsd'
+      'valueChange30dPerc',
+      'result30dUsd',
+      'result30dPerc',
+      'volume30dUsd'
     ])
   })
 

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -688,6 +688,47 @@ module.exports = (
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getSummaryByAsset method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getSummaryByAsset',
+        params: {
+          end
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.summaryByAsset)
+    assert.isObject(res.body.result.total)
+
+    res.body.result.summaryByAsset.forEach((item) => {
+      assert.isObject(item)
+      assert.containsAllKeys(item, [
+        'currency',
+        'balance',
+        'balanceUsd',
+        'valueChange30dUsd',
+        'result30dUsd'
+      ])
+    })
+
+    assert.containsAllKeys(res.body.result.total, [
+      'balanceUsd',
+      'valueChange30dUsd',
+      'result30dUsd'
+    ])
+  })
+
   it('it should be successfully performed by the getWinLossCsv method', async function () {
     this.timeout(60000)
 

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -729,6 +729,30 @@ module.exports = (
     ])
   })
 
+  it('it should not be successfully performed by the getSummaryByAsset method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getSummaryByAsset',
+        params: {
+          end: 'not integer'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
   it('it should be successfully performed by the getWinLossCsv method', async function () {
     this.timeout(60000)
 

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -80,6 +80,7 @@ const WinLossVSAccountBalance = require('../sync/win.loss.vs.account.balance')
 const Wallets = require('../sync/wallets')
 const BalanceHistory = require('../sync/balance.history')
 const WinLoss = require('../sync/win.loss')
+const SummaryByAsset = require('../sync/summary.by.asset')
 const PositionsSnapshot = require('../sync/positions.snapshot')
 const FullSnapshotReport = require('../sync/full.snapshot.report')
 const Trades = require('../sync/trades')
@@ -145,6 +146,7 @@ module.exports = ({
           ['_wallets', TYPES.Wallets],
           ['_balanceHistory', TYPES.BalanceHistory],
           ['_winLoss', TYPES.WinLoss],
+          ['_summaryByAsset', TYPES.SummaryByAsset],
           ['_positionsSnapshot', TYPES.PositionsSnapshot],
           ['_fullSnapshotReport', TYPES.FullSnapshotReport],
           ['_fullTaxReport', TYPES.FullTaxReport],
@@ -345,6 +347,8 @@ module.exports = ({
       .to(BalanceHistory)
     bind(TYPES.WinLoss)
       .to(WinLoss)
+    bind(TYPES.SummaryByAsset)
+      .to(SummaryByAsset)
     bind(TYPES.PositionsSnapshot)
       .to(PositionsSnapshot)
     bind(TYPES.FullSnapshotReport)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -68,5 +68,6 @@ module.exports = {
   SyncUserStepManager: Symbol.for('SyncUserStepManager'),
   SyncUserStepData: Symbol.for('SyncUserStepData'),
   SyncUserStepDataFactory: Symbol.for('SyncUserStepDataFactory'),
-  HTTPRequest: Symbol.for('HTTPRequest')
+  HTTPRequest: Symbol.for('HTTPRequest'),
+  SummaryByAsset: Symbol.for('SummaryByAsset')
 }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -337,6 +337,15 @@ const paramsSchemaForPerformingLoanApi = {
   }
 }
 
+const paramsSchemaForSummaryByAssetApi = {
+  type: 'object',
+  properties: {
+    end: {
+      type: 'integer'
+    }
+  }
+}
+
 const {
   timezone,
   dateFormat
@@ -452,6 +461,7 @@ module.exports = {
   paramsSchemaForTotalFeesReportApi,
   paramsSchemaForPerformingLoanApi,
   paramsSchemaForCandlesApi,
+  paramsSchemaForSummaryByAssetApi,
   paramsSchemaForBalanceHistoryCsv,
   paramsSchemaForWinLossCsv,
   paramsSchemaForWinLossVSAccountBalanceCsv,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1445,6 +1445,15 @@ class FrameworkReportService extends ReportService {
     }, 'getWinLossVSAccountBalance', args, cb)
   }
 
+  getSummaryByAsset (space, args, cb) {
+    return this._privResponder(async () => {
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.SUMMARY_BY_ASSET, args)
+
+      return this._summaryByAsset.getSummaryByAsset(args)
+    }, 'getSummaryByAsset', args, cb)
+  }
+
   /**
    * @override
    */

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1450,6 +1450,8 @@ class FrameworkReportService extends ReportService {
       await this._dataConsistencyChecker
         .check(this._CHECKER_NAMES.SUMMARY_BY_ASSET, args)
 
+      checkParams(args, 'paramsSchemaForSummaryByAssetApi')
+
       return this._summaryByAsset.getSummaryByAsset(args)
     }, 'getSummaryByAsset', args, cb)
   }

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -9,5 +9,6 @@ module.exports = {
   FULL_TAX_REPORT: 'getFullTaxReport',
   TRADED_VOLUME: 'getTradedVolume',
   TOTAL_FEES_REPORT: 'getTotalFeesReport',
-  PERFORMING_LOAN: 'getPerformingLoan'
+  PERFORMING_LOAN: 'getPerformingLoan',
+  SUMMARY_BY_ASSET: 'getSummaryByAsset'
 }

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -160,6 +160,21 @@ class Checkers {
 
     return true
   }
+
+  // TODO:
+  [CHECKER_NAMES.SUMMARY_BY_ASSET] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.CANDLES,
+            this.SYNC_API_METHODS.MOVEMENTS
+          ]
+        }
+      })
+  }
 }
 
 decorateInjectable(Checkers, depsTypes)

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -161,7 +161,6 @@ class Checkers {
     return true
   }
 
-  // TODO:
   [CHECKER_NAMES.SUMMARY_BY_ASSET] (auth) {
     return this.syncCollsManager
       .haveCollsBeenSyncedUpToDate({

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -157,6 +157,9 @@ class SummaryByAsset {
       const actualRate = calcedEndWalletbalanceUsd / calcedEndWalletbalance
       const valueChange30d = calcedEndWalletbalance - calcedStartWalletbalance
       const valueChange30dUsd = valueChange30d * actualRate
+      const valueChange30dPerc = calcedStartWalletbalance === 0
+        ? 0
+        : (valueChange30d / calcedStartWalletbalance) * 100
       const calcedMovementsByCurrency = this.#calcMovementsByCurrency(
         { withdrawals, deposits },
         currency
@@ -168,6 +171,7 @@ class SummaryByAsset {
         balance: calcedEndWalletbalance,
         balanceUsd: calcedEndWalletbalanceUsd,
         valueChange30dUsd,
+        valueChange30dPerc,
         result30dUsd
       }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.SyncSchema,
+  TYPES.BalanceHistory,
+  TYPES.FOREX_SYMBS,
+  TYPES.Authenticator,
+  TYPES.SYNC_API_METHODS,
+  TYPES.Movements,
+  TYPES.Wallets
+]
+class SummaryByAsset {
+  constructor (
+    dao,
+    syncSchema,
+    balanceHistory,
+    FOREX_SYMBS,
+    authenticator,
+    SYNC_API_METHODS,
+    movements,
+    wallets
+  ) {
+    this.dao = dao
+    this.syncSchema = syncSchema
+    this.balanceHistory = balanceHistory
+    this.FOREX_SYMBS = FOREX_SYMBS
+    this.authenticator = authenticator
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.movements = movements
+    this.wallets = wallets
+
+    this.movementsMethodColl = this.syncSchema.getMethodCollMap()
+      .get(this.SYNC_API_METHODS.MOVEMENTS)
+    this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
+      .get(this.SYNC_API_METHODS.LEDGERS)
+    this.movementsSymbolFieldName = this.movementsMethodColl.symbolFieldName
+    this.ledgersSymbolFieldName = this.ledgersMethodColl.symbolFieldName
+  }
+
+  // TODO:
+  async getSummaryByAsset (args) {
+    const auth = args?.auth ?? {}
+    const user = await this.authenticator
+      .verifyRequestUser({ auth })
+
+    // TODO: mock data
+    return [
+      {
+        currency: 'BTC',
+        balance: 12.32,
+        balanceUsd: 246_400,
+        valueChange30dUsd: 246_400, // means the difference between the value 30 days ago and the current value
+        result30dUsd: 246_400, // show the value change without the deposit/withdrawals
+        volume30dUsd: 246_400 //  means traded, lended, funded volume for 30 days period
+      }
+    ]
+  }
+}
+
+decorateInjectable(SummaryByAsset, depsTypes)
+
+module.exports = SummaryByAsset

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -164,7 +164,11 @@ class SummaryByAsset {
         { withdrawals, deposits },
         currency
       )
+      const result30d = valueChange30d - calcedMovementsByCurrency
       const result30dUsd = (valueChange30d - calcedMovementsByCurrency) * actualRate
+      const result30dPerc = calcedMovementsByCurrency === 0
+        ? 0
+        : (result30d / calcedMovementsByCurrency) * 100
 
       const res = {
         currency,
@@ -172,7 +176,8 @@ class SummaryByAsset {
         balanceUsd: calcedEndWalletbalanceUsd,
         valueChange30dUsd,
         valueChange30dPerc,
-        result30dUsd
+        result30dUsd,
+        result30dPerc
       }
 
       currencyRes.push(res)

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -83,14 +83,7 @@ class SummaryByAsset {
       endWalletsPromise
     ])
 
-    const res = this.#calcSummaryByAsset({
-      withdrawals,
-      deposits,
-      startWallets,
-      endWallets
-    })
-
-    // TODO: mock data
+    // TODO: Data example
     // [
     //   {
     //     currency: 'BTC',
@@ -101,8 +94,23 @@ class SummaryByAsset {
     //     volume30dUsd: 246_400 //  means traded, lended, funded volume for 30 days period
     //   }
     // ]
+    const summaryByAsset = this.#calcSummaryByAsset({
+      withdrawals,
+      deposits,
+      startWallets,
+      endWallets
+    })
+    // TODO: Data example
+    const total = {
+      balanceUsd: 246_400,
+      valueChange30dUsd: 246_400,
+      result30dUsd: 246_400
+    }
 
-    return res
+    return {
+      summaryByAsset,
+      total
+    }
   }
 
   #calcSummaryByAsset ({

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -112,17 +112,17 @@ class SummaryByAsset {
     endWallets
   }) {
     const currencyRes = []
-    const currencySet = new Set(...endWallets.map((wallet) => (
+    const currencySet = new Set(endWallets.map((wallet) => (
       wallet.currency
     )))
 
     for (const currency of currencySet) {
-      const startWalletsForCurrency = startWallets.find((wallet) => (
+      const startWalletsForCurrency = startWallets.filter((wallet) => (
         wallet.currency === currency
-      )) ?? []
-      const endWalletsForCurrency = endWallets.find((wallet) => (
+      ))
+      const endWalletsForCurrency = endWallets.filter((wallet) => (
         wallet.currency === currency
-      )) ?? []
+      ))
 
       const calcedStartWalletbalance = this.#calcFieldByName(
         startWalletsForCurrency,

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -319,7 +319,9 @@ class SummaryByAsset {
       valueChange30dPerc: 0,
       result30dUsd: 0,
       result30dPerc: 0,
-      volume30dUsd: 0
+      volume30dUsd: 0,
+
+      calcedStartWalletBalanceUsd: 0
     }
 
     return summaryByAsset.reduce((accum, curr) => {

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -142,6 +142,9 @@ class SummaryByAsset {
     )))
 
     for (const currency of currencySet) {
+      const ledgersForCurrency = ledgers.filter((ledger) => (
+        ledger[this.ledgersSymbolFieldName] === currency
+      ))
       const startWalletsForCurrency = startWallets.filter((wallet) => (
         wallet.currency === currency
       ))
@@ -149,6 +152,9 @@ class SummaryByAsset {
         wallet.currency === currency
       ))
 
+      const calcedVolume30d = this.#calcVolume30d(
+        ledgersForCurrency
+      )
       const calcedStartWalletbalance = this.#calcFieldByName(
         startWalletsForCurrency,
         'balance'
@@ -186,6 +192,7 @@ class SummaryByAsset {
       const result30dPerc = calcedMovementsByCurrency === 0
         ? 0
         : (result30d / calcedMovementsByCurrency) * 100
+      const volume30dUsd = calcedVolume30d * actualRate
 
       const res = {
         currency,
@@ -194,7 +201,8 @@ class SummaryByAsset {
         valueChange30dUsd,
         valueChange30dPerc,
         result30dUsd,
-        result30dPerc
+        result30dPerc,
+        volume30dUsd
       }
 
       currencyRes.push(res)
@@ -209,6 +217,18 @@ class SummaryByAsset {
         ? accum + curr[fieldName]
         : accum
     ), 0)
+  }
+
+  #calcVolume30d (ledgers) {
+    return ledgers.reduce((accum, curr) => {
+      const amount = curr?.amount
+
+      if (!Number.isFinite(amount)) {
+        return accum
+      }
+
+      return accum + Math.abs(amount)
+    }, 0)
   }
 
   #calcMovementsByCurrency (movements, currency) {

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { omit } = require('lib-js-util-base')
 const moment = require('moment')
 
 const { decorateInjectable } = require('../../di/utils')
@@ -94,7 +95,7 @@ class SummaryByAsset {
       endWalletsPromise
     ])
 
-    const summaryByAsset = await this.#calcSummaryByAsset({
+    const _summaryByAsset = await this.#calcSummaryByAsset({
       start,
       ledgers,
       withdrawals,
@@ -102,7 +103,10 @@ class SummaryByAsset {
       startWallets,
       endWallets
     })
-    const total = this.#calcTotal(summaryByAsset)
+    const total = this.#calcTotal(_summaryByAsset)
+    const summaryByAsset = _summaryByAsset.map((item) => (
+      omit(item, ['calcedStartWalletBalanceUsd'])
+    ))
 
     return {
       summaryByAsset,
@@ -324,7 +328,7 @@ class SummaryByAsset {
       calcedStartWalletBalanceUsd: 0
     }
 
-    return summaryByAsset.reduce((accum, curr) => {
+    const res = summaryByAsset.reduce((accum, curr) => {
       this.#calcObjPropsByName(
         accum,
         curr,
@@ -345,6 +349,8 @@ class SummaryByAsset {
 
       return accum
     }, initTotal)
+
+    return omit(res, ['calcedStartWalletBalanceUsd'])
   }
 
   #calcObjPropsByName (accum, curr, propNames) {


### PR DESCRIPTION
This PR adds an endpoint to get the `summary by asset` (for 30 day period) for the new summary page of the framework mode

![Screenshot from 2023-09-22 13-15-36](https://github.com/bitfinexcom/bfx-reports-framework/assets/16489235/72b67612-d697-4cf8-a095-d87a879e1a4d)

---

Basic changes:
- Adds `getSummaryByAsset` endpoint
- Adds test cases for `getSummaryByAsset` endpoint

---

Request example:
```jsonc
{
  "auth": {
    "token": "user-token"
  },
  "method": "getSummaryByAsset",
  "params": {
    "end": 1690464617000 // if not pass `end` param by default `end` = Date.now()
  }
}
```

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "summaryByAsset": [
      {
        "currency": "USD",
        "balance": 2396.33327987,
        "balanceUsd": 2396.33327987,
        "valueChange30dUsd": 0,
        "valueChange30dPerc": 0,
        "result30dUsd": 0,
        "result30dPerc": 0,
        "volume30dUsd": 0
      },
      {
        "currency": "BTC",
        "balance": 0.00134209,
        "balanceUsd": 39.2695534,
        "valueChange30dUsd": 0,
        "valueChange30dPerc": 0,
        "result30dUsd": 0,
        "result30dPerc": 0,
        "volume30dUsd": 0
      }
    ],
    "total": {
      "balanceUsd": 2435.60283327,
      "valueChange30dUsd": 0,
      "valueChange30dPerc": 0,
      "result30dUsd": 0,
      "result30dPerc": 0,
      "volume30dUsd": 0
    }
  },
  "id": null
}
```

---

**Depends** on these PRs:
- https://github.com/bitfinexcom/lib-js-util-base/pull/10
- https://github.com/bitfinexcom/bfx-reports-framework/pull/329
