### PR TITLE
Set 10 reqs per min for bfx api trades endpoint

### DIFF
--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -41,7 +41,7 @@ class BfxApiRouter extends BaseBfxApiRouter {
       ['payInvoiceList', 90],
       ['accountTrades', 90],
       ['fundingTrades', 90],
-      ['trades', 15],
+      ['trades', 10],
       ['statusMessages', 90],
       ['candles', 20],
       ['orderTrades', 90],


### PR DESCRIPTION
This PR sets `10` reqs/min for BFX API `trades` endpoint to help big users go through `Rate Limit` for the `Tax Report`