### PR TITLE
Select EXCHANGE trades for trx tax report

### DIFF
--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v41.1716385152034.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v41.1716385152034.js
@@ -22,7 +22,16 @@ class MigrationV41 extends AbstractMigration {
     const sqlArr = [
       'ALTER TABLE ledgers ADD COLUMN exactUsdValue DECIMAL(22,12)',
       'ALTER TABLE trades ADD COLUMN exactUsdValue DECIMAL(22,12)',
-      'ALTER TABLE movements ADD COLUMN exactUsdValue DECIMAL(22,12)'
+      'ALTER TABLE movements ADD COLUMN exactUsdValue DECIMAL(22,12)',
+
+      'ALTER TABLE trades ADD COLUMN _isExchange INT',
+      `UPDATE trades SET _isExchange = (
+        SELECT 1 FROM (
+          SELECT * FROM trades AS t
+          WHERE t.orderType COLLATE NOCASE LIKE '%EXCHANGE%'
+            AND t._id = trades._id
+        )
+      )`
     ]
 
     this.addSql(sqlArr)

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -3,7 +3,7 @@
 const SYNC_API_METHODS = require('../../schema/sync.api.methods')
 const {
   addPropsToResIfExist,
-  getFlagsFromLedgerDescription,
+  getFlagsFromStringProp,
   getCategoryFromDescription,
   convertArrayMapToObjectMap
 } = require('./helpers')
@@ -106,12 +106,13 @@ class ApiMiddlewareHandlerAfter {
 
   [SYNC_API_METHODS.LEDGERS] (args, apiRes) {
     const res = apiRes.res.map(item => {
-      const { balance } = { ...item }
+      const { balance } = item ?? {}
 
       return {
         ...item,
-        ...getFlagsFromLedgerDescription(
+        ...getFlagsFromStringProp(
           item,
+          'description',
           [
             {
               fieldName: '_isMarginFundingPayment',
@@ -136,6 +137,29 @@ class ApiMiddlewareHandlerAfter {
           ]
         ),
         _nativeBalance: balance
+      }
+    })
+
+    return {
+      ...apiRes,
+      res
+    }
+  }
+
+  [SYNC_API_METHODS.TRADES] (args, apiRes) {
+    const res = apiRes.res.map((item) => {
+      return {
+        ...item,
+        ...getFlagsFromStringProp(
+          item,
+          'orderType',
+          [
+            {
+              fieldName: '_isExchange',
+              pattern: 'EXCHANGE'
+            }
+          ]
+        )
       }
     })
 

--- a/workers/loc.api/sync/data.inserter/api.middleware/helpers/get-flags-from-string-prop.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/helpers/get-flags-from-string-prop.js
@@ -1,14 +1,13 @@
 'use strict'
 
 module.exports = (
-  ledger,
+  item,
+  stringPropName,
   schemas = []
 ) => {
-  if (
-    !ledger ||
-    typeof ledger !== 'object' ||
-    typeof ledger.description !== 'string'
-  ) {
+  const stringProp = item?.[stringPropName]
+
+  if (typeof stringProp !== 'string') {
     return {}
   }
 
@@ -18,12 +17,12 @@ module.exports = (
       pattern,
       handler,
       isCaseSensitivity
-    } = { ...schema }
+    } = schema ?? {}
 
     if (typeof handler === 'function') {
       return {
         ...accum,
-        [fieldName]: handler(ledger.description)
+        [fieldName]: handler(stringProp)
       }
     }
 
@@ -34,7 +33,7 @@ module.exports = (
 
     return {
       ...accum,
-      [fieldName]: regExp.test(ledger.description)
+      [fieldName]: regExp.test(stringProp)
     }
   }, {})
 }

--- a/workers/loc.api/sync/data.inserter/api.middleware/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/helpers/index.js
@@ -3,8 +3,8 @@
 const addPropsToResIfExist = require(
   './add-props-to-res-if-exist'
 )
-const getFlagsFromLedgerDescription = require(
-  './get-flags-from-ledger-description'
+const getFlagsFromStringProp = require(
+  './get-flags-from-string-prop'
 )
 const getCategoryFromDescription = require(
   './get-category-from-description'
@@ -15,7 +15,7 @@ const convertArrayMapToObjectMap = require(
 
 module.exports = {
   addPropsToResIfExist,
-  getFlagsFromLedgerDescription,
+  getFlagsFromStringProp,
   getCategoryFromDescription,
   convertArrayMapToObjectMap
 }

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -162,12 +162,14 @@ const _models = new Map([
       fee: 'DECIMAL(22,12)',
       feeCurrency: 'VARCHAR(255)',
       subUserId: 'INT',
+      _isExchange: 'INT',
       user_id: 'INT NOT NULL',
 
       [UNIQUE_INDEX_FIELD_NAME]: ['id', 'symbol', 'user_id'],
       [INDEX_FIELD_NAME]: [
         ['user_id', 'symbol', 'mtsCreate'],
         ['user_id', 'orderID', 'mtsCreate'],
+        ['user_id', '_isExchange', 'mtsCreate'],
         ['user_id', 'mtsCreate'],
         ['user_id', 'subUserId', 'mtsCreate',
           'WHERE subUserId IS NOT NULL'],

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -299,6 +299,10 @@ class TransactionTaxReport {
       {
         filter: {
           user_id: user._id,
+          $eq: {
+            user_id: user._id,
+            _isExchange: 1
+          },
           $lte: { mtsCreate: end },
           $gte: { mtsCreate: start },
           ...symbFilter


### PR DESCRIPTION
This PR selects `EXCHANGE` trades for the trx tax report

---

Base changes:
- Add `_isExchange` field to `trades` table model
- Remap `trades` table via DB migration to fill `_isExchange`
- Fill trade `_isExchange` field after `sync`
- Select `EXCHANGE` trades for trx tax report
