### PR TITLE
[PART-6] Add transaction tax report

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -112,7 +112,8 @@ const {
   syncFactory,
   processMessageManagerFactory,
   syncUserStepDataFactory,
-  wsEventEmitterFactory
+  wsEventEmitterFactory,
+  interrupterFactory
 } = require('./factories')
 const Crypto = require('../sync/crypto')
 const Authenticator = require('../sync/authenticator')
@@ -343,6 +344,8 @@ module.exports = ({
     bind(TYPES.SyncInterrupter)
       .to(SyncInterrupter)
       .inSingletonScope()
+    bind(TYPES.InterrupterFactory)
+      .toFactory(interrupterFactory)
     bind(TYPES.Movements)
       .to(Movements)
     bind(TYPES.WinLossVSAccountBalance)

--- a/workers/loc.api/di/factories/index.js
+++ b/workers/loc.api/di/factories/index.js
@@ -7,6 +7,7 @@ const syncFactory = require('./sync-factory')
 const processMessageManagerFactory = require('./process-message-manager-factory')
 const syncUserStepDataFactory = require('./sync-user-step-data-factory')
 const wsEventEmitterFactory = require('./ws-event-emitter-factory')
+const interrupterFactory = require('./interrupter-factory')
 
 module.exports = {
   migrationsFactory,
@@ -15,5 +16,6 @@ module.exports = {
   syncFactory,
   processMessageManagerFactory,
   syncUserStepDataFactory,
-  wsEventEmitterFactory
+  wsEventEmitterFactory,
+  interrupterFactory
 }

--- a/workers/loc.api/di/factories/interrupter-factory.js
+++ b/workers/loc.api/di/factories/interrupter-factory.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const {
+  AuthError
+} = require('bfx-report/workers/loc.api/errors')
+
+const TYPES = require('../types')
+
+module.exports = (ctx) => {
+  const authenticator = ctx.container.get(TYPES.Authenticator)
+
+  return (params) => {
+    const { user, name } = params ?? {}
+
+    if (!user) {
+      throw new AuthError()
+    }
+
+    const interrupter = ctx.container.get(
+      TYPES.Interrupter
+    ).setName(name)
+
+    authenticator.setInterrupterToUserSession(
+      user, interrupter
+    )
+
+    return interrupter
+  }
+}

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -70,5 +70,6 @@ module.exports = {
   SyncUserStepDataFactory: Symbol.for('SyncUserStepDataFactory'),
   HTTPRequest: Symbol.for('HTTPRequest'),
   SummaryByAsset: Symbol.for('SummaryByAsset'),
-  TransactionTaxReport: Symbol.for('TransactionTaxReport')
+  TransactionTaxReport: Symbol.for('TransactionTaxReport'),
+  InterrupterFactory: Symbol.for('InterrupterFactory')
 }

--- a/workers/loc.api/generate-report-file/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-report-file/csv-writer/full-snapshot-report-csv-writer.js
@@ -47,7 +47,8 @@ module.exports = (
   const res = await getDataFromApi({
     getData: rService[name].bind(rService),
     args,
-    callerName: 'REPORT_FILE_WRITER'
+    callerName: 'REPORT_FILE_WRITER',
+    shouldNotInterrupt: true
   })
 
   const {

--- a/workers/loc.api/generate-report-file/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-report-file/csv-writer/full-tax-report-csv-writer.js
@@ -48,7 +48,8 @@ module.exports = (
   const res = await getDataFromApi({
     getData: rService[name].bind(rService),
     args,
-    callerName: 'REPORT_FILE_WRITER'
+    callerName: 'REPORT_FILE_WRITER',
+    shouldNotInterrupt: true
   })
   const {
     timestamps,

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -49,6 +49,22 @@ const paramsSchemaForUpdateSubAccount = {
   }
 }
 
+const paramsSchemaForInterruptOperations = {
+  type: 'object',
+  properties: {
+    names: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'string',
+        enum: [
+          'TRX_TAX_REPORT_INTERRUPTER'
+        ]
+      }
+    }
+  }
+}
+
 const paramsSchemaForCandlesApi = {
   ...cloneDeep(baseParamsSchemaForCandlesApi),
   properties: {
@@ -482,6 +498,7 @@ module.exports = {
   paramsSchemaForEditCandlesConf,
   paramsSchemaForCreateSubAccount,
   paramsSchemaForUpdateSubAccount,
+  paramsSchemaForInterruptOperations,
   paramsSchemaForBalanceHistoryApi,
   paramsSchemaForWinLossApi,
   paramsSchemaForWinLossVSAccountBalanceApi,

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -256,7 +256,9 @@ class FrameworkReportService extends ReportService {
 
   getPlatformStatus (space, args, cb) {
     return this._responder(async () => {
-      const rest = this._getREST({})
+      const rest = this._getREST({}, {
+        interrupter: args?.interrupter
+      })
 
       const res = await rest.status()
       const isMaintenance = !Array.isArray(res) || !res[0]
@@ -461,6 +463,14 @@ class FrameworkReportService extends ReportService {
     return this._privResponder(() => {
       return this._sync.stop()
     }, 'stopSyncNow', args, cb)
+  }
+
+  interruptOperations (space, args = {}, cb) {
+    return this._privResponder(() => {
+      checkParams(args, 'paramsSchemaForInterruptOperations', ['names'])
+
+      return this._authenticator.interruptOperations(args)
+    }, 'interruptOperations', args, cb)
   }
 
   getPublicTradesConf (space, args = {}, cb) {
@@ -720,7 +730,8 @@ class FrameworkReportService extends ReportService {
           (args) => this._getDataFromApi({
             getData: (space, args) => super.getActivePositions(space, args),
             args,
-            callerName: 'ACTIVE_POSITIONS_GETTER'
+            callerName: 'ACTIVE_POSITIONS_GETTER',
+            shouldNotInterrupt: true
           }),
           args,
           {
@@ -760,7 +771,8 @@ class FrameworkReportService extends ReportService {
               return super.getPositionsAudit(space, args)
             },
             args,
-            callerName: 'POSITIONS_AUDIT_GETTER'
+            callerName: 'POSITIONS_AUDIT_GETTER',
+            shouldNotInterrupt: true
           }),
           args,
           {

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -189,7 +189,8 @@ class SubAccountApiData {
         const res = await this.getDataFromApi({
           getData: (space, args) => method(args),
           args,
-          callerName: 'SUB_ACCOUNT_API_DATA'
+          callerName: 'SUB_ACCOUNT_API_DATA',
+          shouldNotInterrupt: true
         })
 
         resArr.push(res)

--- a/workers/loc.api/sync/sync.interrupter/index.js
+++ b/workers/loc.api/sync/sync.interrupter/index.js
@@ -3,6 +3,9 @@
 const Interrupter = require(
   'bfx-report/workers/loc.api/interrupter'
 )
+const INTERRUPTER_NAMES = require(
+  'bfx-report/workers/loc.api/interrupter/interrupter.names'
+)
 
 const SYNC_PROGRESS_STATES = require('../progress/sync.progress.states')
 
@@ -20,6 +23,7 @@ class SyncInterrupter extends Interrupter {
     this.INITIAL_PROGRESS = 'SYNCHRONIZATION_HAS_NOT_BEEN_STARTED_TO_INTERRUPT'
     this.INTERRUPTED_PROGRESS = SYNC_PROGRESS_STATES.INTERRUPTED_PROGRESS
 
+    this.setName(INTERRUPTER_NAMES.SYNC_INTERRUPTER)
     this._init()
   }
 

--- a/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
@@ -20,7 +20,8 @@ module.exports = async (trades, opts) => {
     isBackIterativeSaleLookUp = false,
     isBackIterativeBuyLookUp = false,
     isBuyTradesWithUnrealizedProfitRequired = false,
-    isNotGainOrLossRequired = false
+    isNotGainOrLossRequired = false,
+    interrupter
   } = opts ?? {}
 
   const saleTradesWithRealizedProfit = []
@@ -42,6 +43,13 @@ module.exports = async (trades, opts) => {
     : trades
 
   for (const [i, trade] of tradeIterator.entries()) {
+    if (interrupter?.hasInterrupted()) {
+      return {
+        saleTradesWithRealizedProfit,
+        buyTradesWithUnrealizedProfit
+      }
+    }
+
     const currentLoopUnlockMts = Date.now()
 
     /*
@@ -162,6 +170,12 @@ module.exports = async (trades, opts) => {
     )
 
     for (let j = startPoint; checkPoint(j); j = shiftPoint(j)) {
+      if (interrupter?.hasInterrupted()) {
+        return {
+          saleTradesWithRealizedProfit,
+          buyTradesWithUnrealizedProfit
+        }
+      }
       if (trade.isSaleTrxHistFilled) {
         break
       }


### PR DESCRIPTION
This PR adds ability to interrupt the trx tax report after sign-out and interruption ability in case `Rate Limit`

---

Due to long public trade data collecting needs to add trx tax report generation interruption after sign-out. And as well, add a separate endpoint for interruption for better UX
When getting `Rate Limit` or `cool down` due to `Rate Limit` for `1min` occurs, it needs to provide a feature to interrupt the tax report and sync being processed

---

It's a 4-part of the feature, the main idea taken from these PRs: https://github.com/bitfinexcom/bfx-reports-framework/pull/373, https://github.com/bitfinexcom/bfx-reports-framework/pull/378, https://github.com/bitfinexcom/bfx-reports-framework/pull/379
- separates into small parts
- improves and speeds up the currency conversion approach

---

Basic changes:
- Adds ability to interrupt the trx tax report after sign-out
- Adds `interruptOperations` endpoint
- Implement interruption ability in BfxApiRouter service

---

- `interruptOperations` request example
```jsonc
{
  "auth": {
    "token": "user_token"
  },
  "method": "interruptOperations",
  "params": {
    "names": ["TRX_TAX_REPORT_INTERRUPTER"]
  }
}
```

- `interruptOperations` response example
```jsonc
{
  "jsonrpc": "2.0",
  "result": true,
  "id": null
}
```

---

**Depends** on these PRs:
- https://github.com/bitfinexcom/bfx-report/pull/371
- https://github.com/bitfinexcom/bfx-report/pull/373
