### PR TITLE
Fix infrequent case for process.send

### DIFF
--- a/workers/loc.api/process.message.manager/utils.js
+++ b/workers/loc.api/process.message.manager/utils.js
@@ -45,7 +45,10 @@ const sendState = (state, data) => {
   ) {
     throw new ProcessStateSendingError()
   }
-  if (typeof process.send !== 'function') {
+  if (
+    typeof process.send !== 'function' ||
+    !process.connected
+  ) {
     return false
   }
 


### PR DESCRIPTION
This PR fixes an infrequent case for `process.send()` when the app is on its way to being closed and the child process channel is closed but the worker still sends a message to the main one

---

![Screenshot from 2024-08-22 14-11-45](https://github.com/user-attachments/assets/69900274-10f6-4fee-98cd-bd5121a0347e)
