### PR TITLE
[PART-5] Add transaction tax report

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -266,6 +266,12 @@ class PubTradeFindForTrxTaxError extends BaseError {
   }
 }
 
+class PubTradePriceFindForTrxTaxError extends BaseError {
+  constructor (message = 'ERR_NO_PUBLIC_TRADE_PRICE_FOR_TRX_TAX') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -305,5 +311,6 @@ module.exports = {
   AuthTokenTTLSettingError,
   CurrencyConversionError,
   CurrencyPairSeparationError,
-  PubTradeFindForTrxTaxError
+  PubTradeFindForTrxTaxError,
+  PubTradePriceFindForTrxTaxError
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -260,6 +260,12 @@ class CurrencyPairSeparationError extends BaseError {
   }
 }
 
+class PubTradeFindForTrxTaxError extends BaseError {
+  constructor (message = 'ERR_NO_PUBLIC_TRADES_FOR_TRX_TAX') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
@@ -298,5 +304,6 @@ module.exports = {
   AuthTokenGenerationError,
   AuthTokenTTLSettingError,
   CurrencyConversionError,
-  CurrencyPairSeparationError
+  CurrencyPairSeparationError,
+  PubTradeFindForTrxTaxError
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { PubTradeFindForTrxTaxError } = require('../../../errors')
+
 module.exports = (pubTrades, mts) => {
   if (
     !Array.isArray(pubTrades) ||
@@ -9,8 +11,7 @@ module.exports = (pubTrades, mts) => {
     pubTrades[0]?.mts > mts ||
     pubTrades[pubTrades.length - 1]?.mts < mts
   ) {
-    // TODO:
-    throw new Error('ERR_NO_PUBLIC_TRADES')
+    throw new PubTradeFindForTrxTaxError()
   }
 
   let startIndex = 0

--- a/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
@@ -1,0 +1,35 @@
+'use strict'
+
+module.exports = (pubTrades, mts) => {
+  if (
+    !Array.isArray(pubTrades) ||
+    pubTrades.length === 0 ||
+    !Number.isFinite(pubTrades[0]?.mts) ||
+    !Number.isFinite(pubTrades[pubTrades.length - 1]?.mts) ||
+    pubTrades[0]?.mts > mts ||
+    pubTrades[pubTrades.length - 1]?.mts < mts
+  ) {
+    // TODO:
+    throw new Error('ERR_NO_PUBLIC_TRADES')
+  }
+
+  let startIndex = 0
+  let endIndex = pubTrades.length - 1
+  let middleIndex = null
+
+  while (startIndex <= endIndex) {
+    middleIndex = Math.floor((startIndex + endIndex) / 2)
+
+    if (pubTrades[middleIndex]?.mts === mts) {
+      return pubTrades[middleIndex]
+    }
+    if (mts < pubTrades[middleIndex]?.mts) {
+      endIndex = middleIndex - 1
+    }
+    if (mts > pubTrades[middleIndex]?.mts) {
+      startIndex = middleIndex + 1
+    }
+  }
+
+  return pubTrades[middleIndex]
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
@@ -1,19 +1,6 @@
 'use strict'
 
-const { PubTradeFindForTrxTaxError } = require('../../../errors')
-
 module.exports = (pubTrades, mts) => {
-  if (
-    !Array.isArray(pubTrades) ||
-    pubTrades.length === 0 ||
-    !Number.isFinite(pubTrades[0]?.mts) ||
-    !Number.isFinite(pubTrades[pubTrades.length - 1]?.mts) ||
-    pubTrades[0]?.mts > mts ||
-    pubTrades[pubTrades.length - 1]?.mts < mts
-  ) {
-    throw new PubTradeFindForTrxTaxError()
-  }
-
   let startIndex = 0
   let endIndex = pubTrades.length - 1
   let middleIndex = null

--- a/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
@@ -7,6 +7,14 @@ const TrxPriceCalculator = require('./trx.price.calculator')
 // Handle tETHF0:USTF0 symbols
 const symbRegExpNormalizer = /F0$/i
 
+const setCcyCalculator = (map, symb, trxPriceCalculator) => {
+  if (!map.has(symb)) {
+    map.set(symb, [])
+  }
+
+  map.get(symb).push(trxPriceCalculator)
+}
+
 module.exports = (trxs) => {
   const trxMapByCcy = new Map()
 
@@ -23,11 +31,7 @@ module.exports = (trxs) => {
     const isLastSymbInPriorCcyList = priorCcyListIndexForLastSymb >= 0
 
     if (isFirstSymbForex) {
-      if (!trxMapByCcy.has(lastSymb)) {
-        trxMapByCcy.set(lastSymb, [])
-      }
-
-      trxMapByCcy.get(lastSymb).push(new TrxPriceCalculator(
+      setCcyCalculator(trxMapByCcy, lastSymb, new TrxPriceCalculator(
         trx,
         TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME,
         TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME
@@ -36,11 +40,7 @@ module.exports = (trxs) => {
       continue
     }
     if (isLastSymbForex) {
-      if (!trxMapByCcy.has(firstSymb)) {
-        trxMapByCcy.set(firstSymb, [])
-      }
-
-      trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+      setCcyCalculator(trxMapByCcy, firstSymb, new TrxPriceCalculator(
         trx,
         TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
         TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME
@@ -55,11 +55,7 @@ module.exports = (trxs) => {
         priorCcyListIndexForFirstSymb <= priorCcyListIndexForLastSymb
       )
     ) {
-      if (!trxMapByCcy.has(firstSymb)) {
-        trxMapByCcy.set(firstSymb, [])
-      }
-
-      trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+      setCcyCalculator(trxMapByCcy, firstSymb, new TrxPriceCalculator(
         trx,
         TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
         TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME
@@ -74,11 +70,7 @@ module.exports = (trxs) => {
         priorCcyListIndexForLastSymb <= priorCcyListIndexForFirstSymb
       )
     ) {
-      if (!trxMapByCcy.has(lastSymb)) {
-        trxMapByCcy.set(lastSymb, [])
-      }
-
-      trxMapByCcy.get(lastSymb).push(new TrxPriceCalculator(
+      setCcyCalculator(trxMapByCcy, lastSymb, new TrxPriceCalculator(
         trx,
         TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME,
         TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME
@@ -87,11 +79,7 @@ module.exports = (trxs) => {
       continue
     }
 
-    if (!trxMapByCcy.has(firstSymb)) {
-      trxMapByCcy.set(firstSymb, [])
-    }
-
-    trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+    setCcyCalculator(trxMapByCcy, firstSymb, new TrxPriceCalculator(
       trx,
       TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
       TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME

--- a/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const {
-  isForexSymb
-} = require('../../helpers')
+const { isForexSymb } = require('../../helpers')
 const PRIORITY_CURRENCY_LIST = require('./priority.currency.list')
+const TrxPriceCalculator = require('./trx.price.calculator')
 
 // Handle tETHF0:USTF0 symbols
 const symbRegExpNormalizer = /F0$/i
@@ -28,13 +27,11 @@ module.exports = (trxs) => {
         trxMapByCcy.set(lastSymb, [])
       }
 
-      trxMapByCcy.get(lastSymb).push({
-        isFirstSymbForex,
-        isLastSymbForex,
-        convPricePropName: 'lastSymbPrice',
-        calcPricePropName: 'firstSymbPrice',
-        trx
-      })
+      trxMapByCcy.get(lastSymb).push(new TrxPriceCalculator(
+        trx,
+        TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME,
+        TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME
+      ))
 
       continue
     }
@@ -43,13 +40,11 @@ module.exports = (trxs) => {
         trxMapByCcy.set(firstSymb, [])
       }
 
-      trxMapByCcy.get(firstSymb).push({
-        isFirstSymbForex,
-        isLastSymbForex,
-        convPricePropName: 'firstSymbPrice',
-        calcPricePropName: 'lastSymbPrice',
-        trx
-      })
+      trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+        trx,
+        TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
+        TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME
+      ))
 
       continue
     }
@@ -64,13 +59,11 @@ module.exports = (trxs) => {
         trxMapByCcy.set(firstSymb, [])
       }
 
-      trxMapByCcy.get(firstSymb).push({
-        isFirstSymbForex,
-        isLastSymbForex,
-        convPricePropName: 'firstSymbPrice',
-        calcPricePropName: 'lastSymbPrice',
-        trx
-      })
+      trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+        trx,
+        TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
+        TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME
+      ))
 
       continue
     }
@@ -85,13 +78,11 @@ module.exports = (trxs) => {
         trxMapByCcy.set(lastSymb, [])
       }
 
-      trxMapByCcy.get(lastSymb).push({
-        isFirstSymbForex,
-        isLastSymbForex,
-        convPricePropName: 'lastSymbPrice',
-        calcPricePropName: 'firstSymbPrice',
-        trx
-      })
+      trxMapByCcy.get(lastSymb).push(new TrxPriceCalculator(
+        trx,
+        TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME,
+        TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME
+      ))
 
       continue
     }
@@ -100,13 +91,11 @@ module.exports = (trxs) => {
       trxMapByCcy.set(firstSymb, [])
     }
 
-    trxMapByCcy.get(firstSymb).push({
-      isFirstSymbForex,
-      isLastSymbForex,
-      convPricePropName: 'firstSymbPrice',
-      calcPricePropName: 'lastSymbPrice',
-      trx
-    })
+    trxMapByCcy.get(firstSymb).push(new TrxPriceCalculator(
+      trx,
+      TrxPriceCalculator.FIRST_SYMB_PRICE_PROP_NAME,
+      TrxPriceCalculator.LAST_SYMB_PRICE_PROP_NAME
+    ))
   }
 
   return trxMapByCcy

--- a/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-map-by-ccy.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const {
+  isForexSymb
+} = require('../../helpers')
+const PRIORITY_CURRENCY_LIST = require('./priority.currency.list')
+
+// Handle tETHF0:USTF0 symbols
+const symbRegExpNormalizer = /F0$/i
+
+module.exports = (trxs) => {
+  const trxMapByCcy = new Map()
+
+  for (const trx of trxs) {
+    const firstSymb = trx.firstSymb.replace(symbRegExpNormalizer, '')
+    const lastSymb = trx.lastSymb.replace(symbRegExpNormalizer, '')
+    const isFirstSymbForex = isForexSymb(trx.firstSymb)
+    const isLastSymbForex = isForexSymb(trx.lastSymb)
+    const priorCcyListIndexForFirstSymb = PRIORITY_CURRENCY_LIST
+      .indexOf(firstSymb)
+    const priorCcyListIndexForLastSymb = PRIORITY_CURRENCY_LIST
+      .indexOf(lastSymb)
+    const isFirstSymbInPriorCcyList = priorCcyListIndexForFirstSymb >= 0
+    const isLastSymbInPriorCcyList = priorCcyListIndexForLastSymb >= 0
+
+    if (isFirstSymbForex) {
+      if (!trxMapByCcy.has(lastSymb)) {
+        trxMapByCcy.set(lastSymb, [])
+      }
+
+      trxMapByCcy.get(lastSymb).push({
+        isFirstSymbForex,
+        isLastSymbForex,
+        convPricePropName: 'lastSymbPrice',
+        calcPricePropName: 'firstSymbPrice',
+        trx
+      })
+
+      continue
+    }
+    if (isLastSymbForex) {
+      if (!trxMapByCcy.has(firstSymb)) {
+        trxMapByCcy.set(firstSymb, [])
+      }
+
+      trxMapByCcy.get(firstSymb).push({
+        isFirstSymbForex,
+        isLastSymbForex,
+        convPricePropName: 'firstSymbPrice',
+        calcPricePropName: 'lastSymbPrice',
+        trx
+      })
+
+      continue
+    }
+    if (
+      isFirstSymbInPriorCcyList &&
+      (
+        !isLastSymbInPriorCcyList ||
+        priorCcyListIndexForFirstSymb <= priorCcyListIndexForLastSymb
+      )
+    ) {
+      if (!trxMapByCcy.has(firstSymb)) {
+        trxMapByCcy.set(firstSymb, [])
+      }
+
+      trxMapByCcy.get(firstSymb).push({
+        isFirstSymbForex,
+        isLastSymbForex,
+        convPricePropName: 'firstSymbPrice',
+        calcPricePropName: 'lastSymbPrice',
+        trx
+      })
+
+      continue
+    }
+    if (
+      isLastSymbInPriorCcyList &&
+      (
+        !isFirstSymbInPriorCcyList ||
+        priorCcyListIndexForLastSymb <= priorCcyListIndexForFirstSymb
+      )
+    ) {
+      if (!trxMapByCcy.has(lastSymb)) {
+        trxMapByCcy.set(lastSymb, [])
+      }
+
+      trxMapByCcy.get(lastSymb).push({
+        isFirstSymbForex,
+        isLastSymbForex,
+        convPricePropName: 'lastSymbPrice',
+        calcPricePropName: 'firstSymbPrice',
+        trx
+      })
+
+      continue
+    }
+
+    if (!trxMapByCcy.has(firstSymb)) {
+      trxMapByCcy.set(firstSymb, [])
+    }
+
+    trxMapByCcy.get(firstSymb).push({
+      isFirstSymbForex,
+      isLastSymbForex,
+      convPricePropName: 'firstSymbPrice',
+      calcPricePropName: 'lastSymbPrice',
+      trx
+    })
+  }
+
+  return trxMapByCcy
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -6,6 +6,7 @@ const remapTrades = require('./remap-trades')
 const remapMovements = require('./remap-movements')
 const lookUpTrades = require('./look-up-trades')
 const getTrxMapByCcy = require('./get-trx-map-by-ccy')
+const findPublicTrade = require('./find-public-trade')
 
 module.exports = {
   TRX_TAX_STRATEGIES,
@@ -13,5 +14,6 @@ module.exports = {
   remapTrades,
   remapMovements,
   lookUpTrades,
-  getTrxMapByCcy
+  getTrxMapByCcy,
+  findPublicTrade
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -5,11 +5,13 @@ const PRIORITY_CURRENCY_LIST = require('./priority.currency.list')
 const remapTrades = require('./remap-trades')
 const remapMovements = require('./remap-movements')
 const lookUpTrades = require('./look-up-trades')
+const getTrxMapByCcy = require('./get-trx-map-by-ccy')
 
 module.exports = {
   TRX_TAX_STRATEGIES,
   PRIORITY_CURRENCY_LIST,
   remapTrades,
   remapMovements,
-  lookUpTrades
+  lookUpTrades,
+  getTrxMapByCcy
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -1,12 +1,14 @@
 'use strict'
 
 const TRX_TAX_STRATEGIES = require('./trx.tax.strategies')
+const PRIORITY_CURRENCY_LIST = require('./priority.currency.list')
 const remapTrades = require('./remap-trades')
 const remapMovements = require('./remap-movements')
 const lookUpTrades = require('./look-up-trades')
 
 module.exports = {
   TRX_TAX_STRATEGIES,
+  PRIORITY_CURRENCY_LIST,
   remapTrades,
   remapMovements,
   lookUpTrades

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -7,6 +7,7 @@ const remapMovements = require('./remap-movements')
 const lookUpTrades = require('./look-up-trades')
 const getTrxMapByCcy = require('./get-trx-map-by-ccy')
 const findPublicTrade = require('./find-public-trade')
+const TrxPriceCalculator = require('./trx.price.calculator')
 
 module.exports = {
   TRX_TAX_STRATEGIES,
@@ -15,5 +16,6 @@ module.exports = {
   remapMovements,
   lookUpTrades,
   getTrxMapByCcy,
-  findPublicTrade
+  findPublicTrade,
+  TrxPriceCalculator
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/priority.currency.list.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/priority.currency.list.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const PRIORITY_CURRENCY_LIST = [
+  'BTC',
+  'ETH',
+  'UST'
+]
+
+module.exports = PRIORITY_CURRENCY_LIST

--- a/workers/loc.api/sync/transaction.tax.report/helpers/priority.currency.list.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/priority.currency.list.js
@@ -1,5 +1,9 @@
 'use strict'
 
+/*
+ * The order is important:
+ * the smaller the index, the more priority currency
+ */
 const PRIORITY_CURRENCY_LIST = [
   'BTC',
   'ETH',

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -52,9 +52,9 @@ module.exports = (movements, params) => {
 
     if (
       Number.isFinite(movement.exactUsdValue) &&
-      movement.exactUsdValue > 0
+      movement.exactUsdValue !== 0
     ) {
-      const price = movement.exactUsdValue / movement.amount
+      const price = Math.abs(movement.exactUsdValue / movement.amount)
 
       remappedMovement.firstSymbPriceUsd = price
       remappedMovement.execPrice = price

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -42,10 +42,12 @@ module.exports = (trades, params) => {
     }
     if (
       Number.isFinite(trade.exactUsdValue) &&
-      trade.exactUsdValue > 0
+      trade.exactUsdValue !== 0
     ) {
-      trade.firstSymbPriceUsd = trade.exactUsdValue / trade.execAmount
-      trade.lastSymbPriceUsd = trade.exactUsdValue / trade.execPrice
+      trade.firstSymbPriceUsd = Math.abs(trade.exactUsdValue / trade.execAmount)
+      trade.lastSymbPriceUsd = Math.abs(
+        trade.exactUsdValue / (trade.execAmount * trade.execPrice)
+      )
 
       continue
     }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
@@ -1,0 +1,56 @@
+'use strict'
+
+class TrxPriceCalculator {
+  static FIRST_SYMB_PRICE_PROP_NAME = 'firstSymbPrice'
+  static LAST_SYMB_PRICE_PROP_NAME = 'lastSymbPrice'
+
+  constructor (
+    trx,
+    convPricePropName,
+    calcPricePropName
+  ) {
+    this.trx = trx
+    this.convPricePropName = convPricePropName
+    this.calcPricePropName = calcPricePropName
+  }
+
+  calcPrice (pubTradePrice) {
+    if (
+      !Number.isFinite(pubTradePrice) ||
+      pubTradePrice === 0
+    ) {
+      // TODO:
+      throw new Error('ERR_NO_PUBLIC_TRADES_PRICE')
+    }
+
+    this.trx.exactUsdValue = Math.abs(this.trx.execAmount * pubTradePrice)
+    this.trx[this.convPricePropName] = pubTradePrice
+
+    if (this.trx.isAdditionalTrxMovements) {
+      this.trx.execPrice = pubTradePrice
+    }
+    if (
+      !Number.isFinite(this.trx.execPrice) ||
+      this.trx.execPrice === 0
+    ) {
+      return
+    }
+    if (this.constructor.FIRST_SYMB_PRICE_PROP_NAME === this.calcPricePropName) {
+      this.trx[this.calcPricePropName] = this.#calcFirstSymbPrice(pubTradePrice)
+
+      return
+    }
+
+    this.trx[this.calcPricePropName] = this.#calcLastSymbPrice(pubTradePrice)
+  }
+
+  #calcFirstSymbPrice (pubTradePrice) {
+    return pubTradePrice * this.trx.execPrice
+  }
+
+  #calcLastSymbPrice (pubTradePrice) {
+    return pubTradePrice / this.trx.execPrice
+  }
+}
+
+module.exports = TrxPriceCalculator

--- a/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { PubTradePriceFindForTrxTaxError } = require('../../../errors')
+
 class TrxPriceCalculator {
   static FIRST_SYMB_PRICE_PROP_NAME = 'firstSymbPrice'
   static LAST_SYMB_PRICE_PROP_NAME = 'lastSymbPrice'
@@ -19,8 +21,7 @@ class TrxPriceCalculator {
       !Number.isFinite(pubTradePrice) ||
       pubTradePrice === 0
     ) {
-      // TODO:
-      throw new Error('ERR_NO_PUBLIC_TRADES_PRICE')
+      throw new PubTradePriceFindForTrxTaxError()
     }
 
     this.trx.exactUsdValue = Math.abs(this.trx.execAmount * pubTradePrice)

--- a/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
@@ -3,8 +3,8 @@
 const { PubTradePriceFindForTrxTaxError } = require('../../../errors')
 
 class TrxPriceCalculator {
-  static FIRST_SYMB_PRICE_PROP_NAME = 'firstSymbPrice'
-  static LAST_SYMB_PRICE_PROP_NAME = 'lastSymbPrice'
+  static FIRST_SYMB_PRICE_PROP_NAME = 'firstSymbPriceUsd'
+  static LAST_SYMB_PRICE_PROP_NAME = 'lastSymbPriceUsd'
 
   constructor (
     trx,
@@ -24,7 +24,6 @@ class TrxPriceCalculator {
       throw new PubTradePriceFindForTrxTaxError()
     }
 
-    this.trx.exactUsdValue = Math.abs(this.trx.execAmount * pubTradePrice)
     this.trx[this.convPricePropName] = pubTradePrice
 
     if (this.trx.isAdditionalTrxMovements) {
@@ -37,12 +36,16 @@ class TrxPriceCalculator {
       return
     }
     if (this.constructor.FIRST_SYMB_PRICE_PROP_NAME === this.calcPricePropName) {
-      this.trx[this.calcPricePropName] = this.#calcFirstSymbPrice(pubTradePrice)
+      const priceUsd = this.#calcFirstSymbPrice(pubTradePrice)
+      this.trx[this.calcPricePropName] = priceUsd
+      this.trx.exactUsdValue = this.trx.execAmount * priceUsd
 
       return
     }
 
-    this.trx[this.calcPricePropName] = this.#calcLastSymbPrice(pubTradePrice)
+    const priceUsd = this.#calcLastSymbPrice(pubTradePrice)
+    this.trx[this.calcPricePropName] = priceUsd
+    this.trx.exactUsdValue = this.trx.execAmount * pubTradePrice
   }
 
   #calcFirstSymbPrice (pubTradePrice) {

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -229,6 +229,43 @@ class TransactionTaxReport {
       }
     )
   }
+
+  async #getPublicTrades (params, opts) {
+    const {
+      symbol,
+      start = 0,
+      end = Date.now(),
+      sort = -1,
+      limit = 10000
+    } = params ?? {}
+    const { interrupter } = opts
+    const args = {
+      isNotMoreThanInnerMax: true,
+      params: {
+        symbol,
+        start,
+        end,
+        sort,
+        limit,
+        notCheckNextPage: true,
+        notThrowError: true
+      }
+    }
+
+    const getDataFn = this.rService[this.SYNC_API_METHODS.PUBLIC_TRADES]
+      .bind(this.rService)
+
+    const res = await this.getDataFromApi({
+      getData: (s, args) => getDataFn(args),
+      args,
+      callerName: 'TRANSACTION_TAX_REPORT',
+      eNetErrorAttemptsTimeframeMin: 10,
+      eNetErrorAttemptsTimeoutMs: 10000,
+      interrupter
+    })
+
+    return res
+  }
 }
 
 decorateInjectable(TransactionTaxReport, depsTypes)

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -204,12 +204,12 @@ class TransactionTaxReport {
   async #convertCurrencies (trxs, opts) {
     const trxMapByCcy = getTrxMapByCcy(trxs)
 
-    for (const [symbol, trxData] of trxMapByCcy.entries()) {
-      const trxDataIterator = getBackIterable(trxData)
+    for (const [symbol, trxPriceCalculators] of trxMapByCcy.entries()) {
+      const trxPriceCalculatorIterator = getBackIterable(trxPriceCalculators)
       let pubTrades = []
 
-      for (const trxDataItem of trxDataIterator) {
-        const { trx } = trxDataItem
+      for (const trxPriceCalculator of trxPriceCalculatorIterator) {
+        const { trx } = trxPriceCalculator
 
         if (
           pubTrades.length === 0 ||
@@ -223,20 +223,7 @@ class TransactionTaxReport {
         }
 
         const pubTrade = findPublicTrade(pubTrades, trx.mtsCreate)
-
-        if (
-          !Number.isFinite(pubTrade?.price) ||
-          pubTrade.price === 0
-        ) {
-          // TODO:
-          throw new Error('ERR_NO_PUBLIC_TRADES_PRICE')
-        }
-
-        if (trx.isAdditionalTrxMovements) {
-          trx.execPrice = pubTrade?.price
-        }
-
-        trx.exactUsdValue = Math.abs(trx.execAmount * pubTrade?.price)
+        trxPriceCalculator.calcPrice(pubTrade?.price)
       }
     }
   }


### PR DESCRIPTION
This PR adds currency conversion to USD and stores cached `exactUsdValue` field in appropriate tables for `Transaction Tax Report`. For currency conversion uses the priority currency list: `['BTC', 'ETH', 'UST']`

---

It's a 4-part of the feature, the main idea taken from these PRs: https://github.com/bitfinexcom/bfx-reports-framework/pull/373, https://github.com/bitfinexcom/bfx-reports-framework/pull/378, https://github.com/bitfinexcom/bfx-reports-framework/pull/379
- separates into small parts
- improves and speeds up the currency conversion approach

---

The ccy conversion approach is the following:
```
eg we have trades (BTC/ETH):
2024-05-15T15:02:10 -> Starts here, requests 10K trades starting at 2024-05-15T15:02:09.99
Reply includes trades up to 2024-05-15T15:02:40
2024-05-15T15:02:12 -> Included in trade before
2024-05-15T15:02:50 -> Request new 10K from 2024-05-15T15:02:49.99
Note that the space between  2024-05-15T15:02:40 and 2024-05-15T15:02:49.99 would be empty.
```
