### PR TITLE
Add exchange volume and trading fee values to summary by asset

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -718,21 +718,21 @@ module.exports = (
         'currency',
         'balance',
         'balanceUsd',
-        'valueChange30dUsd',
-        'valueChange30dPerc',
-        'result30dUsd',
-        'result30dPerc',
-        'volume30dUsd'
+        'balanceChange',
+        'balanceChangePerc',
+        'volume',
+        'volumeUsd',
+        'tradingFees',
+        'marginFundingPayment'
       ])
     })
 
     assert.containsAllKeys(res.body.result.total, [
       'balanceUsd',
-      'valueChange30dUsd',
-      'valueChange30dPerc',
-      'result30dUsd',
-      'result30dPerc',
-      'volume30dUsd'
+      'balanceChangeUsd',
+      'balanceChangePerc',
+      'volumeUsd',
+      'tradingFeesUsd'
     ])
   })
 
@@ -765,21 +765,21 @@ module.exports = (
         'currency',
         'balance',
         'balanceUsd',
-        'valueChange30dUsd',
-        'valueChange30dPerc',
-        'result30dUsd',
-        'result30dPerc',
-        'volume30dUsd'
+        'balanceChange',
+        'balanceChangePerc',
+        'volume',
+        'volumeUsd',
+        'tradingFees',
+        'marginFundingPayment'
       ])
     })
 
     assert.containsAllKeys(res.body.result.total, [
       'balanceUsd',
-      'valueChange30dUsd',
-      'valueChange30dPerc',
-      'result30dUsd',
-      'result30dPerc',
-      'volume30dUsd'
+      'balanceChangeUsd',
+      'balanceChangePerc',
+      'volumeUsd',
+      'tradingFeesUsd'
     ])
   })
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -11,9 +11,8 @@ const depsTypes = (TYPES) => [
   TYPES.Authenticator,
   TYPES.SYNC_API_METHODS,
   TYPES.ALLOWED_COLLS,
-  TYPES.Movements,
   TYPES.Wallets,
-  TYPES.CurrencyConverter
+  TYPES.Trades
 ]
 class SummaryByAsset {
   constructor (
@@ -22,26 +21,21 @@ class SummaryByAsset {
     authenticator,
     SYNC_API_METHODS,
     ALLOWED_COLLS,
-    movements,
     wallets,
-    currencyConverter
+    trades
   ) {
     this.dao = dao
     this.syncSchema = syncSchema
     this.authenticator = authenticator
     this.SYNC_API_METHODS = SYNC_API_METHODS
     this.ALLOWED_COLLS = ALLOWED_COLLS
-    this.movements = movements
     this.wallets = wallets
-    this.currencyConverter = currencyConverter
+    this.trades = trades
 
-    this.movementsMethodColl = this.syncSchema.getMethodCollMap()
-      .get(this.SYNC_API_METHODS.MOVEMENTS)
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
     this.ledgersModel = this.syncSchema.getModelsMap()
       .get(this.ALLOWED_COLLS.LEDGERS)
-    this.movementsSymbolFieldName = this.movementsMethodColl.symbolFieldName
     this.ledgersSymbolFieldName = this.ledgersMethodColl.symbolFieldName
   }
 
@@ -54,24 +48,15 @@ class SummaryByAsset {
       .valueOf()
     const start = args?.params?.start ?? mts30dUntilEnd
 
-    const ledgersPromise = this.#getLedgers({
+    const tradesPromise = this.trades.getTrades({
       auth,
       start,
       end
     })
-    const withdrawalsPromise = this.movements.getMovements({
+    const ledgersPromise = this.#getLedgers({
       auth,
       start,
-      end,
-      sort: [['mtsStarted', -1]],
-      isWithdrawals: true
-    })
-    const depositsPromise = this.movements.getMovements({
-      auth,
-      start,
-      end,
-      sort: [['mtsUpdated', -1]],
-      isDeposits: true
+      end
     })
     const startWalletsPromise = this.wallets.getWallets({
       auth,
@@ -83,30 +68,30 @@ class SummaryByAsset {
     })
 
     const [
+      trades,
       ledgers,
-      withdrawals,
-      deposits,
       startWallets,
       endWallets
     ] = await Promise.all([
+      tradesPromise,
       ledgersPromise,
-      withdrawalsPromise,
-      depositsPromise,
       startWalletsPromise,
       endWalletsPromise
     ])
 
     const _summaryByAsset = await this.#calcSummaryByAsset({
-      start,
+      trades,
       ledgers,
-      withdrawals,
-      deposits,
       startWallets,
       endWallets
     })
     const total = this.#calcTotal(_summaryByAsset)
     const summaryByAsset = _summaryByAsset.map((item) => (
-      omit(item, ['calcedStartWalletBalanceUsd'])
+      omit(item, [
+        'balanceChangeUsd',
+        'tradingFeesUsd',
+        'calcedStartWalletBalanceUsd'
+      ])
     ))
 
     return {
@@ -116,21 +101,15 @@ class SummaryByAsset {
   }
 
   async #calcSummaryByAsset ({
-    start,
+    trades,
     ledgers,
-    withdrawals,
-    deposits,
     startWallets,
     endWallets
   }) {
     const currencyRes = []
-    const currencySet = new Set(endWallets.map((wallet) => (
-      wallet.currency
+    const currencySet = new Set(ledgers.map((ledger) => (
+      ledger?.currency
     )))
-    const startRateMap = await this.#getStartRateMapByCandles(
-      start,
-      currencySet
-    )
 
     for (const currency of currencySet) {
       const startWalletsForCurrency = startWallets.filter((wallet) => (
@@ -152,7 +131,6 @@ class SummaryByAsset {
         endWalletsForCurrency,
         'balance'
       )
-
       const calcedEndWalletBalanceUsd = this.#calcFieldByName(
         endWalletsForCurrency,
         'balanceUsd'
@@ -162,68 +140,75 @@ class SummaryByAsset {
         !Number.isFinite(calcedStartWalletBalance) ||
         !Number.isFinite(calcedStartWalletBalanceUsd) ||
         !Number.isFinite(calcedEndWalletBalance) ||
-        !Number.isFinite(calcedEndWalletBalanceUsd) ||
-        calcedEndWalletBalance === 0 ||
-        calcedEndWalletBalanceUsd === 0
+        !Number.isFinite(calcedEndWalletBalanceUsd)
       ) {
         continue
       }
 
-      // Start rate can't be calced by start wallets
-      // due to possibility of non-existent ones
-      const startRate = startRateMap.get(currency)
+      const calcedActualRate = calcedEndWalletBalance === 0
+        ? 0
+        : calcedEndWalletBalanceUsd / calcedEndWalletBalance
       const actualRate = currency === 'USD'
         ? 1
-        : calcedEndWalletBalanceUsd / calcedEndWalletBalance
+        : calcedActualRate
 
       const ledgersForCurrency = ledgers.filter((ledger) => (
         ledger[this.ledgersSymbolFieldName] === currency
       ))
-      const exchangeLedgers = ledgersForCurrency.filter((ledger) => (
-        ledger._category === 5
+      const tradesForCurrency = trades.filter((trade) => (
+        trade?.baseCurrency === currency
       ))
-      const calcedExchangeLedgers = this.#calcFieldByName(
-        exchangeLedgers,
+      const marginFundingPaymentLedgers = ledgersForCurrency.filter((ledger) => (
+        ledger._category === 28
+      ))
+      const tradingFeeLedgers = ledgersForCurrency.filter((ledger) => (
+        ledger._category === 201
+      ))
+
+      const volume = this.#calcFieldByName(
+        tradesForCurrency,
+        'execAmount',
+        { isAbs: true }
+      )
+      const volumeUsd = this.#calcFieldByName(
+        tradesForCurrency,
+        'amountUsd'
+      )
+      const marginFundingPayment = this.#calcFieldByName(
+        marginFundingPaymentLedgers,
         'amount'
       )
-      const calcedExchangeProfitUsd = this.#calcExchangeProfitUsd(
-        exchangeLedgers,
-        startRate
+      const calcedTradingFeeLedgers = this.#calcFieldByName(
+        tradingFeeLedgers,
+        'amount'
       )
-      const calcedVolume30d = this.#calcVolume30d(
-        ledgersForCurrency
+      const calcedTradingFeeUsdLedgers = this.#calcFieldByName(
+        tradingFeeLedgers,
+        'amountUsd'
       )
 
-      const valueChange30d = calcedEndWalletBalance - calcedStartWalletBalance
-      const valueChange30dUsd = valueChange30d * actualRate
-      const valueChange30dPerc = calcedStartWalletBalanceUsd === 0
+      const balanceChange = calcedEndWalletBalance - calcedStartWalletBalance
+      const balanceChangePerc = calcedStartWalletBalance === 0
         ? 0
-        : (valueChange30dUsd / calcedStartWalletBalanceUsd) * 100
-      const calcedMovementsByCurrency = this.#calcMovementsByCurrency(
-        { withdrawals, deposits },
-        currency
-      )
-      const result30d = (
-        valueChange30d -
-        calcedMovementsByCurrency -
-        calcedExchangeLedgers
-      )
-      const result30dUsd = (result30d * (actualRate - startRate)) +
-        calcedExchangeProfitUsd
-      const result30dPerc = calcedStartWalletBalanceUsd === 0
-        ? 0
-        : (result30dUsd / calcedStartWalletBalanceUsd) * 100
-      const volume30dUsd = calcedVolume30d * actualRate
+        : (balanceChange / calcedStartWalletBalance) * 100
+      const balanceChangeUsd = balanceChange * actualRate
+
+      // In the Ledgers amount of fee is negative value, skip sign for UI
+      const tradingFees = Math.abs(calcedTradingFeeLedgers)
+      const tradingFeesUsd = Math.abs(calcedTradingFeeUsdLedgers)
 
       const res = {
         currency,
         balance: calcedEndWalletBalance,
         balanceUsd: calcedEndWalletBalanceUsd,
-        valueChange30dUsd,
-        valueChange30dPerc,
-        result30dUsd,
-        result30dPerc,
-        volume30dUsd,
+        balanceChange,
+        balanceChangePerc,
+        balanceChangeUsd,
+        volume,
+        volumeUsd,
+        tradingFees,
+        tradingFeesUsd,
+        marginFundingPayment,
 
         // It's used to total perc calc
         calcedStartWalletBalanceUsd
@@ -235,65 +220,20 @@ class SummaryByAsset {
     return currencyRes
   }
 
-  #calcFieldByName (wallets, fieldName) {
-    return wallets.reduce((accum, curr) => (
-      Number.isFinite(curr?.[fieldName])
-        ? accum + curr[fieldName]
-        : accum
-    ), 0)
-  }
+  #calcFieldByName (wallets, fieldName, opts) {
+    const { isAbs } = opts ?? {}
 
-  #calcVolume30d (ledgers) {
-    return ledgers.reduce((accum, curr) => {
-      const amount = curr?.amount
-
-      if (!Number.isFinite(amount)) {
+    return wallets.reduce((accum, curr) => {
+      if (!Number.isFinite(curr?.[fieldName])) {
         return accum
       }
 
-      return accum + Math.abs(amount)
+      const val = isAbs
+        ? Math.abs(curr[fieldName])
+        : curr[fieldName]
+
+      return accum + val
     }, 0)
-  }
-
-  #calcExchangeProfitUsd (ledgers, startRate) {
-    return ledgers.reduce((accum, curr) => {
-      const amount = curr?.amount
-      const amountUsd = curr?.amountUsd
-
-      if (
-        !Number.isFinite(amount) ||
-        !Number.isFinite(amountUsd) ||
-        amount > 0 // Take into account the sale
-      ) {
-        return accum
-      }
-
-      const profit = amountUsd - (amount * startRate)
-
-      return accum + profit
-    }, 0)
-  }
-
-  #calcMovementsByCurrency (movements, currency) {
-    const { withdrawals, deposits } = movements ?? {}
-
-    const withdrawalsForCurrency = withdrawals.filter((item) => (
-      item?.[this.movementsSymbolFieldName] === currency
-    ))
-    const depositsForCurrency = deposits.filter((item) => (
-      item?.[this.movementsSymbolFieldName] === currency
-    ))
-
-    const calcedWithdrawals = this.#calcFieldByName(
-      withdrawalsForCurrency,
-      'amount'
-    )
-    const calcedDeposits = this.#calcFieldByName(
-      depositsForCurrency,
-      'amount'
-    )
-
-    return calcedWithdrawals + calcedDeposits
   }
 
   #getLedgers (args) {
@@ -320,11 +260,10 @@ class SummaryByAsset {
   #calcTotal (summaryByAsset) {
     const initTotal = {
       balanceUsd: 0,
-      valueChange30dUsd: 0,
-      valueChange30dPerc: 0,
-      result30dUsd: 0,
-      result30dPerc: 0,
-      volume30dUsd: 0,
+      balanceChangeUsd: 0,
+      balanceChangePerc: 0,
+      volumeUsd: 0,
+      tradingFeesUsd: 0,
 
       calcedStartWalletBalanceUsd: 0
     }
@@ -335,17 +274,16 @@ class SummaryByAsset {
         curr,
         [
           'balanceUsd',
-          'valueChange30dUsd',
-          'result30dUsd',
-          'volume30dUsd',
+          'balanceChangeUsd',
+          'volumeUsd',
+          'tradingFeesUsd',
 
           'calcedStartWalletBalanceUsd'
         ]
       )
 
       if (accum.calcedStartWalletBalanceUsd !== 0) {
-        accum.valueChange30dPerc = (accum.valueChange30dUsd / accum.calcedStartWalletBalanceUsd) * 100
-        accum.result30dPerc = (accum.result30dUsd / accum.calcedStartWalletBalanceUsd) * 100
+        accum.balanceChangePerc = (accum.balanceChangeUsd / accum.calcedStartWalletBalanceUsd) * 100
       }
 
       return accum
@@ -360,19 +298,6 @@ class SummaryByAsset {
         ? accum[propName] + curr[propName]
         : accum[propName]
     }
-  }
-
-  async #getStartRateMapByCandles (start, currencySet) {
-    const startRates = await this.currencyConverter.convertByCandles(
-      [...currencySet].map((ccy) => ({ ccy, multip: 1, rate: 0 })),
-      {
-        symbolFieldName: 'ccy',
-        mts: start,
-        convFields: [{ inputField: 'multip', outputField: 'rate' }]
-      }
-    )
-
-    return new Map(startRates.map(({ ccy, rate }) => [ccy, rate]))
   }
 }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -50,8 +50,10 @@ class SummaryByAsset {
 
     const tradesPromise = this.trades.getTrades({
       auth,
-      start,
-      end
+      params: {
+        start,
+        end
+      }
     })
     const ledgersPromise = this.#getLedgers({
       auth,

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -109,9 +109,14 @@ class SummaryByAsset {
     endWallets
   }) {
     const currencyRes = []
-    const currencySet = new Set(ledgers.map((ledger) => (
-      ledger?.currency
-    )))
+    const currencySet = new Set([
+      ...ledgers.map((ledger) => (
+        ledger?.currency
+      )),
+      ...endWallets.map((wallet) => (
+        wallet?.currency
+      ))
+    ])
 
     for (const currency of currencySet) {
       const startWalletsForCurrency = startWallets.filter((wallet) => (
@@ -198,6 +203,16 @@ class SummaryByAsset {
       // In the Ledgers amount of fee is negative value, skip sign for UI
       const tradingFees = Math.abs(calcedTradingFeeLedgers)
       const tradingFeesUsd = Math.abs(calcedTradingFeeUsdLedgers)
+
+      if (
+        calcedEndWalletBalanceUsd < 0.01 &&
+        volume <= 0 &&
+        balanceChange <= 0 &&
+        tradingFees <= 0 &&
+        marginFundingPayment <= 0
+      ) {
+        continue
+      }
 
       const res = {
         currency,

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -88,7 +88,7 @@ class Trades {
         feeCurrency,
         symbol
       } = _trade
-      const symb = splitSymbolPairs(symbol)[1]
+      const [baseCurrency, symb] = splitSymbolPairs(symbol)
       const isFeeInUsd = feeCurrency === 'USD'
       const isPriceInUsd = symb === 'USD'
 
@@ -131,6 +131,7 @@ class Trades {
       _trade.calcAmount = calcAmount
       _trade.feeUsd = feeUsd
       _trade.feeForCurrConv = feeForCurrConv
+      _trade.baseCurrency = baseCurrency
 
       return _trade
     })


### PR DESCRIPTION
This PR adds exchange volume and trading fee values to the summary by asset

---

Adds the following:
- `volume`: takes from trades, should be in base currency, eg `BTC`
- `volumeUsd`: `amountUsd`, the same as for `getTradedVolume` endpoint
- `tradingFees`: takes from ledgers category `201`, should be in base currency, eg `BTC`
- `tradingFeesUsd`: the same as `tradingFees` but uses `amountUsd` field to take into account the price for the timestamp of the transaction
- `marginFundingPayment`: takes from ledgers category `28`, should be in base currency, eg `BTC`

---

Response example:

```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "summaryByAsset": [
      {
        "currency": "XDC",
        "balance": 0.123,
        "balanceUsd": 0.123,
        "balanceChange": 0.123,
        "balanceChangePerc": 123,
        "volume": 12.123,
        "volumeUsd": 12.123,
        "tradingFees": 0.123,
        "marginFundingPayment": 0
      }
    ],
    "total": {
      "balanceUsd": 12.123,
      "balanceChangeUsd": 12.123,
      "balanceChangePerc": 123.123,
      "volumeUsd": 1234.123,
      "tradingFeesUsd": 1.123
    }
  },
  "id": null
}
```
