### PR TITLE
Avoid queuing sync by scheduler if sync is already in progress

### DIFF
--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -99,14 +99,11 @@ class SyncQueue extends EventEmitter {
     const ownerUserIdFilter = Number.isInteger(ownerUserId)
       ? { ownerUserId }
       : {}
-    const isOwnerSchedulerFilter = isOwnerScheduler
-      ? { isOwnerScheduler: 1 }
-      : {}
 
     const allSyncs = await this._getAll({
-      state: [NEW_JOB_STATE, ERROR_JOB_STATE],
+      state: [NEW_JOB_STATE, ERROR_JOB_STATE, LOCKED_JOB_STATE],
       ...ownerUserIdFilter,
-      ...isOwnerSchedulerFilter
+      isOwnerScheduler: 1
     })
     const hasALLInDB = allSyncs.some(item => {
       return item.collName === this.ALLOWED_COLLS.ALL

--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -85,8 +85,14 @@ class SyncQueue extends EventEmitter {
     } = params ?? {}
 
     if (
-      !Number.isInteger(ownerUserId) &&
-      !isOwnerScheduler
+      (
+        !Number.isInteger(ownerUserId) &&
+        !isOwnerScheduler
+      ) ||
+      (
+        Number.isInteger(ownerUserId) &&
+        isOwnerScheduler
+      )
     ) {
       throw new SyncQueueOwnerSettingError()
     }


### PR DESCRIPTION
This PR adds ability to avoid queuing sync by scheduler if sync is already in progress to prevent redundant sync in case a user has lots of data and sync takes time until the run of the scheduler
