### PR TITLE
[PART-3] Add transaction tax report

### DIFF
--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -97,7 +97,8 @@ class Movements {
       end,
       sort: ledgersOrder,
       isWithdrawals,
-      isDeposits
+      isDeposits,
+      isExcludePrivate
     })
 
     const [
@@ -182,7 +183,9 @@ class Movements {
         currency,
         amount,
         amountUsd,
-        subUserId
+        subUserId,
+        _id,
+        exactUsdValue
       } = ledger
 
       return {
@@ -199,7 +202,9 @@ class Movements {
         transactionId: '',
         note: '',
         subUserId,
-        _isFromLedgers: true
+        isLedgers: true,
+        _id,
+        exactUsdValue
       }
     })
   }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const TRX_TAX_STRATEGIES = require('./trx.tax.strategies')
+const remapTrades = require('./remap-trades')
+const remapMovements = require('./remap-movements')
 
 module.exports = {
-  TRX_TAX_STRATEGIES
+  TRX_TAX_STRATEGIES,
+  remapTrades,
+  remapMovements
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -28,10 +28,13 @@ module.exports = (movements, params) => {
       : ''
 
     const remappedMovement = {
+      _id: movement._id,
       // NOTE: it means entries are not taken form trades table
       isAdditionalTrxMovements: true,
       // NOTE: movements can have sub-account transfer entries from ledgers table
       isMovements: !movement.isLedgers,
+      isLedgers: !!movement.isLedgers,
+      isTrades: false,
       symbol: `t${firstSymb}${symbSeparator}${lastSymb}`,
       mtsCreate: movement.mtsUpdated,
       firstSymb,

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const {
+  isForexSymb
+} = require('../../helpers')
+
+module.exports = (movements, params) => {
+  const {
+    remappedTrxs,
+    remappedTrxsForConvToUsd
+  } = params
+
+  for (const movement of movements) {
+    if (
+      !movement?.currency ||
+      isForexSymb(movement.currency) ||
+      !Number.isFinite(movement?.amount) ||
+      movement.amount === 0 ||
+      !Number.isFinite(movement?.mtsUpdated)
+    ) {
+      continue
+    }
+
+    const firstSymb = movement.currency
+    const lastSymb = 'USD'
+    const symbSeparator = firstSymb.length > 3
+      ? ':'
+      : ''
+
+    const remappedMovement = {
+      // NOTE: it means entries are not taken form trades table
+      isAdditionalTrxMovements: true,
+      // NOTE: movements can have sub-account transfer entries from ledgers table
+      isMovements: !movement.isLedgers,
+      symbol: `t${firstSymb}${symbSeparator}${lastSymb}`,
+      mtsCreate: movement.mtsUpdated,
+      firstSymb,
+      lastSymb,
+      firstSymbPrice: null,
+      lastSymbPrice: 1,
+      execAmount: movement.amount,
+      // NOTE: execPrice = firstSymbPrice and should be set when converting currencies
+      execPrice: 0,
+      // NOTE: exactUsdValue can be null on the first launch, for warm-up it's filling from pub-trades
+      exactUsdValue: movement.exactUsdValue
+    }
+
+    remappedTrxs.push(remappedMovement)
+
+    if (
+      Number.isFinite(movement.exactUsdValue) &&
+      movement.exactUsdValue > 0
+    ) {
+      const price = movement.exactUsdValue / movement.amount
+
+      remappedMovement.firstSymbPrice = price
+      remappedMovement.execPrice = price
+
+      continue
+    }
+
+    remappedTrxsForConvToUsd.push(remappedMovement)
+  }
+
+  return params
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -39,10 +39,10 @@ module.exports = (movements, params) => {
       mtsCreate: movement.mtsUpdated,
       firstSymb,
       lastSymb,
-      firstSymbPrice: null,
-      lastSymbPrice: 1,
+      firstSymbPriceUsd: null,
+      lastSymbPriceUsd: 1,
       execAmount: movement.amount,
-      // NOTE: execPrice = firstSymbPrice and should be set when converting currencies
+      // NOTE: execPrice = firstSymbPriceUsd and should be set when converting currencies
       execPrice: 0,
       // NOTE: exactUsdValue can be null on the first launch, for warm-up it's filling from pub-trades
       exactUsdValue: movement.exactUsdValue
@@ -56,7 +56,7 @@ module.exports = (movements, params) => {
     ) {
       const price = movement.exactUsdValue / movement.amount
 
-      remappedMovement.firstSymbPrice = price
+      remappedMovement.firstSymbPriceUsd = price
       remappedMovement.execPrice = price
 
       continue

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const splitSymbolPairs = require(
+  'bfx-report/workers/loc.api/helpers/split-symbol-pairs'
+)
+
+module.exports = (trades, params) => {
+  const {
+    remappedTrxs,
+    remappedTrxsForConvToUsd
+  } = params
+
+  for (const trade of trades) {
+    if (
+      !trade?.symbol ||
+      !Number.isFinite(trade?.execAmount) ||
+      trade.execAmount === 0 ||
+      !Number.isFinite(trade?.execPrice) ||
+      trade.execPrice === 0 ||
+      !Number.isFinite(trade?.mtsCreate)
+    ) {
+      continue
+    }
+
+    const [firstSymb, lastSymb] = splitSymbolPairs(trade.symbol)
+    trade.firstSymb = firstSymb
+    trade.lastSymb = lastSymb
+    trade.firstSymbPrice = null
+    trade.lastSymbPrice = null
+
+    remappedTrxs.push(trade)
+
+    if (lastSymb === 'USD') {
+      trade.firstSymbPrice = trade.execPrice
+      trade.lastSymbPrice = 1
+
+      continue
+    }
+    if (
+      Number.isFinite(trade.exactUsdValue) &&
+      trade.exactUsdValue > 0
+    ) {
+      trade.firstSymbPrice = trade.exactUsdValue / trade.execAmount
+      trade.lastSymbPrice = trade.exactUsdValue / trade.execPrice
+
+      continue
+    }
+
+    remappedTrxsForConvToUsd.push(trade)
+  }
+
+  return params
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -25,8 +25,8 @@ module.exports = (trades, params) => {
     const [firstSymb, lastSymb] = splitSymbolPairs(trade.symbol)
     trade.firstSymb = firstSymb
     trade.lastSymb = lastSymb
-    trade.firstSymbPrice = null
-    trade.lastSymbPrice = null
+    trade.firstSymbPriceUsd = null
+    trade.lastSymbPriceUsd = null
     trade.isAdditionalTrxMovements = false
     trade.isMovements = false
     trade.isLedgers = false
@@ -35,8 +35,8 @@ module.exports = (trades, params) => {
     remappedTrxs.push(trade)
 
     if (lastSymb === 'USD') {
-      trade.firstSymbPrice = trade.execPrice
-      trade.lastSymbPrice = 1
+      trade.firstSymbPriceUsd = trade.execPrice
+      trade.lastSymbPriceUsd = 1
 
       continue
     }
@@ -44,8 +44,8 @@ module.exports = (trades, params) => {
       Number.isFinite(trade.exactUsdValue) &&
       trade.exactUsdValue > 0
     ) {
-      trade.firstSymbPrice = trade.exactUsdValue / trade.execAmount
-      trade.lastSymbPrice = trade.exactUsdValue / trade.execPrice
+      trade.firstSymbPriceUsd = trade.exactUsdValue / trade.execAmount
+      trade.lastSymbPriceUsd = trade.exactUsdValue / trade.execPrice
 
       continue
     }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -27,6 +27,10 @@ module.exports = (trades, params) => {
     trade.lastSymb = lastSymb
     trade.firstSymbPrice = null
     trade.lastSymbPrice = null
+    trade.isAdditionalTrxMovements = false
+    trade.isMovements = false
+    trade.isLedgers = false
+    trade.isTrades = true
 
     remappedTrxs.push(trade)
 


### PR DESCRIPTION
This PR adds ability to fetch transactions entries based on `trades`, `movements` and  `ledgers` tables for `Transaction Tax Report`

---

It's a 1-part of the feature, the main idea taken from these PRs: https://github.com/bitfinexcom/bfx-reports-framework/pull/373, https://github.com/bitfinexcom/bfx-reports-framework/pull/378, https://github.com/bitfinexcom/bfx-reports-framework/pull/379
- separates into small parts
- improves and speeds up the currency conversion approach

---

Basic changes:
- Adds ability to return `exactUsdValue` and `_id` for movements
- Adds ability to fetch transactions
