### PR TITLE
Move statement details section under logo for pdf reports

### DIFF
--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -62,7 +62,7 @@ class PdfWriter extends MainPdfWriter {
       template = 'No data',
       format = 'portrait',
       orientation = 'Letter',
-      headerHeight = '54mm',
+      headerHeight = '65mm',
       footerHeight = '28mm'
     } = args ?? {}
 

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -61,7 +61,9 @@ class PdfWriter extends MainPdfWriter {
     const {
       template = 'No data',
       format = 'portrait',
-      orientation = 'Letter'
+      orientation = 'Letter',
+      headerHeight = '70mm',
+      footerHeight = '28mm'
     } = args ?? {}
 
     if (this.isElectronjsEnv) {
@@ -72,8 +74,18 @@ class PdfWriter extends MainPdfWriter {
       })
     }
 
+    const headerOpt = headerHeight
+      ? { header: { height: headerHeight } }
+      : {}
+    const footerOpt = footerHeight
+      ? { footer: { height: footerHeight } }
+      : {}
+
     return await new Promise((resolve, reject) => {
       pdf.create(template, {
+        ...headerOpt,
+        ...footerOpt,
+
         format,
         orientation,
         type: 'pdf',

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -62,7 +62,7 @@ class PdfWriter extends MainPdfWriter {
       template = 'No data',
       format = 'portrait',
       orientation = 'Letter',
-      headerHeight = '70mm',
+      headerHeight = '54mm',
       footerHeight = '28mm'
     } = args ?? {}
 

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/full-snapshot-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/full-snapshot-report.pug
@@ -18,7 +18,7 @@ block content
     :translate(prop='template.positions')
       Positions
 
-  ul.responsive-table.sm.no-margin-bottom
+  ul.responsive-table.no-margin-bottom
     li.table-header
       each columnVal, columnKey in reportColumns.positionsSnapshot
         .col #{columnVal}
@@ -27,7 +27,7 @@ block content
         each columnVal, columnKey in reportColumns.positionsSnapshot
           .col #{dataItem[columnKey]}
 
-  ul.responsive-table.sm.width-by-content
+  ul.responsive-table.width-by-content
     li.table-header
       each columnVal, columnKey in reportColumns.positionsTotalPlUsd
         .col #{columnVal}

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/full-tax-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/full-tax-report.pug
@@ -15,7 +15,7 @@ block content
     :translate(prop='template.startingPositionsSnapshot')
       Starting positions snapshot
 
-  ul.responsive-table.sm
+  ul.responsive-table
     li.table-header
       each columnVal, columnKey in reportColumns.positionsSnapshot
         .col #{columnVal}
@@ -28,7 +28,7 @@ block content
     :translate(prop='template.endingPositionsSnapshot')
       Ending positions snapshot
 
-  ul.responsive-table.sm
+  ul.responsive-table
     li.table-header
       each columnVal, columnKey in reportColumns.positionsSnapshot
         .col #{columnVal}
@@ -57,7 +57,7 @@ block content
     :translate(prop='template.movementsDetails')
       Movements details
 
-  ul.responsive-table.sm.no-margin-bottom
+  ul.responsive-table.no-margin-bottom
     li.table-header
       each columnVal, columnKey in reportColumns.movements
         .col #{columnVal}
@@ -66,7 +66,7 @@ block content
         each columnVal, columnKey in reportColumns.movements
           .col #{dataItem[columnKey]}
 
-  ul.responsive-table.sm.width-by-content
+  ul.responsive-table.width-by-content
     li.table-header
       each columnVal, columnKey in reportColumns.movementsTotalAmount
         .col #{columnVal}


### PR DESCRIPTION
This PR moves the `Statement Details` section under the logo for pdf reports

---

![S-D-2](https://github.com/bitfinexcom/bfx-report/assets/16489235/89b9c4d0-a8ff-48ab-acfa-5e4797772f39)

![S-D-1](https://github.com/bitfinexcom/bfx-report/assets/16489235/e2c477af-f443-4c26-8982-de1ea1adf914)

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/349
