### PR TITLE
Rework db model usage to use new model interface

### DIFF
--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -221,14 +221,7 @@ class BetterSqliteDAO extends DAO {
   }
 
   _createTablesIfNotExists (opts = {}) {
-    const models = this._getModelsMap({
-      models: opts?.models,
-      omittedFields: [
-        TRIGGER_FIELD_NAME,
-        INDEX_FIELD_NAME,
-        UNIQUE_INDEX_FIELD_NAME
-      ]
-    })
+    const models = opts?.models ?? this._getModelsMap()
     const sql = getTableCreationQuery(models, opts)
 
     return this.query({

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -238,10 +238,7 @@ class BetterSqliteDAO extends DAO {
   }
 
   _createIndexisIfNotExists (opts = {}) {
-    const models = this._getModelsMap({
-      models: opts?.models,
-      omittedFields: []
-    })
+    const models = opts?.models ?? this._getModelsMap()
     const sql = getIndexCreationQuery(models, opts)
 
     return this.query({

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -227,10 +227,7 @@ class BetterSqliteDAO extends DAO {
   }
 
   _createTriggerIfNotExists (opts = {}) {
-    const models = this._getModelsMap({
-      models: opts?.models,
-      omittedFields: []
-    })
+    const models = opts?.models ?? this._getModelsMap()
     const sql = getTriggerCreationQuery(models, opts)
 
     return this.query({

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -29,6 +29,10 @@ class DAO {
     return this.syncSchema.getModelsMap()
   }
 
+  _getModelOf (tableName) {
+    return this.syncSchema.getModelOf(tableName)
+  }
+
   _getMethodCollMap (params) {
     return this.syncSchema.getMethodCollMap(params)
   }

--- a/workers/loc.api/sync/dao/dao.js
+++ b/workers/loc.api/sync/dao/dao.js
@@ -25,8 +25,8 @@ class DAO {
     this.processMessageManagerFactory = processMessageManagerFactory
   }
 
-  _getModelsMap (params) {
-    return this.syncSchema.getModelsMap(params)
+  _getModelsMap () {
+    return this.syncSchema.getModelsMap()
   }
 
   _getMethodCollMap (params) {

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-query.js
@@ -25,7 +25,10 @@ module.exports = (args, methodColl, opts) => {
     filter
   } = getFilterParams(args, methodColl, { isPublic })
 
-  const _model = { ...model, ...additionalModel }
+  const modelFields = {
+    ...model.getModelFields(),
+    ...additionalModel
+  }
   const exclude = isPublic ? ['_id', 'user_id'] : ['_id']
 
   const {
@@ -46,7 +49,7 @@ module.exports = (args, methodColl, opts) => {
   } = getGroupQuery(methodColl)
   const { subQuery, subQueryValues } = getSubQuery(methodColl)
   const projection = getProjectionQuery(
-    _model,
+    modelFields,
     exclude,
     isExcludePrivate
   )

--- a/workers/loc.api/sync/dao/helpers/get-index-creation-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-index-creation-query.js
@@ -1,10 +1,5 @@
 'use strict'
 
-const {
-  INDEX_FIELD_NAME,
-  UNIQUE_INDEX_FIELD_NAME
-} = require('../../schema/models/model/db.service.field.names')
-
 const _getIndexQuery = (
   name,
   fields = [],
@@ -67,18 +62,20 @@ const _getIndexQueryFromModel = (
     shouldNotAddIfNotExistsStm
   } = opts ?? {}
 
+  const modelUniqueIndexies = model.getUniqueIndexies()
+  const modelIndexies = model.getIndexies()
   const uniqueIndexFields = (
-    model[UNIQUE_INDEX_FIELD_NAME] &&
-    typeof model[UNIQUE_INDEX_FIELD_NAME] === 'string'
+    modelUniqueIndexies &&
+    typeof modelUniqueIndexies === 'string'
   )
-    ? model[UNIQUE_INDEX_FIELD_NAME].split(' ')
-    : model[UNIQUE_INDEX_FIELD_NAME]
+    ? modelUniqueIndexies.split(' ')
+    : modelUniqueIndexies
   const indexFields = (
-    model[INDEX_FIELD_NAME] &&
-    typeof model[INDEX_FIELD_NAME] === 'string'
+    modelIndexies &&
+    typeof modelIndexies === 'string'
   )
-    ? model[INDEX_FIELD_NAME].split(' ')
-    : model[INDEX_FIELD_NAME]
+    ? modelIndexies.split(' ')
+    : modelIndexies
 
   const uniqueIndexiesArr = _getIndexQuery(
     name,

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -16,10 +16,7 @@ const getFieldsFilters = (
     const _params = { ...params }
     const field = _params[fieldName]
 
-    if (
-      Object.keys(model)
-        .some(key => key === modelFieldName)
-    ) {
+    if (model.hasModelFieldName(modelFieldName)) {
       if (typeof field === 'boolean') {
         return {
           ...accum,

--- a/workers/loc.api/sync/dao/helpers/get-projection-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-projection-query.js
@@ -1,8 +1,13 @@
 'use strict'
 
+const Model = require('../../schema/models/model')
+
 const _getProjArr = (model) => {
   if (Array.isArray(model)) {
     return model
+  }
+  if (model instanceof Model) {
+    return model.getModelFieldKeys()
   }
   if (
     model &&

--- a/workers/loc.api/sync/dao/helpers/get-table-creation-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-table-creation-query.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const {
-  CONSTR_FIELD_NAME
-} = require('../../schema/models/model/db.service.field.names')
-
 const _getConstraintsQuery = (name, model) => {
-  const constraintsArr = Array.isArray(model[CONSTR_FIELD_NAME])
-    ? model[CONSTR_FIELD_NAME]
-    : [model[CONSTR_FIELD_NAME]]
+  const modelConstraints = model.getConstraints()
+  const constraintsArr = Array.isArray(modelConstraints)
+    ? modelConstraints
+    : [modelConstraints]
 
   return constraintsArr.reduce((accum, item) => {
     const _constraints = (
@@ -43,8 +40,7 @@ module.exports = (models = [], opts = {}) => {
     const _name = `${prefix}${name}`
     const constraints = _getConstraintsQuery(_name, model)
 
-    const keys = Object.keys(model)
-      .filter((field) => field !== CONSTR_FIELD_NAME)
+    const keys = model.getModelFieldKeys()
     const columnDefs = keys.reduce((accum, field, i, arr) => {
       const isLast = arr.length === (i + 1)
       const type = model[field]

--- a/workers/loc.api/sync/dao/helpers/get-trigger-creation-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-trigger-creation-query.js
@@ -1,9 +1,5 @@
 'use strict'
 
-const {
-  TRIGGER_FIELD_NAME
-} = require('../../schema/models/model/db.service.field.names')
-
 const _getTriggersQuery = (
   name,
   model,
@@ -13,9 +9,10 @@ const _getTriggersQuery = (
     shouldNotAddIfNotExistsStm
   } = opts ?? {}
 
-  const triggersArr = Array.isArray(model[TRIGGER_FIELD_NAME])
-    ? model[TRIGGER_FIELD_NAME]
-    : [model[TRIGGER_FIELD_NAME]]
+  const modelTriggers = model.getTriggers()
+  const triggersArr = Array.isArray(modelTriggers)
+    ? modelTriggers
+    : [modelTriggers]
 
   return triggersArr.reduce((accum, item) => {
     if (

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -16,7 +16,7 @@ const normalizeApiData = (
     return data
   }
 
-  const modelKeys = Object.keys(model)
+  const modelKeys = model.getModelFieldKeys()
 
   if (modelKeys.length === 0) {
     return data

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -539,11 +539,7 @@ class DataInserter extends EventEmitter {
     _args.params.notThrowError = true
     const currIterationArgs = cloneDeep(_args)
 
-    const { subUserId } = model ?? {}
-    const hasNotSubUserField = (
-      !subUserId ||
-      typeof subUserId !== 'string'
-    )
+    const hasNotSubUserField = !model.hasModelFieldName('subUserId')
     const { auth: _auth } = _args ?? {}
     const { session } = _auth ?? {}
     const sessionAuth = isPublic || hasNotSubUserField

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -213,24 +213,22 @@ class SyncUserStepManager {
     const hasUserIdField = (
       Number.isInteger(userId)
     )
-    const hasUserIdFieldInModel = (
-      typeof model?.user_id === 'string'
-    )
+    const hasUserIdFieldInModel = model
+      .hasModelFieldName('user_id')
     const hasSubUserIdField = (
       Number.isInteger(subUserId)
     )
-    const hasSubUserIdFieldInModel = (
-      typeof model?.subUserId === 'string'
-    )
+    const hasSubUserIdFieldInModel = model
+      .hasModelFieldName('subUserId')
     const hasSymbolField = (
       symbolFieldName &&
-      typeof model?.[symbolFieldName] === 'string' &&
+      model.hasModelFieldName(symbolFieldName) &&
       symbol &&
       typeof symbol === 'string'
     )
     const hasTimeframeField = (
       timeframeFieldName &&
-      typeof model?.[timeframeFieldName] === 'string' &&
+      model.hasModelFieldName(timeframeFieldName) &&
       timeframe &&
       typeof timeframe === 'string'
     )

--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -25,10 +25,12 @@ class Movements {
     this.ALLOWED_COLLS = ALLOWED_COLLS
     this.authenticator = authenticator
 
-    this.movementsModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.MOVEMENTS)
-    this.ledgersModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.LEDGERS)
+    this.movementsModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.MOVEMENTS)
+      .getModelFields()
+    this.ledgersModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.LEDGERS)
+      .getModelFields()
   }
 
   async getMovements (params = {}) {
@@ -177,7 +179,7 @@ class Movements {
       end = Date.now(),
       filter: _filter,
       sort = [['mts', -1], ['id', -1]],
-      projection = this.ledgersModel,
+      projection = this.ledgersModelFields,
       exclude = ['user_id'],
       isExcludePrivate = true,
       isWithdrawals = false,
@@ -227,7 +229,7 @@ class Movements {
       end = Date.now(),
       filter: _filter,
       sort = [['mts', -1], ['id', -1]],
-      projection = this.ledgersModel,
+      projection = this.ledgersModelFields,
       exclude = ['user_id'],
       isExcludePrivate = true,
       isWithdrawals = false,

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -35,8 +35,9 @@ class PerformingLoan {
 
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
-    this.ledgersModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.LEDGERS)
+    this.ledgersModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.LEDGERS)
+      .getModelFields()
   }
 
   async _getLedgers ({
@@ -47,7 +48,7 @@ class PerformingLoan {
     filter = {
       $eq: { _isMarginFundingPayment: 1 }
     },
-    projection = this.ledgersModel
+    projection = this.ledgersModelFields
   }) {
     const user = await this.authenticator
       .verifyRequestUser({ auth })

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -45,10 +45,12 @@ class PositionsSnapshot {
     this.currencyConverter = currencyConverter
     this.authenticator = authenticator
 
-    this.positionsHistoryModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.POSITIONS_HISTORY)
-    this.positionsSnapshotModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.POSITIONS_SNAPSHOT)
+    this.positionsHistoryModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.POSITIONS_HISTORY)
+      .getModelFields()
+    this.positionsSnapshotModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.POSITIONS_SNAPSHOT)
+      .getModelFields()
     this.positionsSnapshotMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.POSITIONS_SNAPSHOT)
     this.positionsSnapshotSymbolFieldName = this.positionsSnapshotMethodColl.symbolFieldName
@@ -67,7 +69,7 @@ class PositionsSnapshot {
           $gte: { mtsUpdate: endMts }
         },
         sort: [['mtsUpdate', -1]],
-        projection: this.positionsHistoryModel,
+        projection: this.positionsHistoryModelFields,
         exclude: ['user_id'],
         isExcludePrivate: true
       }
@@ -105,7 +107,7 @@ class PositionsSnapshot {
           ...lteFilter
         },
         sort: _sort,
-        projection: this.positionsSnapshotModel,
+        projection: this.positionsSnapshotModelFields,
         exclude: ['user_id'],
         isExcludePrivate: true
       }
@@ -662,7 +664,7 @@ class PositionsSnapshot {
           $lte: { mtsUpdate: end }
         },
         sort: [['mtsUpdate', -1], ['id', -1]],
-        projection: this.positionsHistoryModel,
+        projection: this.positionsHistoryModelFields,
         exclude: ['user_id'],
         isExcludePrivate: true
       }

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -1,18 +1,24 @@
 'use strict'
 
 const { omit, cloneDeep } = require('lib-js-util-base')
+const Model = require('../models/model')
 
 const cloneSchema = (map, omittedFields = []) => {
   const arr = [...map].map(([key, schema]) => {
     const normalizedSchema = omit(schema, omittedFields)
-    const clonedSchema = cloneDeep(normalizedSchema)
+    const clonedSchema = {}
 
-    for (const [propName, value] of Object.entries(schema)) {
-      if (typeof value !== 'function') {
+    for (const [propName, value] of Object.entries(normalizedSchema)) {
+      if (
+        typeof value === 'function' ||
+        value instanceof Model
+      ) {
+        clonedSchema[propName] = value
+
         continue
       }
 
-      clonedSchema[propName] = value
+      clonedSchema[propName] = cloneDeep(value)
     }
 
     return [key, clonedSchema]

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -42,12 +42,7 @@ const getModelsMap = (params = {}) => {
   return cloneSchema(models, omittedFields)
 }
 
-const getModelOf = (tableName, models) => {
-  return { ...getModelsMap({ models }).get(tableName) }
-}
-
 module.exports = {
   cloneSchema,
-  getModelsMap,
-  getModelOf
+  getModelsMap
 }

--- a/workers/loc.api/sync/schema/helpers/index.js
+++ b/workers/loc.api/sync/schema/helpers/index.js
@@ -2,13 +2,6 @@
 
 const { omit, cloneDeep } = require('lib-js-util-base')
 
-const {
-  CONSTR_FIELD_NAME,
-  TRIGGER_FIELD_NAME,
-  INDEX_FIELD_NAME,
-  UNIQUE_INDEX_FIELD_NAME
-} = require('../models/model/db.service.field.names')
-
 const cloneSchema = (map, omittedFields = []) => {
   const arr = [...map].map(([key, schema]) => {
     const normalizedSchema = omit(schema, omittedFields)
@@ -28,21 +21,6 @@ const cloneSchema = (map, omittedFields = []) => {
   return new Map(arr)
 }
 
-const getModelsMap = (params = {}) => {
-  const {
-    models,
-    omittedFields = [
-      CONSTR_FIELD_NAME,
-      TRIGGER_FIELD_NAME,
-      INDEX_FIELD_NAME,
-      UNIQUE_INDEX_FIELD_NAME
-    ]
-  } = { ...params }
-
-  return cloneSchema(models, omittedFields)
-}
-
 module.exports = {
-  cloneSchema,
-  getModelsMap
+  cloneSchema
 }

--- a/workers/loc.api/sync/schema/index.js
+++ b/workers/loc.api/sync/schema/index.js
@@ -2,7 +2,8 @@
 
 const {
   SUPPORTED_DB_VERSION,
-  getModelsMap
+  getModelsMap,
+  getModelOf
 } = require('./models')
 const {
   getMethodCollMap
@@ -11,5 +12,6 @@ const {
 module.exports = {
   SUPPORTED_DB_VERSION,
   getMethodCollMap,
-  getModelsMap
+  getModelsMap,
+  getModelOf
 }

--- a/workers/loc.api/sync/schema/models/index.js
+++ b/workers/loc.api/sync/schema/models/index.js
@@ -79,15 +79,8 @@ const models = new Map([
   [TABLES_NAMES.SYNC_USER_STEPS, syncUserSteps]
 ])
 
-const {
-  getModelsMap: _getModelsMap
-} = require('../helpers')
-
-const getModelsMap = (params = {}) => {
-  return _getModelsMap({
-    ...params,
-    models: params?.models ?? models
-  })
+const getModelsMap = () => {
+  return new Map(...models)
 }
 
 const getModelOf = (tableName) => {

--- a/workers/loc.api/sync/schema/models/index.js
+++ b/workers/loc.api/sync/schema/models/index.js
@@ -80,7 +80,7 @@ const models = new Map([
 ])
 
 const getModelsMap = () => {
-  return new Map(...models)
+  return new Map(models)
 }
 
 const getModelOf = (tableName) => {

--- a/workers/loc.api/sync/schema/models/index.js
+++ b/workers/loc.api/sync/schema/models/index.js
@@ -44,7 +44,7 @@ const progress = require('./progress')
 const syncQueue = require('./sync-queue')
 const syncUserSteps = require('./sync-user-steps')
 
-const _models = new Map([
+const models = new Map([
   [TABLES_NAMES.USERS, users],
   [TABLES_NAMES.SUB_ACCOUNTS, subAccounts],
   [TABLES_NAMES.LEDGERS, ledgers],
@@ -80,19 +80,18 @@ const _models = new Map([
 ])
 
 const {
-  getModelsMap: _getModelsMap,
-  getModelOf: _getModelOf
+  getModelsMap: _getModelsMap
 } = require('../helpers')
 
 const getModelsMap = (params = {}) => {
   return _getModelsMap({
     ...params,
-    models: params?.models ?? _models
+    models: params?.models ?? models
   })
 }
 
 const getModelOf = (tableName) => {
-  return _getModelOf(tableName, _models)
+  return models.get(tableName)
 }
 
 module.exports = {

--- a/workers/loc.api/sync/schema/models/model/index.js
+++ b/workers/loc.api/sync/schema/models/model/index.js
@@ -109,6 +109,10 @@ class Model extends BaseModel {
       : this.#modelFieldKeys
   }
 
+  hasModelFieldName (fieldName) {
+    return !!this.#modelFields[fieldName]
+  }
+
   getTriggers (opts) {
     return this.#getServiceFields(
       BaseModel.TRIGGER_FIELD_NAME,

--- a/workers/loc.api/sync/schema/models/model/index.js
+++ b/workers/loc.api/sync/schema/models/model/index.js
@@ -13,6 +13,7 @@ const BaseModel = require('./base.model')
 
 class Model extends BaseModel {
   #modelFields = {}
+  #modelFieldKeys = []
   #opts = {
     hasNoUID: false,
     hasCreateUpdateMtsTriggers: false
@@ -100,6 +101,12 @@ class Model extends BaseModel {
     return opts?.isCloned
       ? cloneDeep(this.#modelFields)
       : this.#modelFields
+  }
+
+  getModelFieldKeys (opts) {
+    return opts?.isCloned
+      ? cloneDeep(this.#modelFieldKeys)
+      : this.#modelFieldKeys
   }
 
   getTriggers (opts) {
@@ -198,6 +205,7 @@ class Model extends BaseModel {
     for (const [name, value] of Object.entries(this)) {
       if (this.#isNotDbServiceField(name)) {
         this.#modelFields[name] = value
+        this.#modelFieldKeys.push(name)
       }
     }
 
@@ -206,6 +214,7 @@ class Model extends BaseModel {
     }
 
     freezeAndSealObjectDeeply(this.#modelFields)
+    freezeAndSealObjectDeeply(this.#modelFieldKeys)
   }
 
   #isNotDbServiceField (fieldName) {

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -34,8 +34,9 @@ class SummaryByAsset {
 
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
-    this.ledgersModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.LEDGERS)
+    this.ledgersModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.LEDGERS)
+      .getModelFields()
     this.ledgersSymbolFieldName = this.ledgersMethodColl.symbolFieldName
   }
 
@@ -269,7 +270,7 @@ class SummaryByAsset {
           user_id: auth._id
         },
         sort: [['mts', 1], ['id', 1]],
-        projection: this.ledgersModel
+        projection: this.ledgersModelFields
       }
     )
   }

--- a/workers/loc.api/sync/total.fees.report/index.js
+++ b/workers/loc.api/sync/total.fees.report/index.js
@@ -38,8 +38,9 @@ class TotalFeesReport {
 
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
-    this.ledgersModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.LEDGERS)
+    this.ledgersModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.LEDGERS)
+      .getModelFields()
   }
 
   async getTotalFeesReport (args = {}) {
@@ -100,7 +101,7 @@ class TotalFeesReport {
     end,
     symbol,
     filter,
-    projection = this.ledgersModel
+    projection = this.ledgersModelFields
   }) {
     const user = await this.authenticator
       .verifyRequestUser({ auth })

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -41,8 +41,9 @@ class Trades {
 
     this.tradesMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.TRADES)
-    this.tradesModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.TRADES)
+    this.tradesModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.TRADES)
+      .getModelFields()
   }
 
   async _getTrades ({
@@ -71,7 +72,7 @@ class Trades {
           ...symbFilter
         },
         sort: [['mtsCreate', -1]],
-        projection: this.tradesModel,
+        projection: this.tradesModelFields,
         exclude: ['user_id'],
         isExcludePrivate: true
       }

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -70,8 +70,9 @@ class TransactionTaxReport {
     this.currencyConverter = currencyConverter
     this.processMessageManager = processMessageManager
 
-    this.tradesModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.TRADES)
+    this.tradesModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.TRADES)
+      .getModelFields()
   }
 
   async makeTrxTaxReportInBackground (args = {}) {
@@ -442,7 +443,7 @@ class TransactionTaxReport {
           ...symbFilter
         },
         sort: [['mtsCreate', -1]],
-        projection: this.tradesModel,
+        projection: this.tradesModelFields,
         exclude: ['user_id'],
         isExcludePrivate: false
       }

--- a/workers/loc.api/sync/weighted.averages.report/index.js
+++ b/workers/loc.api/sync/weighted.averages.report/index.js
@@ -33,8 +33,9 @@ class WeightedAveragesReport extends BaseWeightedAveragesReport {
     this.syncSchema = syncSchema
     this.ALLOWED_COLLS = ALLOWED_COLLS
 
-    this.tradesModel = this.syncSchema.getModelsMap()
-      .get(this.ALLOWED_COLLS.TRADES)
+    this.tradesModelFields = this.syncSchema
+      .getModelOf(this.ALLOWED_COLLS.TRADES)
+      .getModelFields()
 
     // Used to switch data fetching from DB for framework mode
     this._isNotCalcTakenFromBfxApi = true
@@ -63,7 +64,7 @@ class WeightedAveragesReport extends BaseWeightedAveragesReport {
           ...symbFilter
         },
         sort: [['mtsCreate', -1]],
-        projection: this.tradesModel,
+        projection: this.tradesModelFields,
         exclude: ['user_id'],
         isExcludePrivate: true
       }


### PR DESCRIPTION
This PR reworks DB model usage to use the new model interface implemented in the previous PR https://github.com/bitfinexcom/bfx-reports-framework/pull/406
It speeds up the work by avoiding the usage of `cloneDeep` fn based on `JSON.parse(JSON.stringify(obj))` for the models

---

The PR is part of the refactoring and doesn't have the changes of the main logic and functionality