### PR TITLE
Deduct trading fees in tax report

### DIFF
--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -193,6 +193,9 @@ const paramsSchemaForTransactionTaxReportApi = {
         'FIFO',
         'LIFO'
       ]
+    },
+    shouldFeesBeDeducted: {
+      type: 'boolean'
     }
   }
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-fee-usd.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-fee-usd.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const BigNumber = require('bignumber.js')
+
+module.exports = (trx, opts) => {
+  if (
+    opts?.isNotGainOrLossRequired ||
+    !opts?.shouldFeesBeDeducted ||
+    trx.isTaxablePayment ||
+    !Number.isFinite(trx.trxFee)
+  ) {
+    return new BigNumber(0)
+  }
+  if (
+    trx.trxFeeCcy === trx.firstSymb &&
+    Number.isFinite(trx.firstSymbPriceUsd)
+  ) {
+    return new BigNumber(trx.trxFee)
+      .times(trx.firstSymbPriceUsd)
+  }
+  if (
+    trx.trxFeeCcy === trx.lastSymb &&
+    Number.isFinite(trx.lastSymbPriceUsd)
+  ) {
+    return new BigNumber(trx.trxFee)
+      .times(trx.lastSymbPriceUsd)
+  }
+
+  return new BigNumber(0)
+}

--- a/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-fee-usd.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/get-trx-fee-usd.js
@@ -6,7 +6,10 @@ module.exports = (trx, opts) => {
   if (
     opts?.isNotGainOrLossRequired ||
     !opts?.shouldFeesBeDeducted ||
-    trx.isTaxablePayment ||
+    (
+      !opts?.shouldTaxablePaymentFlagBeSkipped &&
+      trx.isTaxablePayment
+    ) ||
     !Number.isFinite(trx.trxFee)
   ) {
     return new BigNumber(0)

--- a/workers/loc.api/sync/transaction.tax.report/helpers/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/index.js
@@ -13,6 +13,7 @@ const TrxPriceCalculator = require('./trx.price.calculator')
 const getCcyPairForConversion = require('./get-ccy-pair-for-conversion')
 const getTrxTaxType = require('./get-trx-tax-type')
 const setDelistedCcyToMap = require('./set-delisted-ccy-to-map')
+const getTrxFeeUsd = require('./get-trx-fee-usd')
 
 module.exports = {
   TRX_TAX_TYPES,
@@ -27,5 +28,6 @@ module.exports = {
   TrxPriceCalculator,
   getCcyPairForConversion,
   getTrxTaxType,
-  setDelistedCcyToMap
+  setDelistedCcyToMap,
+  getTrxFeeUsd
 }

--- a/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
@@ -18,6 +18,7 @@ const {
 
 const getTrxTaxType = require('./get-trx-tax-type')
 const setDelistedCcyToMap = require('./set-delisted-ccy-to-map')
+const getTrxFeeUsd = require('./get-trx-fee-usd')
 
 module.exports = async (trades, opts) => {
   const {
@@ -87,6 +88,8 @@ module.exports = async (trades, opts) => {
       .buyFilledAmount ?? new BigNumber(0)
     trade.proceedsForBuyTrxUsd = trade
       .proceedsForBuyTrxUsd ?? new BigNumber(0)
+    trade.cumulativeTrxFeesUsd = trade
+      .cumulativeTrxFeesUsd ?? new BigNumber(0)
     trade.saleTrxsForRealizedProfit = trade
       .saleTrxsForRealizedProfit ?? []
 
@@ -181,6 +184,8 @@ module.exports = async (trades, opts) => {
 
       continue
     }
+
+    trade.cumulativeTrxFeesUsd = getTrxFeeUsd(trade, opts)
 
     const startPoint = isBackIterativeBuyLookUp
       ? trades.length - 1
@@ -317,6 +322,8 @@ module.exports = async (trades, opts) => {
           .plus(buyRestAmount.times(salePriceUsd))
         trade.costForSaleTrxUsd = trade.costForSaleTrxUsd
           .plus(buyRestAmount.times(buyPriceUsd))
+        trade.cumulativeTrxFeesUsd = trade.cumulativeTrxFeesUsd
+          .plus(getTrxFeeUsd(tradeForLookup, opts))
         tradeForLookup.isBuyTrxHistFilled = true
       }
       if (buyRestAmount.gt(saleRestAmount)) {
@@ -329,6 +336,10 @@ module.exports = async (trades, opts) => {
           .plus(saleRestAmount.times(salePriceUsd))
         trade.costForSaleTrxUsd = trade.costForSaleTrxUsd
           .plus(saleRestAmount.times(buyPriceUsd))
+        trade.cumulativeTrxFeesUsd = trade.cumulativeTrxFeesUsd
+          .plus(getTrxFeeUsd(tradeForLookup, opts)
+            .times(saleRestAmount.div(buyRestAmount))
+          )
         trade.isSaleTrxHistFilled = true
       }
       if (buyRestAmount.eq(saleRestAmount)) {
@@ -339,6 +350,8 @@ module.exports = async (trades, opts) => {
           .plus(buyRestAmount.times(salePriceUsd))
         trade.costForSaleTrxUsd = trade.costForSaleTrxUsd
           .plus(buyRestAmount.times(buyPriceUsd))
+        trade.cumulativeTrxFeesUsd = trade.cumulativeTrxFeesUsd
+          .plus(getTrxFeeUsd(tradeForLookup, opts))
         tradeForLookup.isBuyTrxHistFilled = true
         trade.isSaleTrxHistFilled = true
       }
@@ -367,6 +380,7 @@ module.exports = async (trades, opts) => {
     trade.proceedsForSaleTrxUsd = saleAmount.times(salePriceUsd)
     trade.gainOrLossUsd = trade.proceedsForSaleTrxUsd
       .minus(trade.costForSaleTrxUsd)
+      .plus(trade.cumulativeTrxFeesUsd)
   }
 
   for (const trade of trades) {
@@ -398,6 +412,7 @@ module.exports = async (trades, opts) => {
     if (trade.isTaxablePayment) {
       const proceeds = new BigNumber(trade.execAmount)
         .times(trade.firstSymbPriceUsd)
+        .plus(getTrxFeeUsd(trade, opts))
         .toNumber()
 
       saleTradesWithRealizedProfit.push({

--- a/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/look-up-trades.js
@@ -412,7 +412,10 @@ module.exports = async (trades, opts) => {
     if (trade.isTaxablePayment) {
       const proceeds = new BigNumber(trade.execAmount)
         .times(trade.firstSymbPriceUsd)
-        .plus(getTrxFeeUsd(trade, opts))
+        .plus(getTrxFeeUsd(trade, {
+          shouldTaxablePaymentFlagBeSkipped: true,
+          ...opts
+        }))
         .toNumber()
 
       saleTradesWithRealizedProfit.push({

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-movements.js
@@ -59,6 +59,8 @@ module.exports = (movements, params) => {
       execPrice: 0,
       // NOTE: exactUsdValue can be null on the first launch, for warm-up it's filling from pub-trades
       exactUsdValue: movement.exactUsdValue,
+      trxFee: movement.fees ?? 0,
+      trxFeeCcy: firstSymb,
 
       isAirdropOnWallet: !!movement?._isAirdropOnWallet,
       isMarginFundingPayment: !!movement?._isMarginFundingPayment,

--- a/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
+++ b/workers/loc.api/sync/transaction.tax.report/helpers/remap-trades.js
@@ -37,6 +37,8 @@ module.exports = (trades, params) => {
     trade.isMovements = false
     trade.isLedgers = false
     trade.isTrades = true
+    trade.trxFee = trade.fee ?? 0
+    trade.trxFeeCcy = trade.feeCurrency
 
     remappedTrxs.push(trade)
 

--- a/workers/loc.api/sync/transaction.tax.report/index.js
+++ b/workers/loc.api/sync/transaction.tax.report/index.js
@@ -103,6 +103,7 @@ class TransactionTaxReport {
     const start = params.start ?? 0
     const end = params.end ?? Date.now()
     const strategy = params.strategy ?? TRX_TAX_STRATEGIES.LIFO
+    const shouldFeesBeDeducted = params.shouldFeesBeDeducted ?? false
     const user = await this.authenticator
       .verifyRequestUser({ auth })
     const interrupter = this.interrupterFactory({
@@ -162,7 +163,8 @@ class TransactionTaxReport {
         isNotGainOrLossRequired: true,
         interrupter,
         logger: this.logger,
-        delistedCcyMap
+        delistedCcyMap,
+        shouldFeesBeDeducted
       }
     )
 
@@ -187,7 +189,8 @@ class TransactionTaxReport {
         isBackIterativeBuyLookUp,
         interrupter,
         logger: this.logger,
-        delistedCcyMap
+        delistedCcyMap,
+        shouldFeesBeDeducted
       }
     )
 


### PR DESCRIPTION
This PR adds ability to deduct trading fees in the tax report. Adds a flag `shouldFeesBeDeducted` to use that via a checkbox in the UI

---

Example:
- 1_transaction buy BTC: amount 1, price 100_000 USD, fee: -10 USD
- 2_transaction buy BTC: amount 2, price 200_000 USD, fee: -20 USD
- 3_transaction sale BTC: amount -1.5, price 150_000 USD, fee: -15 USD

Result:
- PnL: (1.5 * 150_000) - (1 * 100_000 + 0.5 * 200_000) = 25_000 USD
- fees: 15 (from sale) + 10 (from buy 1) + (20 * (0.5 / 2)) (form buy 2, here we consider amount 0.5) = 30 USD
- PnL with fees: 25_000 - 30 = 24970 USD

---

Request example:
```jsonc
{
    "auth": {
        "token": "auth-token"
    },
    "method": "getTransactionTaxReport",
    "params": {
      "start": 1681803136154,
      "end": 1744961536154,
      "strategy": "LIFO",
      "shouldFeesBeDeducted": true // The corresponding flag
    }
}
```
