### PR TITLE
Change order of fetching pub trade price to be end-start

### DIFF
--- a/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/find-public-trade.js
@@ -11,10 +11,10 @@ module.exports = (pubTrades, mts) => {
     if (pubTrades[middleIndex]?.mts === mts) {
       return pubTrades[middleIndex]
     }
-    if (mts < pubTrades[middleIndex]?.mts) {
+    if (mts > pubTrades[middleIndex]?.mts) {
       endIndex = middleIndex - 1
     }
-    if (mts > pubTrades[middleIndex]?.mts) {
+    if (mts < pubTrades[middleIndex]?.mts) {
       startIndex = middleIndex + 1
     }
   }


### PR DESCRIPTION
This PR changes the order of getting the price of the pub trades moving from the end to the start by timestamps to overcome some rare cases. For example, a user performs a currency exchange, but the entry with the same timestamp has not yet been displayed in public trades. We have some reported issues for `MATICM` and `DUSK` coins:
- https://github.com/bitfinexcom/bfx-report-electron/issues/493