### PR TITLE
Move sync schema to separate files

### DIFF
--- a/workers/loc.api/sync/schema/sync-schema/candles.js
+++ b/workers/loc.api/sync/schema/sync-schema/candles.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.CANDLES,
+  maxLimit: 10000,
+  dateFieldName: 'mts',
+  symbolFieldName: '_symbol',
+  timeframeFieldName: '_timeframe',
+  sort: [['mts', -1]],
+  hasNewData: false,
+  start: [],
+  confName: 'candlesConf',
+  isSyncRequiredAtLeastOnce: true,
+  additionalApiCallArgs: { isNotMoreThanInnerMax: true },
+  type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.CANDLES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/change-logs.js
+++ b/workers/loc.api/sync/schema/sync-schema/change-logs.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.CHANGE_LOGS,
+  maxLimit: 10000,
+  dateFieldName: 'mtsCreate',
+  symbolFieldName: null,
+  sort: [['mtsCreate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/currencies.js
+++ b/workers/loc.api/sync/schema/sync-schema/currencies.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.CURRENCIES,
+  maxLimit: 10000,
+  projection: null,
+  sort: [['name', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.CURRENCIES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/funding-credit-history.js
+++ b/workers/loc.api/sync/schema/sync-schema/funding-credit-history.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.FUNDING_CREDIT_HISTORY,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
+}

--- a/workers/loc.api/sync/schema/sync-schema/funding-loan-history.js
+++ b/workers/loc.api/sync/schema/sync-schema/funding-loan-history.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.FUNDING_LOAN_HISTORY,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
+}

--- a/workers/loc.api/sync/schema/sync-schema/funding-offer-history.js
+++ b/workers/loc.api/sync/schema/sync-schema/funding-offer-history.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.FUNDING_OFFER_HISTORY,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
+}

--- a/workers/loc.api/sync/schema/sync-schema/funding-trades.js
+++ b/workers/loc.api/sync/schema/sync-schema/funding-trades.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.FUNDING_TRADES,
+  maxLimit: 1000,
+  dateFieldName: 'mtsCreate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsCreate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.FUNDING_TRADES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/futures.js
+++ b/workers/loc.api/sync/schema/sync-schema/futures.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.FUTURES,
+  maxLimit: 10000,
+  projection: 'pairs',
+  sort: [['pairs', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
+  model: getModelOf(TABLES_NAMES.FUTURES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/inactive-currencies.js
+++ b/workers/loc.api/sync/schema/sync-schema/inactive-currencies.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.INACTIVE_CURRENCIES,
+  maxLimit: 10000,
+  projection: 'pairs',
+  sort: [['pairs', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
+  model: getModelOf(TABLES_NAMES.INACTIVE_CURRENCIES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/inactive-symbols.js
+++ b/workers/loc.api/sync/schema/sync-schema/inactive-symbols.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.INACTIVE_SYMBOLS,
+  maxLimit: 10000,
+  projection: 'pairs',
+  sort: [['pairs', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
+  model: getModelOf(TABLES_NAMES.INACTIVE_SYMBOLS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -19,6 +19,7 @@ const fundingOfferHistory = require('./funding-offer-history')
 const fundingLoanHistory = require('./funding-loan-history')
 const fundingCreditHistory = require('./funding-credit-history')
 const positionsHistory = require('./positions-history')
+const positionsSnapshot = require('./positions-snapshot')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -32,21 +33,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.FUNDING_LOAN_HISTORY, fundingLoanHistory],
   [SYNC_API_METHODS.FUNDING_CREDIT_HISTORY, fundingCreditHistory],
   [SYNC_API_METHODS.POSITIONS_HISTORY, positionsHistory],
-  [
-    SYNC_API_METHODS.POSITIONS_SNAPSHOT,
-    {
-      name: ALLOWED_COLLS.POSITIONS_SNAPSHOT,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.POSITIONS_SNAPSHOT)
-    }
-  ],
+  [SYNC_API_METHODS.POSITIONS_SNAPSHOT, positionsSnapshot],
   [
     SYNC_API_METHODS.LOGINS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -10,25 +10,12 @@ const { getModelOf } = require('../models')
 
 const ledgers = require('./ledgers')
 const trades = require('./trades')
+const fundingTrades = require('./funding-trades')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
   [SYNC_API_METHODS.TRADES, trades],
-  [
-    SYNC_API_METHODS.FUNDING_TRADES,
-    {
-      name: ALLOWED_COLLS.FUNDING_TRADES,
-      maxLimit: 1000,
-      dateFieldName: 'mtsCreate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsCreate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.FUNDING_TRADES)
-    }
-  ],
+  [SYNC_API_METHODS.FUNDING_TRADES, fundingTrades],
   [
     SYNC_API_METHODS.PUBLIC_TRADES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -25,6 +25,7 @@ const changeLogs = require('./change-logs')
 const payInvoiceList = require('./pay-invoice-list')
 const tickersHistory = require('./tickers-history')
 const wallets = require('./wallets')
+const symbols = require('./symbols')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -44,19 +45,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.PAY_INVOICE_LIST, payInvoiceList],
   [SYNC_API_METHODS.TICKERS_HISTORY, tickersHistory],
   [SYNC_API_METHODS.WALLETS, wallets],
-  [
-    SYNC_API_METHODS.SYMBOLS,
-    {
-      name: ALLOWED_COLLS.SYMBOLS,
-      maxLimit: 10000,
-      projection: 'pairs',
-      sort: [['pairs', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
-      model: getModelOf(TABLES_NAMES.SYMBOLS)
-    }
-  ],
+  [SYNC_API_METHODS.SYMBOLS, symbols],
   [
     SYNC_API_METHODS.MAP_SYMBOLS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -1,32 +1,17 @@
 'use strict'
 
-const TABLES_NAMES = require('./tables-names')
-const ALLOWED_COLLS = require('./allowed.colls')
-const SYNC_API_METHODS = require('./sync.api.methods')
-const COLLS_TYPES = require('./colls.types')
-const { cloneSchema } = require('./helpers')
-const { getModelOf } = require('./models')
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const SYNC_API_METHODS = require('../sync.api.methods')
+const COLLS_TYPES = require('../colls.types')
 
-const getMethodCollMap = (methodCollMap = _methodCollMap) => {
-  return cloneSchema(methodCollMap)
-}
+const { cloneSchema } = require('../helpers')
+const { getModelOf } = require('../models')
+
+const ledgers = require('./ledgers')
 
 const _methodCollMap = new Map([
-  [
-    SYNC_API_METHODS.LEDGERS,
-    {
-      name: ALLOWED_COLLS.LEDGERS,
-      maxLimit: 2500,
-      dateFieldName: 'mts',
-      symbolFieldName: 'currency',
-      sort: [['mts', -1], ['id', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.LEDGERS)
-    }
-  ],
+  [SYNC_API_METHODS.LEDGERS, ledgers],
   [
     SYNC_API_METHODS.TRADES,
     {
@@ -399,6 +384,10 @@ const _methodCollMap = new Map([
     }
   ]
 ])
+
+const getMethodCollMap = (methodCollMap = _methodCollMap) => {
+  return cloneSchema(methodCollMap)
+}
 
 module.exports = {
   getMethodCollMap

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -21,6 +21,7 @@ const fundingCreditHistory = require('./funding-credit-history')
 const positionsHistory = require('./positions-history')
 const positionsSnapshot = require('./positions-snapshot')
 const logins = require('./logins')
+const changeLogs = require('./change-logs')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -36,21 +37,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.POSITIONS_HISTORY, positionsHistory],
   [SYNC_API_METHODS.POSITIONS_SNAPSHOT, positionsSnapshot],
   [SYNC_API_METHODS.LOGINS, logins],
-  [
-    SYNC_API_METHODS.CHANGE_LOGS,
-    {
-      name: ALLOWED_COLLS.CHANGE_LOGS,
-      maxLimit: 10000,
-      dateFieldName: 'mtsCreate',
-      symbolFieldName: null,
-      sort: [['mtsCreate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.CHANGE_LOGS)
-    }
-  ],
+  [SYNC_API_METHODS.CHANGE_LOGS, changeLogs],
   [
     SYNC_API_METHODS.PAY_INVOICE_LIST,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -29,6 +29,7 @@ const symbols = require('./symbols')
 const mapSymbols = require('./map-symbols')
 const inactiveCurrencies = require('./inactive-currencies')
 const inactiveSymbols = require('./inactive-symbols')
+const futures = require('./futures')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -52,19 +53,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.MAP_SYMBOLS, mapSymbols],
   [SYNC_API_METHODS.INACTIVE_CURRENCIES, inactiveCurrencies],
   [SYNC_API_METHODS.INACTIVE_SYMBOLS, inactiveSymbols],
-  [
-    SYNC_API_METHODS.FUTURES,
-    {
-      name: ALLOWED_COLLS.FUTURES,
-      maxLimit: 10000,
-      projection: 'pairs',
-      sort: [['pairs', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
-      model: getModelOf(TABLES_NAMES.FUTURES)
-    }
-  ],
+  [SYNC_API_METHODS.FUTURES, futures],
   [
     SYNC_API_METHODS.CURRENCIES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -22,6 +22,7 @@ const positionsHistory = require('./positions-history')
 const positionsSnapshot = require('./positions-snapshot')
 const logins = require('./logins')
 const changeLogs = require('./change-logs')
+const payInvoiceList = require('./pay-invoice-list')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -38,21 +39,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.POSITIONS_SNAPSHOT, positionsSnapshot],
   [SYNC_API_METHODS.LOGINS, logins],
   [SYNC_API_METHODS.CHANGE_LOGS, changeLogs],
-  [
-    SYNC_API_METHODS.PAY_INVOICE_LIST,
-    {
-      name: ALLOWED_COLLS.PAY_INVOICE_LIST,
-      maxLimit: 100,
-      dateFieldName: 't',
-      symbolFieldName: 'currency',
-      sort: [['t', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.PAY_INVOICE_LIST)
-    }
-  ],
+  [SYNC_API_METHODS.PAY_INVOICE_LIST, payInvoiceList],
   [
     SYNC_API_METHODS.TICKERS_HISTORY,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -1,12 +1,6 @@
 'use strict'
 
-const TABLES_NAMES = require('../tables-names')
-const ALLOWED_COLLS = require('../allowed.colls')
 const SYNC_API_METHODS = require('../sync.api.methods')
-const COLLS_TYPES = require('../colls.types')
-
-const { cloneSchema } = require('../helpers')
-const { getModelOf } = require('../models')
 
 const ledgers = require('./ledgers')
 const trades = require('./trades')
@@ -32,6 +26,7 @@ const inactiveSymbols = require('./inactive-symbols')
 const futures = require('./futures')
 const currencies = require('./currencies')
 const marginCurrencyList = require('./margin-currency-list')
+const candles = require('./candles')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -58,25 +53,10 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.FUTURES, futures],
   [SYNC_API_METHODS.CURRENCIES, currencies],
   [SYNC_API_METHODS.MARGIN_CURRENCY_LIST, marginCurrencyList],
-  [
-    SYNC_API_METHODS.CANDLES,
-    {
-      name: ALLOWED_COLLS.CANDLES,
-      maxLimit: 10000,
-      dateFieldName: 'mts',
-      symbolFieldName: '_symbol',
-      timeframeFieldName: '_timeframe',
-      sort: [['mts', -1]],
-      hasNewData: false,
-      start: [],
-      confName: 'candlesConf',
-      isSyncRequiredAtLeastOnce: true,
-      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
-      type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.CANDLES)
-    }
-  ]
+  [SYNC_API_METHODS.CANDLES, candles]
 ])
+
+const { cloneSchema } = require('../helpers')
 
 const getMethodCollMap = (methodCollMap = _methodCollMap) => {
   return cloneSchema(methodCollMap)

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -13,6 +13,7 @@ const trades = require('./trades')
 const fundingTrades = require('./funding-trades')
 const publicTrades = require('./public-trades')
 const statusMessages = require('./status-messages')
+const orders = require('./orders')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -20,21 +21,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.FUNDING_TRADES, fundingTrades],
   [SYNC_API_METHODS.PUBLIC_TRADES, publicTrades],
   [SYNC_API_METHODS.STATUS_MESSAGES, statusMessages],
-  [
-    SYNC_API_METHODS.ORDERS,
-    {
-      name: ALLOWED_COLLS.ORDERS,
-      maxLimit: 2500,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.ORDERS)
-    }
-  ],
+  [SYNC_API_METHODS.ORDERS, orders],
   [
     SYNC_API_METHODS.MOVEMENTS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -20,6 +20,7 @@ const fundingLoanHistory = require('./funding-loan-history')
 const fundingCreditHistory = require('./funding-credit-history')
 const positionsHistory = require('./positions-history')
 const positionsSnapshot = require('./positions-snapshot')
+const logins = require('./logins')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -34,21 +35,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.FUNDING_CREDIT_HISTORY, fundingCreditHistory],
   [SYNC_API_METHODS.POSITIONS_HISTORY, positionsHistory],
   [SYNC_API_METHODS.POSITIONS_SNAPSHOT, positionsSnapshot],
-  [
-    SYNC_API_METHODS.LOGINS,
-    {
-      name: ALLOWED_COLLS.LOGINS,
-      maxLimit: 10000,
-      dateFieldName: 'time',
-      symbolFieldName: null,
-      sort: [['time', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.LOGINS)
-    }
-  ],
+  [SYNC_API_METHODS.LOGINS, logins],
   [
     SYNC_API_METHODS.CHANGE_LOGS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -15,6 +15,7 @@ const publicTrades = require('./public-trades')
 const statusMessages = require('./status-messages')
 const orders = require('./orders')
 const movements = require('./movements')
+const fundingOfferHistory = require('./funding-offer-history')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -24,21 +25,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.STATUS_MESSAGES, statusMessages],
   [SYNC_API_METHODS.ORDERS, orders],
   [SYNC_API_METHODS.MOVEMENTS, movements],
-  [
-    SYNC_API_METHODS.FUNDING_OFFER_HISTORY,
-    {
-      name: ALLOWED_COLLS.FUNDING_OFFER_HISTORY,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.FUNDING_OFFER_HISTORY)
-    }
-  ],
+  [SYNC_API_METHODS.FUNDING_OFFER_HISTORY, fundingOfferHistory],
   [
     SYNC_API_METHODS.FUNDING_LOAN_HISTORY,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -14,6 +14,7 @@ const fundingTrades = require('./funding-trades')
 const publicTrades = require('./public-trades')
 const statusMessages = require('./status-messages')
 const orders = require('./orders')
+const movements = require('./movements')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -22,21 +23,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.PUBLIC_TRADES, publicTrades],
   [SYNC_API_METHODS.STATUS_MESSAGES, statusMessages],
   [SYNC_API_METHODS.ORDERS, orders],
-  [
-    SYNC_API_METHODS.MOVEMENTS,
-    {
-      name: ALLOWED_COLLS.MOVEMENTS,
-      maxLimit: 250,
-      dateFieldName: 'mtsUpdated',
-      symbolFieldName: 'currency',
-      sort: [['mtsUpdated', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.MOVEMENTS)
-    }
-  ],
+  [SYNC_API_METHODS.MOVEMENTS, movements],
   [
     SYNC_API_METHODS.FUNDING_OFFER_HISTORY,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -31,6 +31,7 @@ const inactiveCurrencies = require('./inactive-currencies')
 const inactiveSymbols = require('./inactive-symbols')
 const futures = require('./futures')
 const currencies = require('./currencies')
+const marginCurrencyList = require('./margin-currency-list')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -56,19 +57,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.INACTIVE_SYMBOLS, inactiveSymbols],
   [SYNC_API_METHODS.FUTURES, futures],
   [SYNC_API_METHODS.CURRENCIES, currencies],
-  [
-    SYNC_API_METHODS.MARGIN_CURRENCY_LIST,
-    {
-      name: ALLOWED_COLLS.MARGIN_CURRENCY_LIST,
-      maxLimit: 10000,
-      projection: 'symbol',
-      sort: [['symbol', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
-      model: getModelOf(TABLES_NAMES.MARGIN_CURRENCY_LIST)
-    }
-  ],
+  [SYNC_API_METHODS.MARGIN_CURRENCY_LIST, marginCurrencyList],
   [
     SYNC_API_METHODS.CANDLES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -9,24 +9,11 @@ const { cloneSchema } = require('../helpers')
 const { getModelOf } = require('../models')
 
 const ledgers = require('./ledgers')
+const trades = require('./trades')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
-  [
-    SYNC_API_METHODS.TRADES,
-    {
-      name: ALLOWED_COLLS.TRADES,
-      maxLimit: 2500,
-      dateFieldName: 'mtsCreate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsCreate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.TRADES)
-    }
-  ],
+  [SYNC_API_METHODS.TRADES, trades],
   [
     SYNC_API_METHODS.FUNDING_TRADES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -23,6 +23,7 @@ const positionsSnapshot = require('./positions-snapshot')
 const logins = require('./logins')
 const changeLogs = require('./change-logs')
 const payInvoiceList = require('./pay-invoice-list')
+const tickersHistory = require('./tickers-history')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -40,23 +41,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.LOGINS, logins],
   [SYNC_API_METHODS.CHANGE_LOGS, changeLogs],
   [SYNC_API_METHODS.PAY_INVOICE_LIST, payInvoiceList],
-  [
-    SYNC_API_METHODS.TICKERS_HISTORY,
-    {
-      name: ALLOWED_COLLS.TICKERS_HISTORY,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      confName: 'tickersHistoryConf',
-      isSyncRequiredAtLeastOnce: false,
-      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
-      type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.TICKERS_HISTORY)
-    }
-  ],
+  [SYNC_API_METHODS.TICKERS_HISTORY, tickersHistory],
   [
     SYNC_API_METHODS.WALLETS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -16,6 +16,7 @@ const statusMessages = require('./status-messages')
 const orders = require('./orders')
 const movements = require('./movements')
 const fundingOfferHistory = require('./funding-offer-history')
+const fundingLoanHistory = require('./funding-loan-history')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -26,21 +27,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.ORDERS, orders],
   [SYNC_API_METHODS.MOVEMENTS, movements],
   [SYNC_API_METHODS.FUNDING_OFFER_HISTORY, fundingOfferHistory],
-  [
-    SYNC_API_METHODS.FUNDING_LOAN_HISTORY,
-    {
-      name: ALLOWED_COLLS.FUNDING_LOAN_HISTORY,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.FUNDING_LOAN_HISTORY)
-    }
-  ],
+  [SYNC_API_METHODS.FUNDING_LOAN_HISTORY, fundingLoanHistory],
   [
     SYNC_API_METHODS.FUNDING_CREDIT_HISTORY,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -27,6 +27,7 @@ const tickersHistory = require('./tickers-history')
 const wallets = require('./wallets')
 const symbols = require('./symbols')
 const mapSymbols = require('./map-symbols')
+const inactiveCurrencies = require('./inactive-currencies')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -48,19 +49,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.WALLETS, wallets],
   [SYNC_API_METHODS.SYMBOLS, symbols],
   [SYNC_API_METHODS.MAP_SYMBOLS, mapSymbols],
-  [
-    SYNC_API_METHODS.INACTIVE_CURRENCIES,
-    {
-      name: ALLOWED_COLLS.INACTIVE_CURRENCIES,
-      maxLimit: 10000,
-      projection: 'pairs',
-      sort: [['pairs', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
-      model: getModelOf(TABLES_NAMES.INACTIVE_CURRENCIES)
-    }
-  ],
+  [SYNC_API_METHODS.INACTIVE_CURRENCIES, inactiveCurrencies],
   [
     SYNC_API_METHODS.INACTIVE_SYMBOLS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -12,27 +12,14 @@ const ledgers = require('./ledgers')
 const trades = require('./trades')
 const fundingTrades = require('./funding-trades')
 const publicTrades = require('./public-trades')
+const statusMessages = require('./status-messages')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
   [SYNC_API_METHODS.TRADES, trades],
   [SYNC_API_METHODS.FUNDING_TRADES, fundingTrades],
   [SYNC_API_METHODS.PUBLIC_TRADES, publicTrades],
-  [
-    SYNC_API_METHODS.STATUS_MESSAGES,
-    {
-      name: ALLOWED_COLLS.STATUS_MESSAGES,
-      maxLimit: 5000,
-      dateFieldName: 'timestamp',
-      symbolFieldName: 'key',
-      sort: [['timestamp', -1]],
-      hasNewData: false,
-      confName: 'statusMessagesConf',
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.STATUS_MESSAGES)
-    }
-  ],
+  [SYNC_API_METHODS.STATUS_MESSAGES, statusMessages],
   [
     SYNC_API_METHODS.ORDERS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -26,6 +26,7 @@ const payInvoiceList = require('./pay-invoice-list')
 const tickersHistory = require('./tickers-history')
 const wallets = require('./wallets')
 const symbols = require('./symbols')
+const mapSymbols = require('./map-symbols')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -46,19 +47,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.TICKERS_HISTORY, tickersHistory],
   [SYNC_API_METHODS.WALLETS, wallets],
   [SYNC_API_METHODS.SYMBOLS, symbols],
-  [
-    SYNC_API_METHODS.MAP_SYMBOLS,
-    {
-      name: ALLOWED_COLLS.MAP_SYMBOLS,
-      maxLimit: 10000,
-      projection: ['key', 'value'],
-      sort: [['key', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.MAP_SYMBOLS)
-    }
-  ],
+  [SYNC_API_METHODS.MAP_SYMBOLS, mapSymbols],
   [
     SYNC_API_METHODS.INACTIVE_CURRENCIES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -30,6 +30,7 @@ const mapSymbols = require('./map-symbols')
 const inactiveCurrencies = require('./inactive-currencies')
 const inactiveSymbols = require('./inactive-symbols')
 const futures = require('./futures')
+const currencies = require('./currencies')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -54,19 +55,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.INACTIVE_CURRENCIES, inactiveCurrencies],
   [SYNC_API_METHODS.INACTIVE_SYMBOLS, inactiveSymbols],
   [SYNC_API_METHODS.FUTURES, futures],
-  [
-    SYNC_API_METHODS.CURRENCIES,
-    {
-      name: ALLOWED_COLLS.CURRENCIES,
-      maxLimit: 10000,
-      projection: null,
-      sort: [['name', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.CURRENCIES)
-    }
-  ],
+  [SYNC_API_METHODS.CURRENCIES, currencies],
   [
     SYNC_API_METHODS.MARGIN_CURRENCY_LIST,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -18,6 +18,7 @@ const movements = require('./movements')
 const fundingOfferHistory = require('./funding-offer-history')
 const fundingLoanHistory = require('./funding-loan-history')
 const fundingCreditHistory = require('./funding-credit-history')
+const positionsHistory = require('./positions-history')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -30,22 +31,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.FUNDING_OFFER_HISTORY, fundingOfferHistory],
   [SYNC_API_METHODS.FUNDING_LOAN_HISTORY, fundingLoanHistory],
   [SYNC_API_METHODS.FUNDING_CREDIT_HISTORY, fundingCreditHistory],
-  [
-    SYNC_API_METHODS.POSITIONS_HISTORY,
-    {
-      name: ALLOWED_COLLS.POSITIONS_HISTORY,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      shouldNotApiMiddlewareBeLaunched: true,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
-    }
-  ],
+  [SYNC_API_METHODS.POSITIONS_HISTORY, positionsHistory],
   [
     SYNC_API_METHODS.POSITIONS_SNAPSHOT,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -28,6 +28,7 @@ const wallets = require('./wallets')
 const symbols = require('./symbols')
 const mapSymbols = require('./map-symbols')
 const inactiveCurrencies = require('./inactive-currencies')
+const inactiveSymbols = require('./inactive-symbols')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -50,19 +51,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.SYMBOLS, symbols],
   [SYNC_API_METHODS.MAP_SYMBOLS, mapSymbols],
   [SYNC_API_METHODS.INACTIVE_CURRENCIES, inactiveCurrencies],
-  [
-    SYNC_API_METHODS.INACTIVE_SYMBOLS,
-    {
-      name: ALLOWED_COLLS.INACTIVE_SYMBOLS,
-      maxLimit: 10000,
-      projection: 'pairs',
-      sort: [['pairs', 1]],
-      hasNewData: false,
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
-      model: getModelOf(TABLES_NAMES.INACTIVE_SYMBOLS)
-    }
-  ],
+  [SYNC_API_METHODS.INACTIVE_SYMBOLS, inactiveSymbols],
   [
     SYNC_API_METHODS.FUTURES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -24,6 +24,7 @@ const logins = require('./logins')
 const changeLogs = require('./change-logs')
 const payInvoiceList = require('./pay-invoice-list')
 const tickersHistory = require('./tickers-history')
+const wallets = require('./wallets')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -42,38 +43,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.CHANGE_LOGS, changeLogs],
   [SYNC_API_METHODS.PAY_INVOICE_LIST, payInvoiceList],
   [SYNC_API_METHODS.TICKERS_HISTORY, tickersHistory],
-  [
-    SYNC_API_METHODS.WALLETS,
-    {
-      name: ALLOWED_COLLS.LEDGERS,
-      dateFieldName: 'mts',
-      symbolFieldName: 'currency',
-      sort: [['mts', -1]],
-      groupFns: ['max(mts)', 'max(id)'],
-      groupResBy: ['wallet', 'currency'],
-      isSyncRequiredAtLeastOnce: true,
-      type: COLLS_TYPES.HIDDEN_INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.LEDGERS),
-      dataStructureConverter: (accum, {
-        wallet: type,
-        currency,
-        balance,
-        mts: mtsUpdate
-      } = {}) => {
-        accum.push({
-          type,
-          currency,
-          balance,
-          unsettledInterest: null,
-          balanceAvailable: null,
-          placeHolder: null,
-          mtsUpdate
-        })
-
-        return accum
-      }
-    }
-  ],
+  [SYNC_API_METHODS.WALLETS, wallets],
   [
     SYNC_API_METHODS.SYMBOLS,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -17,6 +17,7 @@ const orders = require('./orders')
 const movements = require('./movements')
 const fundingOfferHistory = require('./funding-offer-history')
 const fundingLoanHistory = require('./funding-loan-history')
+const fundingCreditHistory = require('./funding-credit-history')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
@@ -28,21 +29,7 @@ const _methodCollMap = new Map([
   [SYNC_API_METHODS.MOVEMENTS, movements],
   [SYNC_API_METHODS.FUNDING_OFFER_HISTORY, fundingOfferHistory],
   [SYNC_API_METHODS.FUNDING_LOAN_HISTORY, fundingLoanHistory],
-  [
-    SYNC_API_METHODS.FUNDING_CREDIT_HISTORY,
-    {
-      name: ALLOWED_COLLS.FUNDING_CREDIT_HISTORY,
-      maxLimit: 10000,
-      dateFieldName: 'mtsUpdate',
-      symbolFieldName: 'symbol',
-      sort: [['mtsUpdate', -1]],
-      hasNewData: false,
-      start: [],
-      isSyncRequiredAtLeastOnce: false,
-      type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.FUNDING_CREDIT_HISTORY)
-    }
-  ],
+  [SYNC_API_METHODS.FUNDING_CREDIT_HISTORY, fundingCreditHistory],
   [
     SYNC_API_METHODS.POSITIONS_HISTORY,
     {

--- a/workers/loc.api/sync/schema/sync-schema/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/index.js
@@ -11,28 +11,13 @@ const { getModelOf } = require('../models')
 const ledgers = require('./ledgers')
 const trades = require('./trades')
 const fundingTrades = require('./funding-trades')
+const publicTrades = require('./public-trades')
 
 const _methodCollMap = new Map([
   [SYNC_API_METHODS.LEDGERS, ledgers],
   [SYNC_API_METHODS.TRADES, trades],
   [SYNC_API_METHODS.FUNDING_TRADES, fundingTrades],
-  [
-    SYNC_API_METHODS.PUBLIC_TRADES,
-    {
-      name: ALLOWED_COLLS.PUBLIC_TRADES,
-      maxLimit: 5000,
-      dateFieldName: 'mts',
-      symbolFieldName: '_symbol',
-      sort: [['mts', -1]],
-      hasNewData: false,
-      start: [],
-      confName: 'publicTradesConf',
-      isSyncRequiredAtLeastOnce: false,
-      additionalApiCallArgs: { isNotMoreThanInnerMax: true },
-      type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
-      model: getModelOf(TABLES_NAMES.PUBLIC_TRADES)
-    }
-  ],
+  [SYNC_API_METHODS.PUBLIC_TRADES, publicTrades],
   [
     SYNC_API_METHODS.STATUS_MESSAGES,
     {

--- a/workers/loc.api/sync/schema/sync-schema/ledgers.js
+++ b/workers/loc.api/sync/schema/sync-schema/ledgers.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.LEDGERS,
+  maxLimit: 2500,
+  dateFieldName: 'mts',
+  symbolFieldName: 'currency',
+  sort: [['mts', -1], ['id', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.LEDGERS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/logins.js
+++ b/workers/loc.api/sync/schema/sync-schema/logins.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.LOGINS,
+  maxLimit: 10000,
+  dateFieldName: 'time',
+  symbolFieldName: null,
+  sort: [['time', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.LOGINS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/map-symbols.js
+++ b/workers/loc.api/sync/schema/sync-schema/map-symbols.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.MAP_SYMBOLS,
+  maxLimit: 10000,
+  projection: ['key', 'value'],
+  sort: [['key', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.MAP_SYMBOLS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/margin-currency-list.js
+++ b/workers/loc.api/sync/schema/sync-schema/margin-currency-list.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.MARGIN_CURRENCY_LIST,
+  maxLimit: 10000,
+  projection: 'symbol',
+  sort: [['symbol', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
+  model: getModelOf(TABLES_NAMES.MARGIN_CURRENCY_LIST)
+}

--- a/workers/loc.api/sync/schema/sync-schema/movements.js
+++ b/workers/loc.api/sync/schema/sync-schema/movements.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.MOVEMENTS,
+  maxLimit: 250,
+  dateFieldName: 'mtsUpdated',
+  symbolFieldName: 'currency',
+  sort: [['mtsUpdated', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.MOVEMENTS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/orders.js
+++ b/workers/loc.api/sync/schema/sync-schema/orders.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.ORDERS,
+  maxLimit: 2500,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.ORDERS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/pay-invoice-list.js
+++ b/workers/loc.api/sync/schema/sync-schema/pay-invoice-list.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.PAY_INVOICE_LIST,
+  maxLimit: 100,
+  dateFieldName: 't',
+  symbolFieldName: 'currency',
+  sort: [['t', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.PAY_INVOICE_LIST)
+}

--- a/workers/loc.api/sync/schema/sync-schema/positions-history.js
+++ b/workers/loc.api/sync/schema/sync-schema/positions-history.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.POSITIONS_HISTORY,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  shouldNotApiMiddlewareBeLaunched: true,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.POSITIONS_HISTORY)
+}

--- a/workers/loc.api/sync/schema/sync-schema/positions-snapshot.js
+++ b/workers/loc.api/sync/schema/sync-schema/positions-snapshot.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.POSITIONS_SNAPSHOT,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.POSITIONS_SNAPSHOT)
+}

--- a/workers/loc.api/sync/schema/sync-schema/public-trades.js
+++ b/workers/loc.api/sync/schema/sync-schema/public-trades.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.PUBLIC_TRADES,
+  maxLimit: 5000,
+  dateFieldName: 'mts',
+  symbolFieldName: '_symbol',
+  sort: [['mts', -1]],
+  hasNewData: false,
+  start: [],
+  confName: 'publicTradesConf',
+  isSyncRequiredAtLeastOnce: false,
+  additionalApiCallArgs: { isNotMoreThanInnerMax: true },
+  type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.PUBLIC_TRADES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/status-messages.js
+++ b/workers/loc.api/sync/schema/sync-schema/status-messages.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.STATUS_MESSAGES,
+  maxLimit: 5000,
+  dateFieldName: 'timestamp',
+  symbolFieldName: 'key',
+  sort: [['timestamp', -1]],
+  hasNewData: false,
+  confName: 'statusMessagesConf',
+  isSyncRequiredAtLeastOnce: false,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.STATUS_MESSAGES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/symbols.js
+++ b/workers/loc.api/sync/schema/sync-schema/symbols.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.SYMBOLS,
+  maxLimit: 10000,
+  projection: 'pairs',
+  sort: [['pairs', 1]],
+  hasNewData: false,
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.PUBLIC_UPDATABLE_ARRAY,
+  model: getModelOf(TABLES_NAMES.SYMBOLS)
+}

--- a/workers/loc.api/sync/schema/sync-schema/tickers-history.js
+++ b/workers/loc.api/sync/schema/sync-schema/tickers-history.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.TICKERS_HISTORY,
+  maxLimit: 10000,
+  dateFieldName: 'mtsUpdate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsUpdate', -1]],
+  hasNewData: false,
+  start: [],
+  confName: 'tickersHistoryConf',
+  isSyncRequiredAtLeastOnce: false,
+  additionalApiCallArgs: { isNotMoreThanInnerMax: true },
+  type: COLLS_TYPES.PUBLIC_INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.TICKERS_HISTORY)
+}

--- a/workers/loc.api/sync/schema/sync-schema/trades.js
+++ b/workers/loc.api/sync/schema/sync-schema/trades.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.TRADES,
+  maxLimit: 2500,
+  dateFieldName: 'mtsCreate',
+  symbolFieldName: 'symbol',
+  sort: [['mtsCreate', -1]],
+  hasNewData: false,
+  start: [],
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.TRADES)
+}

--- a/workers/loc.api/sync/schema/sync-schema/wallets.js
+++ b/workers/loc.api/sync/schema/sync-schema/wallets.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const TABLES_NAMES = require('../tables-names')
+const ALLOWED_COLLS = require('../allowed.colls')
+const COLLS_TYPES = require('../colls.types')
+
+const { getModelOf } = require('../models')
+
+module.exports = {
+  name: ALLOWED_COLLS.LEDGERS,
+  dateFieldName: 'mts',
+  symbolFieldName: 'currency',
+  sort: [['mts', -1]],
+  groupFns: ['max(mts)', 'max(id)'],
+  groupResBy: ['wallet', 'currency'],
+  isSyncRequiredAtLeastOnce: true,
+  type: COLLS_TYPES.HIDDEN_INSERTABLE_ARRAY_OBJECTS,
+  model: getModelOf(TABLES_NAMES.LEDGERS),
+  dataStructureConverter: (accum, {
+    wallet: type,
+    currency,
+    balance,
+    mts: mtsUpdate
+  } = {}) => {
+    accum.push({
+      type,
+      currency,
+      balance,
+      unsettledInterest: null,
+      balanceAvailable: null,
+      placeHolder: null,
+      mtsUpdate
+    })
+
+    return accum
+  }
+}


### PR DESCRIPTION
This PR refactors sync schema to be moved to separate files for easier supporting and readability
