### PR TITLE
Fix query builder for null operator

### DIFF
--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -124,7 +124,7 @@ const _getIsNullOperator = (
     return false
   }
   const _alias = alias && typeof alias === 'string'
-    ? `${alias}_`
+    ? `${alias}.`
     : ''
   const operator = fieldName === FILTER_CONDITIONS.IS_NOT_NULL
     ? SQL_OPERATORS.IS_NOT_NULL


### PR DESCRIPTION
This PR fixes query builder for `null` operator for sub-query