### PR TITLE
Use max and min utils from internal lib

### DIFF
--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const {
-  min
-} = require('lodash')
-const { isEmpty } = require('lib-js-util-base')
+const { isEmpty, min } = require('lib-js-util-base')
 const moment = require('moment')
 
 const SyncTempTablesManager = require('../sync.temp.tables.manager')

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const {
-  min,
-  max
-} = require('lodash')
-const {
   omit,
   isEmpty,
-  merge
+  merge,
+  min,
+  max
 } = require('lib-js-util-base')
 
 const {


### PR DESCRIPTION
This PR uses `max` and `min` utils from the `lib-js-util-base` lib instead of the `lodash`

---

**Depends** on this PR:
- https://github.com/bitfinexcom/lib-js-util-base/pull/19
