### PR TITLE
Fix tax report if bfx-api pub-trades endpoint does not return array

### DIFF
--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -458,15 +458,19 @@ class TransactionTaxReport {
       interrupter
     })
 
+    const pubTrades = Array.isArray(res)
+      ? res
+      : []
+
     if (isTestEnv) {
       /*
        * Need to reverse pub-trades array for test env
        * as mocked test server return data in desc order
        */
-      return res.reverse()
+      return pubTrades.reverse()
     }
 
-    return res
+    return pubTrades
   }
 
   async #updateExactUsdValueInColls (trxs) {


### PR DESCRIPTION
This PR fixes the `tax report` if bfx-api `pub-trades` endpoint does not return array

![Screenshot 2024-07-20 at 13 55 44](https://github.com/user-attachments/assets/cf49ac6b-3cdc-465d-848f-e9949428c5c2)

