### PR TITLE
Add InvoicePayOrder and AirdropOnWallet ledgers to movements

### DIFF
--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -988,6 +988,7 @@ class BetterSqliteDAO extends DAO {
       filter = {},
       sort = [],
       subQuery = {
+        filter: {},
         sort: []
       },
       groupFns = [],
@@ -1003,7 +1004,10 @@ class BetterSqliteDAO extends DAO {
       group,
       groupProj
     } = getGroupQuery({ groupFns, groupResBy })
-    const _subQuery = getSubQuery({ name: collName, subQuery })
+    const {
+      subQuery: _subQuery,
+      subQueryValues
+    } = getSubQuery({ name: collName, subQuery })
     const _sort = getOrderQuery(sort)
     const {
       where,
@@ -1035,7 +1039,7 @@ class BetterSqliteDAO extends DAO {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.ALL,
       sql,
-      params: { ...values, ...limitVal }
+      params: { ...values, ...subQueryValues, ...limitVal }
     }, { withWorkerThreads: true })
   }
 

--- a/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v41.1716385152034.js
+++ b/workers/loc.api/sync/dao/db-migrations/sqlite-migrations/migration.v41.1716385152034.js
@@ -24,6 +24,24 @@ class MigrationV41 extends AbstractMigration {
       'ALTER TABLE trades ADD COLUMN exactUsdValue DECIMAL(22,12)',
       'ALTER TABLE movements ADD COLUMN exactUsdValue DECIMAL(22,12)',
 
+      'ALTER TABLE ledgers ADD COLUMN _isInvoicePayOrder INT',
+      `UPDATE ledgers SET _isInvoicePayOrder = (
+        SELECT 1 FROM (
+          SELECT * FROM ledgers AS l
+          WHERE l.description COLLATE NOCASE LIKE '%InvoicePay Order%'
+            AND l._id = ledgers._id
+        )
+      )`,
+
+      'ALTER TABLE ledgers ADD COLUMN _isAirdropOnWallet INT',
+      `UPDATE ledgers SET _isAirdropOnWallet = (
+        SELECT 1 FROM (
+          SELECT * FROM ledgers AS l
+          WHERE l.description COLLATE NOCASE LIKE '%Airdrop on wallet%'
+            AND l._id = ledgers._id
+        )
+      )`,
+
       'ALTER TABLE trades ADD COLUMN _isExchange INT',
       `UPDATE trades SET _isExchange = (
         SELECT 1 FROM (

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
@@ -44,7 +44,7 @@ module.exports = (args, methodColl, opts) => {
     group,
     groupProj
   } = getGroupQuery(methodColl)
-  const subQuery = getSubQuery(methodColl)
+  const { subQuery, subQueryValues } = getSubQuery(methodColl)
   const projection = getProjectionQuery(
     _model,
     exclude,
@@ -65,6 +65,6 @@ module.exports = (args, methodColl, opts) => {
 
   return {
     sql,
-    sqlParams: { ...values, ...limitVal }
+    sqlParams: { ...values, ...subQueryValues, ...limitVal }
   }
 }

--- a/workers/loc.api/sync/dao/helpers/get-sub-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-sub-query.js
@@ -1,16 +1,39 @@
 'use strict'
 
+const getWhereQuery = require('./get-where-query')
 const getOrderQuery = require('./get-order-query')
 
-module.exports = ({
-  name,
-  subQuery: { sort = [] } = {}
-} = {}) => {
+module.exports = (params) => {
+  const {
+    name
+  } = params ?? {}
+  const filter = params?.subQuery?.filter ?? {}
+  const sort = params?.subQuery?.sort ?? []
+
+  const alias = `${name}_sub_q`
+  const {
+    where,
+    values
+  } = getWhereQuery(
+    filter,
+    { alias }
+  )
   const _sort = getOrderQuery(sort)
 
-  if (!_sort) {
-    return name
+  if (
+    !_sort &&
+    !where
+  ) {
+    return {
+      subQuery: name,
+      subQueryValues: {}
+    }
   }
 
-  return `(SELECT * FROM ${name} ${_sort})`
+  const subQuery = `(SELECT * FROM ${name} AS ${alias} ${where} ${_sort})`
+
+  return {
+    subQuery,
+    subQueryValues: values
+  }
 }

--- a/workers/loc.api/sync/dao/helpers/serialization/deserialize-val.js
+++ b/workers/loc.api/sync/dao/helpers/serialization/deserialize-val.js
@@ -16,7 +16,10 @@ module.exports = (
     '_isMarginFundingPayment',
     '_isAffiliateRebate',
     '_isStakingPayments',
-    '_isSubAccountsTransfer'
+    '_isSubAccountsTransfer',
+    '_isInvoicePayOrder',
+    '_isAirdropOnWallet',
+    '_isExchange'
   ]
 ) => {
   if (

--- a/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware/api.middleware.handler.after.js
@@ -133,6 +133,14 @@ class ApiMiddlewareHandlerAfter {
             {
               fieldName: '_isSubAccountsTransfer',
               pattern: '^transfer.+sa[(].+[)]'
+            },
+            {
+              fieldName: '_isInvoicePayOrder',
+              pattern: 'InvoicePay Order'
+            },
+            {
+              fieldName: '_isAirdropOnWallet',
+              pattern: 'Airdrop on wallet'
             }
           ]
         ),

--- a/workers/loc.api/sync/schema/models.js
+++ b/workers/loc.api/sync/schema/models.js
@@ -119,6 +119,8 @@ const _models = new Map([
       _isStakingPayments: 'INT',
       _isSubAccountsTransfer: 'INT',
       _isBalanceRecalced: 'INT',
+      _isInvoicePayOrder: 'INT',
+      _isAirdropOnWallet: 'INT',
       subUserId: 'INT',
       user_id: 'INT NOT NULL',
 
@@ -134,6 +136,8 @@ const _models = new Map([
         ['user_id', '_category', 'mts'],
         ['user_id', 'mts'],
         ['currency', 'mts'],
+        ['_isInvoicePayOrder'],
+        ['_isAirdropOnWallet'],
         ['user_id', 'subUserId', 'mts',
           'WHERE subUserId IS NOT NULL'],
         ['subUserId', 'mts', '_id',

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -183,14 +183,16 @@ class TransactionTaxReport {
       start,
       end,
       isWithdrawals: true,
-      isExcludePrivate: false
+      isExcludePrivate: false,
+      areExtraPaymentsIncluded: true
     })
     const depositsPromise = this.movements.getMovements({
       auth: user,
       start,
       end,
       isDeposits: true,
-      isExcludePrivate: false
+      isExcludePrivate: false,
+      areExtraPaymentsIncluded: true
     })
 
     const [


### PR DESCRIPTION
This PR adds `_isInvoicePayOrder`, `_isAirdropOnWallet`, `_isMarginFundingPayment`, `_isAffiliateRebate`, `_isStakingPayments` ledgers to movements

---

Base changes:
- Add `_isInvoicePayOrder` and `_isAirdropOnWallet` fields to the db model of `ledgers` table
- Remap ledgers table via migration to fill `_isInvoicePayOrder` and `_isAirdropOnWallet`
- Fill ledger `_isInvoicePayOrder` and `_isAirdropOnWallet` fields after sync
- Add new flags to deserialization
- Provide ability to set `where` sql condition to sub-query
- Add `_isInvoicePayOrder`, `_isAirdropOnWallet`, `_isMarginFundingPayment`, `_isAffiliateRebate`, `_isStakingPayments` ledgers to movements
