### PR TITLE
Send ipc messages when trx tax report is ready

### DIFF
--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -7,6 +7,9 @@ module.exports = {
   READY_MIGRATIONS: 'ready:migrations',
   ERROR_MIGRATIONS: 'error:migrations',
 
+  READY_TRX_TAX_REPORT: 'ready:trx-tax-report',
+  ERROR_TRX_TAX_REPORT: 'error:trx-tax-report',
+
   ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
   ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -458,15 +458,19 @@ class TransactionTaxReport {
       interrupter
     })
 
+    const pubTrades = Array.isArray(res)
+      ? res
+      : []
+
     if (isTestEnv) {
       /*
        * Need to reverse pub-trades array for test env
        * as mocked test server return data in desc order
        */
-      return res.reverse()
+      return pubTrades.reverse()
     }
 
-    return res
+    return pubTrades
   }
 
   async #updateExactUsdValueInColls (trxs) {


### PR DESCRIPTION
This PR adds ability to send `IPC` messages when the trx tax report is ready

---

This will be used in the electronjs environment to show a native OS notification to the app in case the tax report is being generated in the background

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-reports-framework/pull/396
