### PR TITLE
Send ipc messages when sync is ready

### DIFF
--- a/workers/loc.api/process.message.manager/process.messages.js
+++ b/workers/loc.api/process.message.manager/process.messages.js
@@ -10,6 +10,9 @@ module.exports = {
   READY_TRX_TAX_REPORT: 'ready:trx-tax-report',
   ERROR_TRX_TAX_REPORT: 'error:trx-tax-report',
 
+  READY_SYNC: 'ready:sync',
+  ERROR_SYNC: 'error:sync',
+
   ALL_TABLE_HAVE_BEEN_CLEARED: 'all-tables-have-been-cleared',
   ALL_TABLE_HAVE_NOT_BEEN_CLEARED: 'all-tables-have-not-been-cleared',
   ALL_TABLE_HAVE_BEEN_REMOVED: 'all-tables-have-been-removed',


### PR DESCRIPTION
This PR adds ability to send IPC messages when the sync is ready

---

This will be used in the electronjs environment to show a native OS notification to the app in case the sync is being processed in the background with the hidden main window
