### PR TITLE
Improve interruption for tax report

### DIFF
--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -187,9 +187,8 @@ class TransactionTaxReport {
       }
     )
 
-    interrupter.emitInterrupted()
-
     if (interrupter.hasInterrupted()) {
+      interrupter.emitInterrupted()
       await this.#emitProgress(
         user,
         { progress: null, state: PROGRESS_STATES.GENERATION_INTERRUPTED }
@@ -198,6 +197,7 @@ class TransactionTaxReport {
       return []
     }
 
+    interrupter.emitInterrupted()
     await this.#emitProgress(
       user,
       { progress: 100, state: PROGRESS_STATES.GENERATION_COMPLETED }
@@ -321,6 +321,10 @@ class TransactionTaxReport {
               !synonymous ||
               trxPriceCalculator.kindOfCcyForTriangulation
             ) {
+              if (interrupter.hasInterrupted()) {
+                return
+              }
+
               throw new PubTradeFindForTrxTaxError({
                 symbol,
                 pubTradeStart,
@@ -330,6 +334,10 @@ class TransactionTaxReport {
             }
 
             for (const [symbol, conversion] of synonymous) {
+              if (interrupter.hasInterrupted()) {
+                return
+              }
+
               const res = await this.#getPublicTrades(
                 {
                   symbol: getCcyPairForConversion(symbol, trxPriceCalculator),
@@ -369,6 +377,10 @@ class TransactionTaxReport {
           pubTradeStart > trx.mtsCreate ||
           pubTradeEnd < trx.mtsCreate
         ) {
+          if (interrupter.hasInterrupted()) {
+            return
+          }
+
           throw new PubTradeFindForTrxTaxError({
             symbol,
             pubTradeStart,
@@ -462,8 +474,23 @@ class TransactionTaxReport {
     const getDataFn = this.rService[this.SYNC_API_METHODS.PUBLIC_TRADES]
       .bind(this.rService)
 
+    let promiseResolve = () => {}
+    const onceInterruptPromise = new Promise((resolve) => {
+      promiseResolve = () => resolve({ res: [] })
+      interrupter.onceInterrupt(promiseResolve)
+    })
+    const getResponse = (res) => {
+      interrupter.offInterrupt(promiseResolve)
+
+      return res ?? []
+    }
+
     for (let i = 0; i < 6; i += 1) {
-      const { res } = await this.getDataFromApi({
+      if (interrupter.hasInterrupted()) {
+        return getResponse()
+      }
+
+      const pubTradesPromise = this.getDataFromApi({
         getData: (s, args) => getDataFn(args),
         args,
         callerName: 'TRANSACTION_TAX_REPORT',
@@ -472,21 +499,26 @@ class TransactionTaxReport {
         interrupter
       })
 
+      const { res } = await Promise.race([
+        pubTradesPromise,
+        onceInterruptPromise
+      ])
+
       if (isTestEnv) {
         /*
          * Need to reverse pub-trades array for test env
          * as mocked test server return data in desc order
          */
-        return res.reverse()
+        return getResponse(res.reverse())
       }
       if (Array.isArray(res)) {
-        return res
+        return getResponse(res)
       }
 
       await setTimeout(10000)
     }
 
-    return []
+    return getResponse()
   }
 
   async #updateExactUsdValueInColls (trxs) {


### PR DESCRIPTION
This PR improves the interruption flow of getting data from the bfx api for the tax report

---

Base changes:
- provides event-driven flow after a delay processing
- speeds up interruption not to wait for timeout in case of a slow internet connection

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/399
