### PR TITLE
Add source field to csv/pdf of tax report

### DIFF
--- a/workers/loc.api/generate-report-file/report.file.job.data.js
+++ b/workers/loc.api/generate-report-file/report.file.job.data.js
@@ -554,7 +554,8 @@ class ReportFileJobData extends BaseReportFileJobData {
       args: reportFileArgs,
       propNameForPagination: null,
       columnsCsv: {
-        asset: 'DESCRIPTION OF PROPERTY',
+        asset: 'CURRENCY',
+        type: 'SOURCE',
         amount: 'AMOUNT',
         mtsAcquired: 'DATE ACQUIRED',
         mtsSold: 'DATE SOLD',
@@ -564,6 +565,7 @@ class ReportFileJobData extends BaseReportFileJobData {
       },
       formatSettings: {
         asset: 'symbol',
+        type: 'lowerCaseWithUpperFirst',
         mtsAcquired: 'date',
         mtsSold: 'date'
       }


### PR DESCRIPTION
This PR adds `source` field to `CSV`/`PDF` of the tax report to follow the UI view

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/381
