### PR TITLE
Add missing translations for pdf reports

### DIFF
--- a/workers/loc.api/generate-report-file/pdf-writer/translations.yml
+++ b/workers/loc.api/generate-report-file/pdf-writer/translations.yml
@@ -23,3 +23,68 @@ ru:
     wallets: Кошельки
     positionsTickers: Тикеры позиций
     walletsTickers: Тикеры кошельков
+
+zh-CN:
+  template:
+    startingPositionsSnapshot: 仓位期初快照
+    endingPositionsSnapshot: 仓位期末快照
+    finalState: 最后状态
+    startingPeriodBalances: 期初余额
+    movementsDetails: 资金流向明细
+    endingPeriodBalances: 期末余额
+    positions: 仓位
+    wallets: 钱包
+    positionsTickers: 仓位牌价
+    walletsTickers: 钱包牌价
+
+zh-TW:
+  template:
+    startingPositionsSnapshot: 倉位期初快照
+    endingPositionsSnapshot: 倉位期末快照
+    finalState: 最終狀態
+    startingPeriodBalances: 期初餘額
+    movementsDetails: 資金流向明細
+    endingPeriodBalances: 期末餘額
+    positions: 倉位
+    wallets: 錢包
+    positionsTickers: 倉位牌價
+    walletsTickers: 錢包牌價
+
+es-EM:
+  template:
+    startingPositionsSnapshot: Captura de las posiciones iniciales
+    endingPositionsSnapshot: Captura de las posiciones finales
+    finalState: Estado final
+    startingPeriodBalances: Balances al inicio del periodo
+    movementsDetails: Detalles de Movimientos
+    endingPeriodBalances: Balances al final del periodo
+    positions: Posiciones
+    wallets: Carteras
+    positionsTickers: cotizaciones de las Posiciones
+    walletsTickers: cotizaciones de las Carteras
+
+tr:
+  template:
+    startingPositionsSnapshot: Pozisyonların Başlangıç Anlık Görüntüsü
+    endingPositionsSnapshot: Pozisyonların Bitiş Anlık Görüntüsü
+    finalState: Son Durum
+    startingPeriodBalances: Başlangıç ​​Dönemi Bakiyeleri
+    movementsDetails: Hareket Detayları
+    endingPeriodBalances: Bitiş Dönemi Bakiyeleri
+    positions: Poziyonlar
+    wallets: Cüzdanlar
+    positionsTickers: Pozisyon Tickerları
+    walletsTickers: Cüzdan Tickerları
+
+pt-BR:
+  template:
+    startingPositionsSnapshot: Captura das posições iniciais
+    endingPositionsSnapshot: Captura das posições finais
+    finalState: Estado final
+    startingPeriodBalances: Saldos no início do período
+    movementsDetails: Detalhes das movimentações
+    endingPeriodBalances: Saldos no final do período
+    positions: Posições
+    wallets: Carteiras
+    positionsTickers: cotações das posições
+    walletsTickers: cotações das Carteiras


### PR DESCRIPTION
This PR adds missing translations for pdf reports

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/356
