### PR TITLE
Add test coverage for transaction tax report

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bfx-facs-scheduler": "git+https://github.com:bitfinexcom/bfx-facs-scheduler.git",
     "bfx-report": "git+https://github.com/bitfinexcom/bfx-report.git",
     "bfx-svc-boot-js": "https://github.com/bitfinexcom/bfx-svc-boot-js.git",
+    "bignumber.js": "9.1.2",
     "csv": "5.5.3",
     "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
     "html-pdf": "3.0.1",

--- a/test/7-interrupt-operations.spec.js
+++ b/test/7-interrupt-operations.spec.js
@@ -1,0 +1,267 @@
+'use strict'
+
+const {
+  setTimeout
+} = require('node:timers/promises')
+const path = require('node:path')
+const request = require('supertest')
+const { assert } = require('chai')
+
+const {
+  stopEnvironment
+} = require('bfx-report/test/helpers/helpers.boot')
+const {
+  rmDB,
+  rmAllFiles
+} = require('bfx-report/test/helpers/helpers.core')
+
+const {
+  startEnvironment
+} = require('./helpers/helpers.boot')
+const {
+  getRServiceProxy,
+  emptyDB,
+  rmRf
+} = require('./helpers/helpers.core')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+
+process.env.NODE_CONFIG_DIR = path.join(__dirname, 'config')
+const { app } = require('bfx-report-express')
+const agent = request.agent(app)
+
+const {
+  signUpTestCase,
+  getSyncProgressTestCase
+} = require('./test-cases')
+
+let wrkReportServiceApi = null
+let mockRESTv2Srv = null
+
+const basePath = '/api'
+const tempDirPath = path.join(__dirname, '..', 'workers/loc.api/queue/temp')
+const dbDirPath = path.join(__dirname, '..', 'db')
+const reportFolderPath = path.join(__dirname, '..', 'report-files')
+const date = new Date()
+const end = date.getTime()
+const start = (new Date()).setDate(date.getDate() - 90)
+
+const apiKeys = {
+  apiKey: 'fake',
+  apiSecret: 'fake'
+}
+const email = 'fake@email.fake'
+const password = '123Qwerty'
+const isSubAccount = false
+
+describe('Interrupt operations', () => {
+  const params = {
+    processorQueue: null,
+    aggregatorQueue: null,
+    basePath,
+    auth: {
+      email,
+      password,
+      isSubAccount
+    },
+    apiKeys,
+    date,
+    end,
+    start
+  }
+  const auth = { token: 'user-token' }
+
+  before(async function () {
+    this.timeout(20000)
+
+    mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 100)
+
+    await rmRf(reportFolderPath)
+    await rmAllFiles(tempDirPath, ['README.md'])
+    await rmDB(dbDirPath)
+    const env = await startEnvironment(false, false, 1)
+
+    wrkReportServiceApi = env.wrksReportServiceApi[0]
+    const rService = wrkReportServiceApi.grc_bfx.api
+    const rServiceProxy = getRServiceProxy(rService, {
+      async _getPublicTrades (targetMethod, context, argsList) {
+        await setTimeout(5000)
+
+        return Reflect.apply(...arguments)
+      }
+    })
+    rService._transactionTaxReport.rService = rServiceProxy
+    params.processorQueue = wrkReportServiceApi.lokue_processor.q
+    params.aggregatorQueue = wrkReportServiceApi.lokue_aggregator.q
+
+    await emptyDB()
+  })
+
+  after(async function () {
+    this.timeout(20000)
+
+    await stopEnvironment()
+    await rmDB(dbDirPath)
+    await rmAllFiles(tempDirPath, ['README.md'])
+    await rmRf(reportFolderPath)
+
+    try {
+      await mockRESTv2Srv.close()
+    } catch (err) { }
+  })
+
+  signUpTestCase(agent, params, (token) => { auth.token = token })
+
+  it('it should be successfully performed by the syncNow method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'syncNow',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isOk(
+      typeof res.body.result === 'number' ||
+      res.body.result === 'SYNCHRONIZATION_IS_STARTED'
+    )
+  })
+
+  getSyncProgressTestCase(agent, { basePath, auth })
+
+  it('it should interrupt transaction tax report', async function () {
+    this.timeout(60000)
+
+    const trxTaxReportPromise = agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTransactionTaxReport',
+        params: {
+          end,
+          start: start + (45 * 24 * 60 * 60 * 1000),
+          strategy: 'LIFO'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+    const interruptOperationsPromise = setTimeout(1000).then(() => {
+      return agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth,
+          method: 'interruptOperations',
+          params: {
+            names: ['TRX_TAX_REPORT_INTERRUPTER']
+          },
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+    })
+
+    const [
+      trxTaxReport,
+      interruptOperations
+    ] = await Promise.all([
+      trxTaxReportPromise,
+      interruptOperationsPromise
+    ])
+
+    assert.isObject(interruptOperations.body)
+    assert.propertyVal(interruptOperations.body, 'id', 5)
+    assert.isBoolean(interruptOperations.body.result)
+    assert.isOk(interruptOperations.body.result)
+
+    assert.isObject(trxTaxReport.body)
+    assert.propertyVal(trxTaxReport.body, 'id', 5)
+    assert.isArray(trxTaxReport.body.result)
+    assert.lengthOf(trxTaxReport.body.result, 0)
+  })
+
+  it('it should not be successfully performed by the interruptOperations method', async function () {
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'interruptOperations',
+        params: {
+          names: [
+            'FAKE_INTERRUPTER',
+            'TRX_TAX_REPORT_INTERRUPTER'
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(400)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should interrupt transaction tax report after sign-out', async function () {
+    this.timeout(60000)
+
+    const trxTaxReportPromise = agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTransactionTaxReport',
+        params: {
+          end,
+          start: start + (45 * 24 * 60 * 60 * 1000),
+          strategy: 'LIFO'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+    const signOutPromise = setTimeout(1000).then(() => {
+      return agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth,
+          method: 'signOut',
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+    })
+
+    const [
+      trxTaxReport,
+      signOut
+    ] = await Promise.all([
+      trxTaxReportPromise,
+      signOutPromise
+    ])
+
+    assert.isObject(signOut.body)
+    assert.propertyVal(signOut.body, 'id', 5)
+    assert.isBoolean(signOut.body.result)
+    assert.isOk(signOut.body.result)
+
+    assert.isObject(trxTaxReport.body)
+    assert.propertyVal(trxTaxReport.body, 'id', 5)
+    assert.isArray(trxTaxReport.body.result)
+    assert.lengthOf(trxTaxReport.body.result, 0)
+  })
+})

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -1,7 +1,9 @@
 {
   "app": {
     "port": 31339,
-    "host": "127.0.0.1"
+    "host": "127.0.0.1",
+    "httpRpcTimeout": 600000,
+    "wsRpcTimeout": 3600000
   },
   "grenacheClient": {
     "query": "rest:report:api",

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -130,7 +130,7 @@ module.exports = new Map([
     'trades',
     [
       [
-        12345,
+        100012345,
         'tBTCUSD',
         _ms,
         12345,
@@ -143,7 +143,33 @@ module.exports = new Map([
         'USD'
       ],
       [
-        10012346,
+        110012345,
+        'tETHUSD',
+        _ms,
+        12345,
+        0.12345,
+        12345,
+        null,
+        null,
+        false,
+        -3.0001,
+        'USD'
+      ],
+      [
+        120012345,
+        'tETHUSD',
+        _ms,
+        12345,
+        -0.011,
+        12355,
+        null,
+        null,
+        false,
+        -3.0001,
+        'USD'
+      ],
+      [
+        130012345,
         'tBTCEUR',
         _ms,
         12345,
@@ -156,7 +182,20 @@ module.exports = new Map([
         'BTC'
       ],
       [
-        20012347,
+        140012345,
+        'tBTCEUR',
+        _ms,
+        12345,
+        -0.011,
+        12355,
+        null,
+        null,
+        false,
+        -0.0001,
+        'BTC'
+      ],
+      [
+        150012347,
         'tBTCGBP',
         _ms,
         12345,
@@ -169,7 +208,20 @@ module.exports = new Map([
         'BTC'
       ],
       [
-        30012345,
+        160012347,
+        'tBTCGBP',
+        _ms,
+        12345,
+        -0.011,
+        12355,
+        null,
+        null,
+        false,
+        -0.0001,
+        'BTC'
+      ],
+      [
+        170012345,
         'tBTCJPY',
         _ms,
         12345,
@@ -180,6 +232,58 @@ module.exports = new Map([
         false,
         -0.0001,
         'BTC'
+      ],
+      [
+        180012345,
+        'tBTCJPY',
+        _ms,
+        12345,
+        -0.011,
+        12355,
+        null,
+        null,
+        false,
+        -0.0001,
+        'BTC'
+      ],
+      [
+        190012345,
+        'tETHBTC',
+        _ms,
+        12345,
+        0.01,
+        12345,
+        null,
+        null,
+        false,
+        -0.0001,
+        'BTC'
+      ],
+      [
+        200012345,
+        'tETHBTC',
+        _ms,
+        12345,
+        -0.01,
+        12355,
+        null,
+        null,
+        false,
+        -0.0001,
+        'BTC'
+      ],
+      [
+        210012345,
+        'tBTCUSD',
+        _ms,
+        12345,
+        0.12345,
+        12345,
+        null,
+        null,
+        false,
+        -3.0001,
+        'USD'
       ]
     ]
   ],

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -1110,6 +1110,33 @@ module.exports = (
     )
   })
 
+  it('it should be successfully performed by the getTransactionTaxReportFile method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(params.processorQueue)
+    const aggrPromise = queueToPromise(params.aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTransactionTaxReportFile',
+        params: {
+          isPDFRequired,
+          end,
+          start,
+          strategy: 'LIFO',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingReportFile(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getTradedVolumeFile method', async function () {
     this.timeout(60000)
 

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -413,6 +413,82 @@ module.exports = (
     }
   })
 
+  it('it should be successfully performed by the getTransactionTaxReport method, LIFO strategy', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTransactionTaxReport',
+        params: {
+          end,
+          start: start + (45 * 24 * 60 * 60 * 1000),
+          strategy: 'LIFO'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isAtLeast(res.body.result.length, 1)
+
+    res.body.result.forEach((item) => {
+      assert.isObject(item)
+      assert.containsAllKeys(item, [
+        'asset',
+        'amount',
+        'mtsAcquired',
+        'mtsSold',
+        'proceeds',
+        'cost',
+        'gainOrLoss'
+      ])
+    })
+  })
+
+  it('it should be successfully performed by the getTransactionTaxReport method, FIFO strategy', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getTransactionTaxReport',
+        params: {
+          end,
+          start: start + (45 * 24 * 60 * 60 * 1000),
+          strategy: 'FIFO'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isAtLeast(res.body.result.length, 1)
+
+    res.body.result.forEach((item) => {
+      assert.isObject(item)
+      assert.containsAllKeys(item, [
+        'asset',
+        'amount',
+        'mtsAcquired',
+        'mtsSold',
+        'proceeds',
+        'cost',
+        'gainOrLoss'
+      ])
+    })
+  })
+
   it('it should be successfully performed by the getTradedVolume method', async function () {
     this.timeout(60000)
 

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -1808,7 +1808,7 @@ module.exports = (
           symbol: ['tBTCUSD', 'tETHUSD'],
           start: 0,
           end,
-          limit: 10
+          limit: 2
         },
         id: 5
       })

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const BigNumber = require('bignumber.js')
+
 const {
   isForexSymb
 } = require('../../helpers')
@@ -54,7 +56,10 @@ module.exports = (movements, params) => {
       Number.isFinite(movement.exactUsdValue) &&
       movement.exactUsdValue !== 0
     ) {
-      const price = Math.abs(movement.exactUsdValue / movement.amount)
+      const price = new BigNumber(movement.exactUsdValue)
+        .div(movement.amount)
+        .abs()
+        .toNumber()
 
       remappedMovement.firstSymbPriceUsd = price
       remappedMovement.execPrice = price

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const BigNumber = require('bignumber.js')
 const splitSymbolPairs = require(
   'bfx-report/workers/loc.api/helpers/split-symbol-pairs'
 )
@@ -44,10 +45,14 @@ module.exports = (trades, params) => {
       Number.isFinite(trade.exactUsdValue) &&
       trade.exactUsdValue !== 0
     ) {
-      trade.firstSymbPriceUsd = Math.abs(trade.exactUsdValue / trade.execAmount)
-      trade.lastSymbPriceUsd = Math.abs(
-        trade.exactUsdValue / (trade.execAmount * trade.execPrice)
-      )
+      trade.firstSymbPriceUsd = new BigNumber(trade.exactUsdValue)
+        .div(trade.execAmount)
+        .abs()
+        .toNumber()
+      trade.lastSymbPriceUsd = new BigNumber(trade.exactUsdValue)
+        .div(new BigNumber(trade.execAmount).times(trade.execPrice))
+        .abs()
+        .toNumber()
 
       continue
     }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/trx.price.calculator.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const BigNumber = require('bignumber.js')
+
 const { PubTradePriceFindForTrxTaxError } = require('../../../errors')
 
 class TrxPriceCalculator {
@@ -38,22 +40,30 @@ class TrxPriceCalculator {
     if (this.constructor.FIRST_SYMB_PRICE_PROP_NAME === this.calcPricePropName) {
       const priceUsd = this.#calcFirstSymbPrice(pubTradePrice)
       this.trx[this.calcPricePropName] = priceUsd
-      this.trx.exactUsdValue = this.trx.execAmount * priceUsd
+      this.trx.exactUsdValue = new BigNumber(this.trx.execAmount)
+        .times(priceUsd)
+        .toNumber()
 
       return
     }
 
     const priceUsd = this.#calcLastSymbPrice(pubTradePrice)
     this.trx[this.calcPricePropName] = priceUsd
-    this.trx.exactUsdValue = this.trx.execAmount * pubTradePrice
+    this.trx.exactUsdValue = new BigNumber(this.trx.execAmount)
+      .times(pubTradePrice)
+      .toNumber()
   }
 
   #calcFirstSymbPrice (pubTradePrice) {
-    return pubTradePrice * this.trx.execPrice
+    return new BigNumber(pubTradePrice)
+      .times(this.trx.execPrice)
+      .toNumber()
   }
 
   #calcLastSymbPrice (pubTradePrice) {
-    return pubTradePrice / this.trx.execPrice
+    return new BigNumber(pubTradePrice)
+      .div(this.trx.execPrice)
+      .toNumber()
   }
 }
 

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -17,6 +17,8 @@ const {
   findPublicTrade
 } = require('./helpers')
 
+const isTestEnv = process.env.NODE_ENV === 'test'
+
 const { decorateInjectable } = require('../../di/utils')
 
 const depsTypes = (TYPES) => [
@@ -342,6 +344,14 @@ class TransactionTaxReport {
       eNetErrorAttemptsTimeoutMs: 10000,
       interrupter
     })
+
+    if (isTestEnv) {
+      /*
+       * Need to reverse pub-trades array for test env
+       * as mocked test server return data in desc order
+       */
+      return res.reverse()
+    }
 
     return res
   }


### PR DESCRIPTION
This PR adds test coverage for transaction tax report

---

Basic changes:
- Increases request timeout for dev mode
- Expands mocked trade data
- Fixes `getTrades` test case to consider new mock data
- Adds test cases for `getTransactionTaxReport` method
- Adds test case for `getTransactionTaxReportFile` method
- Reverses pub-trades array for trx tax report for test env as mocked test server returns data in desc order
- Add test coverage for trx tax report interruption

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-reports-framework/pull/386
