### PR TITLE
Make comprehensive sync performance improvement

### DIFF
--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -135,7 +135,7 @@ class FrameworkReportService extends ReportService {
         isStagingBfxApi
       } = await this._authenticator.signIn(
         args,
-        { isReturnedUser: true }
+        { isReturnedUser: true, doNotQueueQuery: true }
       )
 
       if (

--- a/workers/loc.api/sync/authenticator/index.js
+++ b/workers/loc.api/sync/authenticator/index.js
@@ -1422,7 +1422,8 @@ class Authenticator {
         const res = await this.dao.updateCollBy(
           this.TABLES_NAMES.USERS,
           { _id: session?._id, email: session?.email },
-          { authToken: encryptedAuthToken }
+          { authToken: encryptedAuthToken },
+          { doNotQueueQuery: true }
         )
 
         if (res?.changes < 1) {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -276,21 +276,21 @@ class BetterSqliteDAO extends DAO {
     this._initializeWalCheckpointRestart()
   }
 
-  _setCacheSize (size = -256_000) {
+  _setCacheSize (size = -512_000) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: `cache_size = ${size}`
     })
   }
 
-  _setPageSize (size = 4096 * 5) {
+  _setPageSize (size = 4096 * 10) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: `page_size = ${size}`
     })
   }
 
-  _setMmapSize (size = 268_435_456) {
+  _setMmapSize (size = 512_000_000) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: `mmap_size = ${size}`

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -1041,7 +1041,7 @@ class BetterSqliteDAO extends DAO {
       action: MAIN_DB_WORKER_ACTIONS.ALL,
       sql,
       params: { ...values, ...subQueryValues, ...limitVal }
-    }, { withWorkerThreads: true })
+    }, { withWorkerThreads: false })
   }
 
   /**
@@ -1066,7 +1066,7 @@ class BetterSqliteDAO extends DAO {
       action: MAIN_DB_WORKER_ACTIONS.GET,
       sql,
       params
-    }, { withWorkerThreads: true })
+    }, { withWorkerThreads: false })
   }
 
   /**

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -356,7 +356,7 @@ class BetterSqliteDAO extends DAO {
       sql: opts?.shouldSizeOfAllTablesBeChecked
         ? 'optimize = 0x10002'
         : 'optimize'
-    })
+    }, { withWorkerThreads: true })
   }
 
   enableForeignKeys () {

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -283,6 +283,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _setMmapSize (size = 268_435_456) {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
+      sql: `mmap_size = ${size}`
+    })
+  }
+
   _setAnalysisLimit (limit = 400) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -539,6 +546,7 @@ class BetterSqliteDAO extends DAO {
     await this.enableForeignKeys()
     await this._enableWALJournalMode()
     await this._setCacheSize()
+    await this._setMmapSize()
     await this._setAnalysisLimit()
     await this.optimize({ shouldSizeOfAllTablesBeChecked: true })
   }

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -276,7 +276,7 @@ class BetterSqliteDAO extends DAO {
     this._initializeWalCheckpointRestart()
   }
 
-  _setCacheSize (size = 10000) {
+  _setCacheSize (size = -256_000) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
       sql: `cache_size = ${size}`

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -283,6 +283,13 @@ class BetterSqliteDAO extends DAO {
     })
   }
 
+  _setPageSize (size = 4096 * 5) {
+    return this.query({
+      action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
+      sql: `page_size = ${size}`
+    })
+  }
+
   _setMmapSize (size = 268_435_456) {
     return this.query({
       action: MAIN_DB_WORKER_ACTIONS.EXEC_PRAGMA,
@@ -546,6 +553,7 @@ class BetterSqliteDAO extends DAO {
     await this.enableForeignKeys()
     await this._enableWALJournalMode()
     await this._setCacheSize()
+    await this._setPageSize()
     await this._setMmapSize()
     await this._setAnalysisLimit()
     await this.optimize({ shouldSizeOfAllTablesBeChecked: true })

--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -1019,7 +1019,8 @@ class BetterSqliteDAO extends DAO {
       projection = [],
       exclude = [],
       isExcludePrivate = false,
-      limit = null
+      limit = null,
+      withWorkerThreads = true
     } = {}
   ) {
     const {
@@ -1062,7 +1063,7 @@ class BetterSqliteDAO extends DAO {
       action: MAIN_DB_WORKER_ACTIONS.ALL,
       sql,
       params: { ...values, ...subQueryValues, ...limitVal }
-    }, { withWorkerThreads: false })
+    }, { withWorkerThreads })
   }
 
   /**
@@ -1071,8 +1072,12 @@ class BetterSqliteDAO extends DAO {
   getElemInCollBy (
     name,
     filter = {},
-    sort = []
+    sort = [],
+    opts
   ) {
+    const {
+      withWorkerThreads = true
+    } = opts ?? {}
     const _sort = getOrderQuery(sort)
     const {
       where,
@@ -1087,7 +1092,7 @@ class BetterSqliteDAO extends DAO {
       action: MAIN_DB_WORKER_ACTIONS.GET,
       sql,
       params
-    }, { withWorkerThreads: false })
+    }, { withWorkerThreads })
   }
 
   /**

--- a/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/convert.currency.hook.js
@@ -128,7 +128,8 @@ class ConvertCurrencyHook extends DataInserterHook {
               $isNull: updatedFieldNames
             },
             sort: [['_id', 1]],
-            limit: 10000
+            limit: 10000,
+            withWorkerThreads: false
           }
         )
 
@@ -139,7 +140,8 @@ class ConvertCurrencyHook extends DataInserterHook {
         const convElems = await this.currencyConverter
           .convertByCandles(
             elems,
-            _schema
+            _schema,
+            { withWorkerThreads: false }
           )
 
         if (collName === this.ALLOWED_COLLS.LEDGERS) {
@@ -152,6 +154,7 @@ class ConvertCurrencyHook extends DataInserterHook {
             ['_id'],
             [...updatedFieldNames, '_isBalanceRecalced']
           )
+          await this.dao.optimize()
 
           _id = elems[elems.length - 1]._id
 
@@ -164,6 +167,7 @@ class ConvertCurrencyHook extends DataInserterHook {
           ['_id'],
           updatedFieldNames
         )
+        await this.dao.optimize()
 
         _id = elems[elems.length - 1]._id
       }

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -254,13 +254,15 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
         const itemFromMainTable = await this.dao.getElemInCollBy(
           this.TABLES_NAMES.LEDGERS,
           filter,
-          order
+          order,
+          { withWorkerThreads: false }
         )
         const itemFromTempTable = Number.isInteger(this._opts.syncQueueId)
           ? await this.dao.getElemInCollBy(
             tempTableName,
             filter,
-            order
+            order,
+            { withWorkerThreads: false }
           )
           : null
         const itemsFromDb = [itemFromMainTable, itemFromTempTable]
@@ -330,7 +332,8 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
         $isNull: '_isBalanceRecalced',
         $in: { user_id: requiredUserIds }
       },
-      [['mts', 1], ['id', 1]]
+      [['mts', 1], ['id', 1]],
+      { withWorkerThreads: false }
     )
 
     let { mts } = firstNotRecalcedElem ?? {}
@@ -358,7 +361,8 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
             $isNotNull: 'subUserId'
           },
           sort: [['mts', 1], ['id', 1]],
-          limit: 20000
+          limit: 20000,
+          withWorkerThreads: false
         }
       )
 
@@ -407,6 +411,7 @@ class RecalcSubAccountLedgersBalancesHook extends DataInserterHook {
         ['_id'],
         ['balance', 'balanceUsd', '_isBalanceRecalced']
       )
+      await this.dao.optimize()
 
       const lastElem = elems[elems.length - 1]
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -339,6 +339,8 @@ class DataInserter extends EventEmitter {
       if (progress < 100) {
         await this._setProgress(progress)
       }
+
+      await this._optimizeDb()
     }
 
     return { methodCollMap }
@@ -411,6 +413,8 @@ class DataInserter extends EventEmitter {
       if (progress < 100) {
         await this._setProgress(progress)
       }
+
+      await this._optimizeDb()
     }
 
     return { progress, methodCollMap }

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -243,8 +243,6 @@ class DataInserter extends EventEmitter {
       pubMethodCollMap
     })
 
-    await this._optimizeDb()
-
     if (this._isInterrupted) {
       return
     }

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -409,6 +409,9 @@ class SyncUserStepManager {
           baseEnd: currMts
         })
       }
+      if (syncUserStepData.baseStart === syncUserStepData.baseEnd) {
+        syncUserStepData.isBaseStepReady = true
+      }
     }
 
     return {

--- a/workers/loc.api/sync/progress/index.js
+++ b/workers/loc.api/sync/progress/index.js
@@ -38,7 +38,7 @@ class Progress extends EventEmitter {
 
     this._syncStartedAt = null
     this._progressEmitterInterval = null
-    this._progressEmitterIntervalMs = 1000
+    this._progressEmitterIntervalMs = 10_000
     this._error = null
     this._progress = null
     this._state = null

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -171,7 +171,7 @@ class WSTransport {
           async () => {
             const user = await this.authenticator.signIn(
               { auth: payload.auth },
-              { isReturnedUser: true }
+              { isReturnedUser: true, doNotQueueQuery: true }
             )
             const {
               email,

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -222,12 +222,21 @@ class WSTransport {
     })
   }
 
-  _getFreshUsersDataFromDb () {
-    const usersIds = [...this._auth].map(([sid, user]) => user._id)
+  _getFreshUsersDataFromSessions () {
+    return [...this.authenticator.getUserSessions()]
+      .reduce((accum, curr) => {
+        const session = curr[1]
 
-    return this.authenticator.getUsers(
-      { $in: { _id: usersIds } }
-    )
+        for (const [, user] of this._auth.entries()) {
+          if (user._id !== session._id) {
+            continue
+          }
+
+          accum.push(session)
+        }
+
+        return accum
+      }, [])
   }
 
   _findUser (auth = {}, freshUsersDate = []) {
@@ -290,7 +299,7 @@ class WSTransport {
     } = { ...opts }
 
     const freshUsersDate = isReceivedFreshUserDataFromDb
-      ? await this._getFreshUsersDataFromDb()
+      ? await this._getFreshUsersDataFromSessions()
       : false
 
     for (const [sid, socket] of this._sockets) {

--- a/workers/loc.api/ws-transport/index.js
+++ b/workers/loc.api/ws-transport/index.js
@@ -213,7 +213,7 @@ class WSTransport {
 
         socket.ping(null, false)
       })
-    }, 10000)
+    }, 20_000)
 
     this.transport.socket.on('close', () => {
       this._active = false


### PR DESCRIPTION
This PR makes comprehensive sync performance improvement

---

For durability purposes of the sync process with the BFX API was created mocked API for a stress test of the sync: https://github.com/bitfinexcom/bfx-report-electron/pull/510
The mocked API generats 1K entries per day since 2013/01/01, which leads to approx 46GB of database file
Based on the results of mocked API usage adds the following comprehensive improvements:
- Improves sync data bulk movement from the temp tables to the main. The main idea here is that we should make all of these operations atomic in a transaction and not make movements of millions of entries in one SQL query to prevent locking and socket disconnections. Instead, we should move data by packages with 10K entries, iterating by rowid
- Runs `PRAGMA optimize` after each sync insertion and after each sync hook. It speeds up subsequent queries
- Prevents `PRAGMA optimize` after sync is finished as moving millions of entries from temp tables can lead very long time of execution. Instead, make pragma optimize on the start-up of the app considering the doc https://www.sqlite.org/pragma.html#pragma_optimize for long-lived database connections
- Increases `PRAGMA cache_size` to 512MB for performance
- Increases `PRAGMA mmap_size` to 512MB for performance
- Increases `PRAGMA page_size` to 40KB for performance
- Add DB `VACUUM` command strategy. The vacuum cmd creates a new db file and copies all data from the old db file to prevent db fragmentation and shrink size. Because the db file can have gigabytes the cmd can take hours and the app launch will take a lot of time and bring a bad user experience. Here makes sense to execute a vacuum when an absolute size is reached by the free pages, in our case enters `(freePageSize / absoluteSize) < 0.8`
- Fixes setup auth token refresh flow
- Fixes sing-in in case heavy moving transaction of sync data
- Fixes performance issue in the convert currency hook
- Fixes performance issue in the recalc sub account ledgers balances hook
- Increases `progress` emitter interval for performance
- Improve performance for event sending to active users
- Increases WebSocket `ping` interval for performance. This change dapands on this PR: https://github.com/bitfinexcom/bfx-report-express/pull/44
- Fixes rare case of sync process when base start mts equal end one

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report-express/pull/44
