### PR TITLE
Add start param to get summary by asset endpoint

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -698,6 +698,54 @@ module.exports = (
         auth,
         method: 'getSummaryByAsset',
         params: {
+          start,
+          end
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.summaryByAsset)
+    assert.isObject(res.body.result.total)
+
+    res.body.result.summaryByAsset.forEach((item) => {
+      assert.isObject(item)
+      assert.containsAllKeys(item, [
+        'currency',
+        'balance',
+        'balanceUsd',
+        'valueChange30dUsd',
+        'valueChange30dPerc',
+        'result30dUsd',
+        'result30dPerc',
+        'volume30dUsd'
+      ])
+    })
+
+    assert.containsAllKeys(res.body.result.total, [
+      'balanceUsd',
+      'valueChange30dUsd',
+      'valueChange30dPerc',
+      'result30dUsd',
+      'result30dPerc',
+      'volume30dUsd'
+    ])
+  })
+
+  it('it should be successfully performed by the getSummaryByAsset method, 30d period until the end point', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getSummaryByAsset',
+        params: {
           end
         },
         id: 5

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -340,6 +340,10 @@ const paramsSchemaForPerformingLoanApi = {
 const paramsSchemaForSummaryByAssetApi = {
   type: 'object',
   properties: {
+
+    start: {
+      type: 'integer'
+    },
     end: {
       type: 'integer'
     }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -340,7 +340,6 @@ const paramsSchemaForPerformingLoanApi = {
 const paramsSchemaForSummaryByAssetApi = {
   type: 'object',
   properties: {
-
     start: {
       type: 'integer'
     },

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -49,9 +49,10 @@ class SummaryByAsset {
     const auth = await this.authenticator
       .verifyRequestUser({ auth: args?.auth ?? {} })
     const end = args?.params?.end ?? Date.now()
-    const start = args?.params?.start ?? moment.utc(end)
+    const mts30dUntilEnd = moment.utc(end)
       .add(-30, 'days')
       .valueOf()
+    const start = args?.params?.start ?? mts30dUntilEnd
 
     const ledgersPromise = this.#getLedgers({
       auth,

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -49,7 +49,7 @@ class SummaryByAsset {
     const auth = await this.authenticator
       .verifyRequestUser({ auth: args?.auth ?? {} })
     const end = args?.params?.end ?? Date.now()
-    const start = moment.utc(end)
+    const start = args?.params?.start ?? moment.utc(end)
       .add(-30, 'days')
       .valueOf()
 


### PR DESCRIPTION
This PR adds the `start` param to the `getSummaryByAsset` endpoint to be able to select a period more than `30d`

---

Request example:

```jsonc
{
  "auth": {
    "token": "user-token"
  },
  "method": "getSummaryByAsset",
  "params": {
    "end": 1690464617000,
    "start": 1590464617000
  }
}
```
