### PR TITLE
Set 90sec timeout for html-pdf lib

### DIFF
--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -89,6 +89,7 @@ class PdfWriter extends MainPdfWriter {
         format,
         orientation,
         type: 'pdf',
+        timeout: 90000,
         childProcessOptions: {
           env: { OPENSSL_CONF: '/dev/null' }
         }


### PR DESCRIPTION
This PR sets 90sec timeout for `html-pdf` lib

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/351
