### PR TITLE
Stop auth token refresh interval if auth error

### DIFF
--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -7,7 +7,8 @@ const {
   ArgsParamsError
 } = require('bfx-report/workers/loc.api/errors')
 const {
-  isENetError
+  isENetError,
+  isAuthError
 } = require('bfx-report/workers/loc.api/helpers')
 
 const { serializeVal } = require('../dao/helpers')
@@ -1385,6 +1386,10 @@ class Authenticator {
           authToken: prevAuthToken
         })
       } catch (err) {
+        if (isAuthError(err)) {
+          clearInterval(newAuthTokenRefreshInterval)
+        }
+
         this.logger.debug(err)
 
         await this.wsEventEmitterFactory()


### PR DESCRIPTION
This PR adds simple improvements to the token refresh flow: stop the auth token refresh interval if catch an auth error

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/348