### PR TITLE
Add ability to sync candles once per day

### DIFF
--- a/workers/loc.api/di/factories/sync-user-step-data-factory.js
+++ b/workers/loc.api/di/factories/sync-user-step-data-factory.js
@@ -9,6 +9,7 @@ module.exports = (ctx) => {
     )
 
     const paramsOrder = [
+      'syncedAt',
       'symbol',
       'timeframe',
       'baseStart',

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -407,7 +407,8 @@ class DataChecker {
       )
       const shouldFreshSyncBeAdded = this._shouldFreshSyncBeAdded(
         syncUserStepData,
-        currMts
+        currMts,
+        { dayOfYear: 1 }
       )
 
       if (
@@ -502,7 +503,8 @@ class DataChecker {
   ) {
     const {
       measure = 'minutes',
-      allowedTimeDiff = 60
+      allowedTimeDiff = 60,
+      dayOfYear
     } = allowedDiff ?? {}
 
     const baseEnd = (
@@ -517,15 +519,28 @@ class DataChecker {
     )
       ? syncUserStepData.currEnd
       : 0
+    const syncedAt = syncUserStepData.hasSyncedAt
+      ? syncUserStepData.syncedAt
+      : 0
 
     const momentBaseEnd = moment.utc(baseEnd)
     const momentCurrEnd = moment.utc(currEnd)
     const momentCurrMts = moment.utc(currMts)
+    const momentSyncedAt = moment.utc(syncedAt)
 
     const momentMaxEnd = moment.max(momentBaseEnd, momentCurrEnd)
     const momentDiff = momentCurrMts.diff(momentMaxEnd, measure)
+    const yearsDiff = momentCurrMts.year() - momentSyncedAt.year()
+    const dayOfYearDiff = momentCurrMts.dayOfYear() - momentSyncedAt.dayOfYear()
 
-    return momentDiff > allowedTimeDiff
+    return (
+      momentDiff > allowedTimeDiff &&
+      (
+        !Number.isFinite(dayOfYear) ||
+        yearsDiff >= 1 ||
+        dayOfYearDiff >= dayOfYear
+      )
+    )
   }
 
   _wasStartPointChanged (

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -326,7 +326,8 @@ class SyncUserStepManager {
       currStart,
       currEnd,
       isBaseStepReady = false,
-      isCurrStepReady = false
+      isCurrStepReady = false,
+      syncedAt
     } = syncUserStepInfo ?? {}
 
     const baseStart = this._getMinStart(_baseStart)
@@ -348,7 +349,8 @@ class SyncUserStepManager {
         baseEnd: baseEnd ?? currMts,
         isBaseStepReady,
         symbol,
-        timeframe
+        timeframe,
+        syncedAt
       })
 
       return {
@@ -365,7 +367,8 @@ class SyncUserStepManager {
       isBaseStepReady,
       isCurrStepReady,
       symbol,
-      timeframe
+      timeframe,
+      syncedAt
     })
 
     if (!isCurrStepReady) {

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/sync.user.step.data.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/sync.user.step.data.js
@@ -9,6 +9,7 @@ const { decorateInjectable } = require('../../../di/utils')
  */
 class SyncUserStepData {
   constructor () {
+    this.syncedAt = null
     this.symbol = null
     this.timeframe = null
     this.baseStart = null
@@ -23,6 +24,7 @@ class SyncUserStepData {
   }
 
   /**
+   * @param {?number} [syncedAt] - Used to specify synced mts point
    * @param {?string} [symbol] - Used to specify synced symbol, can be `_ALL` if all ones are syncing
    * @param {?string} [timeframe] - Used to specify synced timeframe, eg. for candles collection
    * @param {?number} [baseStart] - Used to specify base start mts point to continue first sync
@@ -34,6 +36,7 @@ class SyncUserStepData {
    */
   setParams (params = {}) {
     const {
+      syncedAt = this.syncedAt,
       symbol = this.symbol,
       timeframe = this.timeframe,
       baseStart = this.baseStart,
@@ -44,6 +47,7 @@ class SyncUserStepData {
       isCurrStepReady = this.isCurrStepReady
     } = params ?? {}
 
+    this.syncedAt = syncedAt
     this.symbol = symbol
     this.timeframe = timeframe
     this.baseStart = baseStart
@@ -116,6 +120,10 @@ class SyncUserStepData {
 
   get hasCurrStart () {
     return Number.isInteger(this.currStart)
+  }
+
+  get hasSyncedAt () {
+    return Number.isInteger(this.syncedAt)
   }
 }
 


### PR DESCRIPTION
This PR adds ability to sync daily `candles` once per day to reduce the number of sync requests to `BFX API` and as a result improve the situation with the `Rate Limit` restriction