### PR TITLE
Fix pub-trade price lookup for trx tax report

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -261,8 +261,8 @@ class CurrencyPairSeparationError extends BaseError {
 }
 
 class PubTradeFindForTrxTaxError extends BaseError {
-  constructor (message = 'ERR_NO_PUBLIC_TRADES_FOR_TRX_TAX') {
-    super(message)
+  constructor (data, message = 'ERR_NO_PUBLIC_TRADES_FOR_TRX_TAX') {
+    super({ data, message })
   }
 }
 

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -237,6 +237,9 @@ class TransactionTaxReport {
       }
 
       const trxPriceCalculatorIterator = getBackIterable(trxPriceCalculators)
+      const symbSeparator = symbol.length > 3
+        ? ':'
+        : ''
 
       let pubTrades = []
       let pubTradeStart = pubTrades[0]?.mts
@@ -257,7 +260,7 @@ class TransactionTaxReport {
           const start = trx.mtsCreate - 1
 
           pubTrades = await this.#getPublicTrades(
-            { symbol: `t${symbol}USD`, start },
+            { symbol: `t${symbol}${symbSeparator}USD`, start },
             opts
           )
 
@@ -279,8 +282,11 @@ class TransactionTaxReport {
             }
 
             for (const [symbol, conversion] of synonymous) {
+              const symbSeparator = symbol.length > 3
+                ? ':'
+                : ''
               const res = await this.#getPublicTrades(
-                { symbol: `t${symbol}USD`, start },
+                { symbol: `t${symbol}${symbSeparator}USD`, start },
                 opts
               )
 

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -32,7 +32,8 @@ const depsTypes = (TYPES) => [
   TYPES.GetDataFromApi,
   TYPES.WSEventEmitterFactory,
   TYPES.Logger,
-  TYPES.InterrupterFactory
+  TYPES.InterrupterFactory,
+  TYPES.CurrencyConverter
 ]
 class TransactionTaxReport {
   constructor (
@@ -46,7 +47,8 @@ class TransactionTaxReport {
     getDataFromApi,
     wsEventEmitterFactory,
     logger,
-    interrupterFactory
+    interrupterFactory,
+    currencyConverter
   ) {
     this.dao = dao
     this.authenticator = authenticator
@@ -59,6 +61,7 @@ class TransactionTaxReport {
     this.wsEventEmitterFactory = wsEventEmitterFactory
     this.logger = logger
     this.interrupterFactory = interrupterFactory
+    this.currencyConverter = currencyConverter
 
     this.tradesModel = this.syncSchema.getModelsMap()
       .get(this.ALLOWED_COLLS.TRADES)
@@ -258,6 +261,48 @@ class TransactionTaxReport {
             opts
           )
 
+          if (
+            !Array.isArray(pubTrades) ||
+            pubTrades.length === 0
+          ) {
+            const ccySynonymous = await this.currencyConverter
+              .getCurrenciesSynonymous()
+            const synonymous = ccySynonymous.get(symbol)
+
+            if (!synonymous) {
+              throw new PubTradeFindForTrxTaxError({
+                symbol,
+                pubTradeStart,
+                pubTradeEnd,
+                requiredMts: trx.mtsCreate
+              })
+            }
+
+            for (const [symbol, conversion] of synonymous) {
+              const res = await this.#getPublicTrades(
+                { symbol: `t${symbol}USD`, start },
+                opts
+              )
+
+              if (
+                !Array.isArray(res) ||
+                res.length === 0
+              ) {
+                continue
+              }
+
+              pubTrades = res.map((item) => {
+                if (Number.isFinite(item?.price)) {
+                  item.price = item.price * conversion
+                }
+
+                return item
+              })
+
+              break
+            }
+          }
+
           pubTradeStart = start ?? pubTrades[0]?.mts
           pubTradeEnd = pubTrades[pubTrades.length - 1]?.mts
         }
@@ -270,7 +315,12 @@ class TransactionTaxReport {
           pubTradeStart > trx.mtsCreate ||
           pubTradeEnd < trx.mtsCreate
         ) {
-          throw new PubTradeFindForTrxTaxError()
+          throw new PubTradeFindForTrxTaxError({
+            symbol,
+            pubTradeStart,
+            pubTradeEnd,
+            requiredMts: trx.mtsCreate
+          })
         }
 
         const pubTrade = findPublicTrade(pubTrades, trx.mtsCreate)


### PR DESCRIPTION
This PR fixes pub-trade price lookup for the trx tax report

---

The issue is the following:
- eg user can have transactions with `LNX` ccy, but public trades endpoint does not provide price for it
- as a workaround, we can use ccy synonymous with conversion
- eg for `LNX` price is `BTC` = 1

![Screenshot from 2024-06-28 13-36-43](https://github.com/bitfinexcom/bfx-reports-framework/assets/16489235/9e7b9bf7-adca-4d94-baeb-4f2081dcde80)

---

Basic changes:
- Improve `PubTradeFindForTrxTaxError` error log
- Fixes pub-trade price lookup for trx tax report
- Add pair separator if ccy length is more than 3
