### PR TITLE
Add ability to reference specific user currencies when candles sync

### DIFF
--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -43,7 +43,7 @@ class BfxApiRouter extends BaseBfxApiRouter {
       ['fundingTrades', 90],
       ['trades', 15],
       ['statusMessages', 90],
-      ['candles', 30],
+      ['candles', 20],
       ['orderTrades', 90],
       ['orderHistory', 90],
       ['activeOrders', 90],

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -30,7 +30,8 @@ const depsTypes = (TYPES) => [
   TYPES.SyncSchema,
   TYPES.FOREX_SYMBS,
   TYPES.ALLOWED_COLLS,
-  TYPES.SYNC_API_METHODS
+  TYPES.SYNC_API_METHODS,
+  TYPES.Logger
 ]
 class CurrencyConverter {
   constructor (
@@ -40,7 +41,8 @@ class CurrencyConverter {
     syncSchema,
     FOREX_SYMBS,
     ALLOWED_COLLS,
-    SYNC_API_METHODS
+    SYNC_API_METHODS,
+    logger
   ) {
     this.rService = rService
     this.getDataFromApi = getDataFromApi
@@ -49,6 +51,7 @@ class CurrencyConverter {
     this.FOREX_SYMBS = FOREX_SYMBS
     this.ALLOWED_COLLS = ALLOWED_COLLS
     this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.logger = logger
 
     this._COLL_NAMES = {
       PUBLIC_TRADES: 'publicTrades',
@@ -114,6 +117,8 @@ class CurrencyConverter {
           return this.currenciesSynonymous
         }
       } catch (err) {
+        this.logger.debug(err)
+
         return this.currenciesSynonymous
       }
     }

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -463,7 +463,7 @@ class DataChecker {
       // To keep flow: one candles request per currency
       if (!syncUserStepData.isBaseStepReady) {
         syncUserStepData.setParams({
-          baseEnd: syncUserStepData.currEnd,
+          baseEnd: syncUserStepData.currEnd ?? currMts,
           isCurrStepReady: true
         })
       }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -284,7 +284,7 @@ class DataInserter extends EventEmitter {
     await this.wsEventEmitter
       .emitSyncingStep('CHECKING_NEW_PUBLIC_DATA')
     const methodCollMap = await this.dataChecker
-      .checkNewPublicData()
+      .checkNewPublicData(this._sessionAuth)
     await this.syncTempTablesManager
       .createTempDBStructureForCurrSync(methodCollMap)
     const size = methodCollMap.size

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -60,7 +60,8 @@ const depsTypes = (TYPES) => [
   TYPES.WSEventEmitter,
   TYPES.GetDataFromApi,
   TYPES.SyncTempTablesManager,
-  TYPES.SyncUserStepManager
+  TYPES.SyncUserStepManager,
+  TYPES.Progress
 ]
 class DataInserter extends EventEmitter {
   constructor (
@@ -79,7 +80,8 @@ class DataInserter extends EventEmitter {
     wsEventEmitter,
     getDataFromApi,
     syncTempTablesManager,
-    syncUserStepManager
+    syncUserStepManager,
+    progress
   ) {
     super()
 
@@ -99,6 +101,7 @@ class DataInserter extends EventEmitter {
     this.getDataFromApi = getDataFromApi
     this.syncTempTablesManager = syncTempTablesManager
     this.syncUserStepManager = syncUserStepManager
+    this.progress = progress
 
     this._asyncProgressHandlers = []
     this._auth = null
@@ -301,6 +304,12 @@ class DataInserter extends EventEmitter {
         .emitSyncingStep(`SYNCING_${getSyncCollName(method)}`)
 
       const { type, start } = schema ?? {}
+
+      if (schema.name === this.ALLOWED_COLLS.CANDLES) {
+        // Considers 10 reqs/min for candles
+        const leftTime = Math.floor((60 / 10) * start.length * 1000)
+        this.progress.setCandlesLeftTime(leftTime)
+      }
 
       for (const syncUserStepData of start) {
         if (isInsertableArrObj(schema?.type, { isPublic: true })) {

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -211,12 +211,16 @@ class SyncUserStepManager {
 
     const defaultStart = this._getMinStart(_defaultStart)
     const hasUserIdField = (
-      typeof model?.user_id === 'string' &&
       Number.isInteger(userId)
     )
+    const hasUserIdFieldInModel = (
+      typeof model?.user_id === 'string'
+    )
     const hasSubUserIdField = (
-      typeof model?.subUserId === 'string' &&
       Number.isInteger(subUserId)
+    )
+    const hasSubUserIdFieldInModel = (
+      typeof model?.subUserId === 'string'
     )
     const hasSymbolField = (
       symbolFieldName &&
@@ -230,13 +234,19 @@ class SyncUserStepManager {
       timeframe &&
       typeof timeframe === 'string'
     )
-    const shouldCollBePublic = !hasUserIdField
+    const shouldCollBePublic = (
+      !hasUserIdField ||
+      !hasUserIdFieldInModel
+    )
     const shouldTableDataBeFetched = (
       dateFieldName &&
       typeof dateFieldName === 'string'
     )
 
-    if (isPublic(syncSchema?.type) !== shouldCollBePublic) {
+    if (
+      tableName !== this.TABLES_NAMES.CANDLES &&
+      isPublic(syncSchema?.type) !== shouldCollBePublic
+    ) {
       throw new LastSyncedInfoGettingError()
     }
 
@@ -257,8 +267,8 @@ class SyncUserStepManager {
       : {}
     const dataFilter = merge(
       {},
-      userIdFilter,
-      subUserIdFilter,
+      hasUserIdFieldInModel ? userIdFilter : {},
+      subUserIdFilter ? hasSubUserIdFieldInModel : {},
       symbolFilter,
       timeframeFilter
     )
@@ -267,7 +277,8 @@ class SyncUserStepManager {
       this.TABLES_NAMES.SYNC_USER_STEPS,
       {
         collName,
-        ...userIdFilter
+        ...userIdFilter,
+        ...subUserIdFilter
       },
       [['syncedAt', -1]]
     )

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -41,6 +41,7 @@ class Progress extends EventEmitter {
     this._state = null
     this._hasNotProgressChanged = true
     this._leftTime = null
+    this._candlesLeftTime = null
     this._prevEstimatedLeftTime = Date.now()
   }
 
@@ -145,7 +146,7 @@ class Progress extends EventEmitter {
     return this
   }
 
-  async _estimateSyncTime (params) {
+  _estimateSyncTime (params) {
     const {
       error,
       progress,
@@ -218,6 +219,7 @@ class Progress extends EventEmitter {
     } = params ?? {}
 
     if (!hasNotProgressChanged) {
+      this._candlesLeftTime = null
       this._prevEstimatedLeftTime = nowMts
       this._leftTime = Math.floor((spentTime / progress) * (100 - progress))
 
@@ -233,7 +235,10 @@ class Progress extends EventEmitter {
     this._prevEstimatedLeftTime = nowMts
     this._leftTime = leftTime > 0
       ? leftTime
-      : null
+      : this._candlesLeftTime ?? this._calcLeftTime({
+        ...params,
+        hasNotProgressChanged: false
+      })
 
     return this._leftTime
   }
@@ -303,6 +308,10 @@ class Progress extends EventEmitter {
         errorRegExp.test(error)
       )
     )
+  }
+
+  setCandlesLeftTime (leftTime) {
+    this._candlesLeftTime = leftTime
   }
 }
 


### PR DESCRIPTION
This PR adds ability to reference specific user currencies when `candles` sync. The aim is to reduce the amount of requests to the `BFX API` candles endpoint and speed up the sync essentially

---

Also for better UX, adds approximate candles sync time estimation considering the amount of syncing currencies 
And sets candles limit 20 `reqs/min` instead of 30 to go through the `Rate Limit`