### PR TITLE
[PART-1] Add transaction tax report

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -97,6 +97,7 @@ const {
   fullTaxReportCsvWriter
 } = require('../generate-report-file/csv-writer')
 const FullTaxReport = require('../sync/full.tax.report')
+const TransactionTaxReport = require('../sync/transaction.tax.report')
 const WeightedAveragesReport = require('../sync/weighted.averages.report')
 const SqliteDbMigrator = require(
   '../sync/dao/db-migrations/sqlite.db.migrator'
@@ -151,6 +152,7 @@ module.exports = ({
           ['_positionsSnapshot', TYPES.PositionsSnapshot],
           ['_fullSnapshotReport', TYPES.FullSnapshotReport],
           ['_fullTaxReport', TYPES.FullTaxReport],
+          ['_transactionTaxReport', TYPES.TransactionTaxReport],
           ['_tradedVolume', TYPES.TradedVolume],
           ['_totalFeesReport', TYPES.TotalFeesReport],
           ['_performingLoan', TYPES.PerformingLoan],
@@ -393,6 +395,9 @@ module.exports = ({
       )
     bind(TYPES.FullTaxReport)
       .to(FullTaxReport)
+    bind(TYPES.TransactionTaxReport)
+      .to(TransactionTaxReport)
+      .inSingletonScope()
     rebind(TYPES.WeightedAveragesReport)
       .to(WeightedAveragesReport)
     rebind(TYPES.ReportFileJobData)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -69,5 +69,6 @@ module.exports = {
   SyncUserStepData: Symbol.for('SyncUserStepData'),
   SyncUserStepDataFactory: Symbol.for('SyncUserStepDataFactory'),
   HTTPRequest: Symbol.for('HTTPRequest'),
-  SummaryByAsset: Symbol.for('SummaryByAsset')
+  SummaryByAsset: Symbol.for('SummaryByAsset'),
+  TransactionTaxReport: Symbol.for('TransactionTaxReport')
 }

--- a/workers/loc.api/generate-report-file/report.file.job.data.js
+++ b/workers/loc.api/generate-report-file/report.file.job.data.js
@@ -528,6 +528,50 @@ class ReportFileJobData extends BaseReportFileJobData {
     return jobData
   }
 
+  async getTransactionTaxReportFileJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForTransactionTaxReportFile')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      uId,
+      uInfo
+    )
+
+    const reportFileArgs = getReportFileArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getTransactionTaxReport',
+      fileNamesMap: [['getTransactionTaxReport', 'transaction-tax-report']],
+      args: reportFileArgs,
+      propNameForPagination: null,
+      columnsCsv: {
+        asset: 'DESCRIPTION OF PROPERTY',
+        amount: 'AMOUNT',
+        mtsAcquired: 'DATE ACQUIRED',
+        mtsSold: 'DATE SOLD',
+        proceeds: 'PROCEEDS',
+        cost: 'COST',
+        gainOrLoss: 'GAIN OR LOSS'
+      },
+      formatSettings: {
+        asset: 'symbol',
+        mtsAcquired: 'date',
+        mtsSold: 'date'
+      }
+    }
+
+    return jobData
+  }
+
   async getTradedVolumeFileJobData (
     args,
     uId,

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -214,6 +214,25 @@ const paramsSchemaForFullTaxReportApi = {
   }
 }
 
+const paramsSchemaForTransactionTaxReportApi = {
+  type: 'object',
+  properties: {
+    end: {
+      type: 'integer'
+    },
+    start: {
+      type: 'integer'
+    },
+    strategy: {
+      type: 'string',
+      enum: [
+        'FIFO',
+        'LIFO'
+      ]
+    }
+  }
+}
+
 const paramsSchemaForWinLossApi = {
   type: 'object',
   properties: {
@@ -412,6 +431,15 @@ const paramsSchemaForFullTaxReportFile = {
   }
 }
 
+const paramsSchemaForTransactionTaxReportFile = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForTransactionTaxReportApi.properties),
+    timezone,
+    dateFormat
+  }
+}
+
 const paramsSchemaForTradedVolumeFile = {
   type: 'object',
   properties: {
@@ -460,6 +488,7 @@ module.exports = {
   paramsSchemaForPositionsSnapshotApi,
   paramsSchemaForFullSnapshotReportApi,
   paramsSchemaForFullTaxReportApi,
+  paramsSchemaForTransactionTaxReportApi,
   paramsSchemaForTradedVolumeApi,
   paramsSchemaForTotalFeesReportApi,
   paramsSchemaForPerformingLoanApi,
@@ -471,6 +500,7 @@ module.exports = {
   paramsSchemaForPositionsSnapshotFile,
   paramsSchemaForFullSnapshotReportFile,
   paramsSchemaForFullTaxReportFile,
+  paramsSchemaForTransactionTaxReportFile,
   paramsSchemaForTradedVolumeFile,
   paramsSchemaForTotalFeesReportFile,
   paramsSchemaForPerformingLoanFile,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1578,6 +1578,20 @@ class FrameworkReportService extends ReportService {
   /**
    * @deprecated
    */
+  getTransactionTaxReportCsv (...args) { return this.getTransactionTaxReportFile(...args) }
+
+  getTransactionTaxReportFile (space, args, cb) {
+    return this._responder(() => {
+      return this._generateReportFile(
+        'getTransactionTaxReportFileJobData',
+        args
+      )
+    }, 'getTransactionTaxReportFile', args, cb)
+  }
+
+  /**
+   * @deprecated
+   */
   getTradedVolumeCsv (...args) { return this.getTradedVolumeFile(...args) }
 
   getTradedVolumeFile (space, args, cb) {

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1420,6 +1420,17 @@ class FrameworkReportService extends ReportService {
     }, 'getTransactionTaxReport', args, cb)
   }
 
+  makeTrxTaxReportInBackground (space, args, cb) {
+    return this._privResponder(async () => {
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.TRANSACTION_TAX_REPORT, args)
+
+      checkParams(args, 'paramsSchemaForTransactionTaxReportApi')
+
+      return this._transactionTaxReport.makeTrxTaxReportInBackground(args)
+    }, 'makeTrxTaxReportInBackground', args, cb)
+  }
+
   getTradedVolume (space, args, cb) {
     return this._privResponder(async () => {
       await this._dataConsistencyChecker

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -1409,6 +1409,17 @@ class FrameworkReportService extends ReportService {
     }, 'getFullTaxReport', args, cb)
   }
 
+  getTransactionTaxReport (space, args, cb) {
+    return this._privResponder(async () => {
+      await this._dataConsistencyChecker
+        .check(this._CHECKER_NAMES.TRANSACTION_TAX_REPORT, args)
+
+      checkParams(args, 'paramsSchemaForTransactionTaxReportApi')
+
+      return this._transactionTaxReport.getTransactionTaxReport(args)
+    }, 'getTransactionTaxReport', args, cb)
+  }
+
   getTradedVolume (space, args, cb) {
     return this._privResponder(async () => {
       await this._dataConsistencyChecker

--- a/workers/loc.api/sync/data.consistency.checker/checker.names.js
+++ b/workers/loc.api/sync/data.consistency.checker/checker.names.js
@@ -7,6 +7,7 @@ module.exports = {
   POSITIONS_SNAPSHOT: 'getPositionsSnapshot',
   FULL_SNAPSHOT_REPORT: 'getFullSnapshotReport',
   FULL_TAX_REPORT: 'getFullTaxReport',
+  TRANSACTION_TAX_REPORT: 'getTransactionTaxReport',
   TRADED_VOLUME: 'getTradedVolume',
   TOTAL_FEES_REPORT: 'getTotalFeesReport',
   PERFORMING_LOAN: 'getPerformingLoan',

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -103,6 +103,20 @@ class Checkers {
       })
   }
 
+  [CHECKER_NAMES.TRANSACTION_TAX_REPORT] (auth) {
+    return this.syncCollsManager
+      .haveCollsBeenSyncedUpToDate({
+        auth,
+        params: {
+          schema: [
+            this.SYNC_API_METHODS.TRADES,
+            this.SYNC_API_METHODS.LEDGERS,
+            this.SYNC_API_METHODS.MOVEMENTS
+          ]
+        }
+      })
+  }
+
   [CHECKER_NAMES.TRADED_VOLUME] (auth) {
     return this.syncCollsManager
       .haveCollsBeenSyncedUpToDate({

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const TRX_TAX_STRATEGIES = require('./trx.tax.strategies')
+
+module.exports = {
+  TRX_TAX_STRATEGIES
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/trx.tax.strategies.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/trx.tax.strategies.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const TRX_TAX_STRATEGIES = {
+  FIFO: 'FIFO',
+  LIFO: 'LIFO'
+}
+
+module.exports = TRX_TAX_STRATEGIES

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const {
+  TRX_TAX_STRATEGIES
+} = require('./helpers')
+
+const { decorateInjectable } = require('../../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.DAO,
+  TYPES.Authenticator,
+  TYPES.SyncSchema,
+  TYPES.ALLOWED_COLLS,
+  TYPES.SYNC_API_METHODS,
+  TYPES.Movements,
+  TYPES.RService,
+  TYPES.GetDataFromApi,
+  TYPES.WSEventEmitterFactory,
+  TYPES.Logger
+]
+class TransactionTaxReport {
+  constructor (
+    dao,
+    authenticator,
+    syncSchema,
+    ALLOWED_COLLS,
+    SYNC_API_METHODS,
+    movements,
+    rService,
+    getDataFromApi,
+    wsEventEmitterFactory,
+    logger
+  ) {
+    this.dao = dao
+    this.authenticator = authenticator
+    this.syncSchema = syncSchema
+    this.ALLOWED_COLLS = ALLOWED_COLLS
+    this.SYNC_API_METHODS = SYNC_API_METHODS
+    this.movements = movements
+    this.rService = rService
+    this.getDataFromApi = getDataFromApi
+    this.wsEventEmitterFactory = wsEventEmitterFactory
+    this.logger = logger
+
+    this.tradesModel = this.syncSchema.getModelsMap()
+      .get(this.ALLOWED_COLLS.TRADES)
+  }
+
+  async makeTrxTaxReportInBackground (args = {}) {
+    const { auth, params } = args ?? {}
+    const user = await this.authenticator
+      .verifyRequestUser({ auth })
+    const _args = { auth: user, params }
+
+    this.wsEventEmitterFactory()
+      .emitTrxTaxReportGenerationInBackgroundToOne(() => {
+        return this.getTransactionTaxReport(_args)
+      }, user)
+      .then(() => {}, (err) => {
+        this.logger.error(`TRX_TAX_REPORT_GEN_FAILED: ${err.stack || err}`)
+      })
+
+    return true
+  }
+
+  async getTransactionTaxReport (args = {}) {
+    const { auth, params } = args ?? {}
+    const start = params.start ?? 0
+    const end = params.end ?? Date.now()
+    const strategy = params.strategy ?? TRX_TAX_STRATEGIES.LIFO
+    const user = await this.authenticator
+      .verifyRequestUser({ auth })
+
+    const isFIFO = strategy === TRX_TAX_STRATEGIES.FIFO
+    const isLIFO = strategy === TRX_TAX_STRATEGIES.LIFO
+
+    // TODO:
+    return []
+  }
+}
+
+decorateInjectable(TransactionTaxReport, depsTypes)
+
+module.exports = TransactionTaxReport

--- a/workers/loc.api/ws-transport/ws.event.emitter.js
+++ b/workers/loc.api/ws-transport/ws.event.emitter.js
@@ -138,6 +138,21 @@ class WSEventEmitter extends AbstractWSEventEmitter {
     }, 'emitBfxUnamePwdAuthRequired')
   }
 
+  emitTrxTaxReportGenerationInBackgroundToOne (
+    handler = () => {},
+    auth = {}
+  ) {
+    return this.emit(async (user, ...args) => {
+      if (this.isNotTargetUser(auth, user)) {
+        return { isNotEmitted: true }
+      }
+
+      return typeof handler === 'function'
+        ? await handler(user, ...args)
+        : handler
+    }, 'emitTrxTaxReportGenerationInBackgroundToOne')
+  }
+
   async emitRedirectingRequestsStatusToApi (
     handler = () => {}
   ) {


### PR DESCRIPTION
This PR adds the main structure for `Transaction Tax Report`

---

It's a 1-part of the feature, the main idea taken from these PRs: https://github.com/bitfinexcom/bfx-reports-framework/pull/373, https://github.com/bitfinexcom/bfx-reports-framework/pull/378, https://github.com/bitfinexcom/bfx-reports-framework/pull/379
- separates into small parts
- improves and speeds up the currency conversion approach (in the future PRs)

---

Basic changes:
- adds `getTransactionTaxReport` endpoint
- adds `getTransactionTaxReportFile` endpoint
- adds `makeTrxTaxReportInBackground` endpoint

---

- `getTransactionTaxReport` request example
```jsonc
{
  "auth": {
    "token": "user_token"
  },
  "method": "getTransactionTaxReport",
  "params": {
    "start": 1706861968714,
    "end": 1712042359302,
    "strategy": "LIFO" // or "FIFO"
  }
}
```

- `getTransactionTaxReport` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": [
    {
      "asset": "LTC",
      "amount": 1.43796106,
      "mtsAcquired": 1712042016000,
      "mtsSold": 1712042359302,
      "proceeds": 142.64861307412,
      "cost": 142.41853930451998,
      "gainOrLoss": 0.23007376960001125
    },
    {
      "asset": "BTC",
      "amount": 0.001342,
      "mtsAcquired": 1649771737942,
      "mtsSold": 1709584808125,
      "proceeds": 90.838638,
      "cost": 54.303808778059306,
      "gainOrLoss": 36.5348292219407
    },
    {
      "asset": "LTC",
      "amount": 1e-8,
      "mtsAcquired": 1706858241000,
      "mtsSold": 1706861968714,
      "proceeds": 6.7707e-7,
      "cost": 6.7876e-7,
      "gainOrLoss": -1.6900000000000634e-9
    }
  ],
  "id": null
}
```

---

- `getTransactionTaxReportFile` request example
```jsonc
{
  "auth": {
    "token": "user_token"
  },
  "method": "getTransactionTaxReportFile",
  "params": {
    "start": 1706861968714,
    "end": 1712042359302,
    "strategy": "LIFO"
  }
}
```

- `getTransactionTaxReportFile` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "isSaveLocaly": true,
    "localReportFolderPath": "/home/user/docs/bitfinex/report-files",
    "remoteReportUrn": null,
    "localCsvFolderPath": "/home/user/docs/bitfinex/report-files",
    "remoteCsvUrn": null
  },
  "id": null
}
```

---

- `makeTrxTaxReportInBackground` request example
```jsonc
{
  "auth": {
    "token": "user_token"
  },
  "method": "makeTrxTaxReportInBackground",
  "params": {
    "start": 1706861968714,
    "end": 1712042359302,
    "strategy": "LIFO"
  }
}
```

- `makeTrxTaxReportInBackground` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": true,
  "id": null
}
```

The idea of the `makeTrxTaxReportInBackground` endpoint is the following:
- the big users may have a lot of trades for a certain year
- to convert currencies to USD are used the public trades endpoint of the BFX API with 15reqs/min rate limit
- it can lead to significant time in report generation
- to fight HTTP timeout for this case, it is necessary to send `makeTrxTaxReportInBackground` HTTP request to schedule generation
- and when the report generation is successful the data of the tax report will be responded via WebSocket

- `emitTrxTaxReportGenerationInBackgroundToOne` WS event example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": [
    {
      "asset": "LTC",
      "amount": 1.43796106,
      "mtsAcquired": 1712042016000,
      "mtsSold": 1712042359302,
      "proceeds": 142.64861307412,
      "cost": 142.41853930451998,
      "gainOrLoss": 0.23007376960001125
    },
    {
      "asset": "BTC",
      "amount": 0.001342,
      "mtsAcquired": 1649771737942,
      "mtsSold": 1709584808125,
      "proceeds": 90.838638,
      "cost": 54.303808778059306,
      "gainOrLoss": 36.5348292219407
    },
    {
      "asset": "LTC",
      "amount": 1e-8,
      "mtsAcquired": 1706858241000,
      "mtsSold": 1706861968714,
      "proceeds": 6.7707e-7,
      "cost": 6.7876e-7,
      "gainOrLoss": -1.6900000000000634e-9
    }
  ],
  "id": null,
  "action": "emitTrxTaxReportGenerationInBackgroundToOne"
}
```

- `emitTrxTaxReportGenerationInBackgroundToOne` WS event example in case an `error`
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 500,
    "message": "Internal Server Error",
    "data": null
  },
  "id": null,
  "action": "emitTrxTaxReportGenerationInBackgroundToOne"
}
```
