### PR TITLE
Migrate from html-pdf to puppeteer for pdf creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-node@v4
       with:
-        node-version: 18.17.1
+        node-version: 20.18.1
     - name: Setup configs
       run: |
         cp config/common.json.example config/common.json \

--- a/Dockerfile.express
+++ b/Dockerfile.express
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine3.18
+FROM node:20.18.1-alpine3.20
 
 ENV BIND_HOST="0.0.0.0"
 

--- a/Dockerfile.grenache-grape
+++ b/Dockerfile.grenache-grape
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine3.18
+FROM node:20.18.1-alpine3.20
 
 ENV BIND_HOST="0.0.0.0"
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -1,4 +1,5 @@
 FROM node:20.18.1-alpine3.20
+
 WORKDIR /home/node/bfx-report-ui
 
 RUN apk add --no-cache --virtual \

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -1,5 +1,4 @@
-FROM node:18.17.1-alpine3.18
-
+FROM node:20.18.1-alpine3.20
 WORKDIR /home/node/bfx-report-ui
 
 RUN apk add --no-cache --virtual \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,16 +1,37 @@
-FROM node:18.17.1-bookworm
+FROM node:20.18.1-alpine3.20
 
 ARG GRC_VER="0.7.1"
 
 WORKDIR /home/node/grenache-cli
 
-RUN apt-get update -y \
-  && apt-get install -y --no-install-recommends \
-    jq \
-    xxd \
-    git \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add --no-cache --virtual \
+  .gyp \
+  python3 \
+  make \
+  jq \
+  help2man \
+  gcc \
+  musl-dev \
+  autoconf \
+  automake \
+  libtool \
+  pkgconfig \
+  file \
+  patch \
+  bison \
+  clang \
+  flex \
+  curl \
+  perl \
+  perl-dev \
+  wget \
+  g++ \
+  git \
+  openssh \
+  bash \
+  chromium
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 RUN wget -c https://github.com/bitfinexcom/grenache-cli/releases/download/${GRC_VER}/grenache-cli-${GRC_VER}.tar.xz \
   && tar -xf grenache-cli-${GRC_VER}.tar.xz \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -29,7 +29,12 @@ RUN apk update && apk add --no-cache --virtual \
   git \
   openssh \
   bash \
-  chromium
+  chromium \
+  nss \
+  freetype \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "lodash": "4.17.21",
     "moment": "2.29.4",
+    "puppeteer": "24.1.0",
     "uuid": "9.0.0",
     "yargs": "17.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "bignumber.js": "9.1.2",
     "csv": "5.5.3",
     "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
-    "html-pdf": "3.0.1",
     "inversify": "6.0.1",
     "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "lodash": "4.17.21",

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -73,7 +73,9 @@ class PdfWriter extends MainPdfWriter {
       })
     }
 
-    const browser = await puppeteer.launch()
+    const browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-gpu']
+    })
     const page = await browser.newPage()
     await page.setContent(template, {
       waitUntil: 'domcontentloaded'


### PR DESCRIPTION
This PR migrates from `html-pdf` to `puppeteer` for pdf creation as the first one repo is not maintained anymore

---

Base changes:
- Migrate pdf gen from `html-pdf` to `puppeteer`
- Rework worker docker file to use alpine image for `puppeteer`: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-on-alpine
- Update nodejs up to `20.18.1` under Docker container to have the same version as Electronjs
- Update nodejs up to `20.18.1` under GH Actions

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/419
