### PR TITLE
Update gh action setup-node to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Setup configs


### PR DESCRIPTION
This PR updates GitHub `action/setup-node` to `v4` to resolve `Node.js 16 actions are deprecated`

---

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

![Screenshot from 2024-04-03 11-42-49](https://github.com/bitfinexcom/bfx-facs-db-better-sqlite/assets/16489235/74935ba1-cd57-4ebb-95c1-9a08802d0ca9)

