### PR TITLE
Rework sync schema model usage to use new model interface

### DIFF
--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -156,8 +156,8 @@ class DataChecker {
       !syncUserStepData.isBaseStepReady ||
       !syncUserStepData.isCurrStepReady
     ) {
-      schema.hasNewData = true
-      schema.start.push(syncUserStepData)
+      schema.setModelField('HAS_NEW_DATA', true)
+      schema.getModelField('START').push(syncUserStepData)
     }
 
     const shouldFreshSyncBeAdded = this._shouldFreshSyncBeAdded(
@@ -175,8 +175,8 @@ class DataChecker {
       currEnd: currMts,
       isCurrStepReady: false
     })
-    schema.hasNewData = true
-    schema.start.push(freshSyncUserStepData)
+    schema.setModelField('HAS_NEW_DATA', true)
+    schema.getModelField('START').push(freshSyncUserStepData)
   }
 
   async _checkNewDataPublicArrObjType (authMap, methodCollMap) {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -422,7 +422,7 @@ class DataChecker {
         !syncUserStepData.isBaseStepReady ||
         !syncUserStepData.isCurrStepReady
       ) {
-        schema.hasNewData = true
+        schema.setModelField('HAS_NEW_DATA', true)
       }
 
       const wasStartPointChanged = this._wasStartPointChanged(
@@ -441,7 +441,7 @@ class DataChecker {
           isBaseStepReady: false
         })
 
-        schema.hasNewData = true
+        schema.setModelField('HAS_NEW_DATA', true)
       }
       if (shouldFreshSyncBeAdded) {
         syncUserStepData.setParams({
@@ -450,10 +450,10 @@ class DataChecker {
           isCurrStepReady: false
         })
 
-        schema.hasNewData = true
+        schema.setModelField('HAS_NEW_DATA', true)
       }
 
-      if (!schema.hasNewData) {
+      if (!schema.getModelField('HAS_NEW_DATA')) {
         continue
       }
 
@@ -466,7 +466,7 @@ class DataChecker {
       }
 
       syncUserStepData.auth = auth
-      schema.start.push(syncUserStepData)
+      schema.getModelField('START').push(syncUserStepData)
     }
   }
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -184,13 +184,17 @@ class DataChecker {
       if (this._isInterrupted) {
         return
       }
-      if (!isInsertableArrObj(schema?.type, { isPublic: true })) {
+
+      const type = schema.getModelField('TYPE')
+      const name = schema.getModelField('NAME')
+
+      if (!isInsertableArrObj(type, { isPublic: true })) {
         continue
       }
 
       this._resetSyncSchemaProps(schema)
 
-      if (schema.name === this.ALLOWED_COLLS.CANDLES) {
+      if (name === this.ALLOWED_COLLS.CANDLES) {
         // If `authMap` is empty sync candles for all users
         const _authMap = (
           !(authMap instanceof Map) ||
@@ -208,9 +212,9 @@ class DataChecker {
         }
       }
       if (
-        schema.name === this.ALLOWED_COLLS.PUBLIC_TRADES ||
-        schema.name === this.ALLOWED_COLLS.TICKERS_HISTORY ||
-        schema.name === this.ALLOWED_COLLS.CANDLES
+        name === this.ALLOWED_COLLS.PUBLIC_TRADES ||
+        name === this.ALLOWED_COLLS.TICKERS_HISTORY ||
+        name === this.ALLOWED_COLLS.CANDLES
       ) {
         await this._checkNewConfigurablePublicData(method, schema)
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -225,11 +225,9 @@ class DataChecker {
     }
 
     const currMts = Date.now()
-    const {
-      type,
-      confName,
-      timeframeFieldName
-    } = schema ?? {}
+    const type = schema.getModelField('TYPE')
+    const confName = schema.getModelField('CONF_NAME')
+    const timeframeFieldName = schema.getModelField('TIMEFRAME_FIELD_NAME')
     const groupResBy = (
       timeframeFieldName &&
       typeof timeframeFieldName === 'string'
@@ -282,8 +280,8 @@ class DataChecker {
         !syncUserStepData.isBaseStepReady ||
         !syncUserStepData.isCurrStepReady
       ) {
-        schema.hasNewData = true
-        schema.start.push(syncUserStepData)
+        schema.setModelField('HAS_NEW_DATA', true)
+        schema.getModelField('START').push(syncUserStepData)
 
         if (isUpdatable(type)) {
           continue
@@ -297,8 +295,8 @@ class DataChecker {
           isCurrStepReady: false
         })
 
-        schema.hasNewData = true
-        schema.start.push(freshSyncUserStepData)
+        schema.setModelField('HAS_NEW_DATA', true)
+        schema.getModelField('START').push(freshSyncUserStepData)
 
         continue
       }
@@ -340,8 +338,8 @@ class DataChecker {
         })
       }
 
-      schema.hasNewData = true
-      schema.start.push(freshSyncUserStepData)
+      schema.setModelField('HAS_NEW_DATA', true)
+      schema.getModelField('START').push(freshSyncUserStepData)
     }
   }
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -717,8 +717,9 @@ class DataChecker {
   }
 
   _resetSyncSchemaProps (schema) {
-    schema.hasNewData = false
-    schema.start = []
+    schema
+      .setModelField('HAS_NEW_DATA', false)
+      .setModelField('START', [])
   }
 
   _getMethodCollMap () {

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -113,7 +113,10 @@ class DataChecker {
       if (this._isInterrupted) {
         return
       }
-      if (!isInsertableArrObj(schema?.type, { isPrivate: true })) {
+
+      const type = schema.getModelField('TYPE')
+
+      if (!isInsertableArrObj(type, { isPrivate: true })) {
         continue
       }
 

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -482,7 +482,7 @@ class DataChecker {
       }
 
       const type = schema.getModelField('TYPE')
-      const name = schema.getModelField('TYPE')
+      const name = schema.getModelField('NAME')
 
       if (
         !isUpdatable(type) ||

--- a/workers/loc.api/sync/data.inserter/data.checker/index.js
+++ b/workers/loc.api/sync/data.inserter/data.checker/index.js
@@ -475,16 +475,20 @@ class DataChecker {
       if (this._isInterrupted) {
         return
       }
+
+      const type = schema.getModelField('TYPE')
+      const name = schema.getModelField('TYPE')
+
       if (
-        !isUpdatable(schema?.type) ||
-        !isPublic(schema?.type)
+        !isUpdatable(type) ||
+        !isPublic(type)
       ) {
         continue
       }
 
       this._resetSyncSchemaProps(schema)
 
-      const hasStatusMessagesSection = schema?.name === this.ALLOWED_COLLS.STATUS_MESSAGES
+      const hasStatusMessagesSection = name === this.ALLOWED_COLLS.STATUS_MESSAGES
 
       if (hasStatusMessagesSection) {
         await this._checkNewConfigurablePublicData(method, schema)
@@ -507,8 +511,8 @@ class DataChecker {
         !syncUserStepData.isBaseStepReady ||
         !syncUserStepData.isCurrStepReady
       ) {
-        schema.hasNewData = true
-        schema.start.push(syncUserStepData)
+        schema.setModelField('HAS_NEW_DATA', true)
+        schema.getModelField('START').push(syncUserStepData)
 
         continue
       }
@@ -517,8 +521,8 @@ class DataChecker {
         ...syncUserStepData.getParams(),
         isCurrStepReady: false
       })
-      schema.hasNewData = true
-      schema.start.push(freshSyncUserStepData)
+      schema.setModelField('HAS_NEW_DATA', true)
+      schema.getModelField('START').push(freshSyncUserStepData)
     }
   }
 

--- a/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
+++ b/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
@@ -8,9 +8,11 @@ const _reduceMethodCollMap = (
   isAllowed = () => true
 ) => {
   return [..._methodCollMap].reduce((accum, curr) => {
+    const name = curr[1].getModelField('NAME')
+
     if (
-      accum.every(item => item.name !== curr[1].name) &&
-      res.every(item => item.name !== curr[1].name) &&
+      accum.every(item => item.name !== name) &&
+      res.every(item => item.name !== name) &&
       isAllowed(curr)
     ) {
       accum.push(curr)
@@ -21,11 +23,15 @@ const _reduceMethodCollMap = (
 }
 
 const _isPubColl = (coll) => {
-  return isPublic(coll[1].type)
+  const type = coll[1].getModelField('TYPE')
+
+  return isPublic(type)
 }
 
 const _isAllowedColl = (coll, allowedCollsNames) => {
-  return allowedCollsNames.some(item => item === coll[1].name)
+  const name = coll[1].getModelField('NAME')
+
+  return allowedCollsNames.some(item => item === name)
 }
 
 module.exports = (
@@ -81,7 +87,11 @@ module.exports = (
     const subRes = _reduceMethodCollMap(
       _methodCollMap,
       res,
-      curr => curr[1].name === collName
+      (curr) => {
+        const name = curr[1].getModelField('NAME')
+
+        return name === collName
+      }
     )
 
     res.push(...subRes)

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -301,16 +301,18 @@ class DataInserter extends EventEmitter {
       await this.wsEventEmitter
         .emitSyncingStep(`SYNCING_${getSyncCollName(method)}`)
 
-      const { type, start } = schema ?? {}
+      const name = schema.getModelField('NAME')
+      const type = schema.getModelField('TYPE')
+      const start = schema.getModelField('START')
 
-      if (schema.name === this.ALLOWED_COLLS.CANDLES) {
+      if (name === this.ALLOWED_COLLS.CANDLES) {
         // Considers 10 reqs/min for candles
         const leftTime = Math.floor((60 / 10) * start.length * 1000)
         this.progress.setCandlesLeftTime(leftTime)
       }
 
       for (const syncUserStepData of start) {
-        if (isInsertableArrObj(schema?.type, { isPublic: true })) {
+        if (isInsertableArrObj(type, { isPublic: true })) {
           await this._insertApiData(
             method,
             schema,

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -528,17 +528,17 @@ class DataInserter extends EventEmitter {
       !authToken
     )
     const isPrivate = !isPublic
+    const type = schema.getModelField('TYPE')
 
-    if (!isInsertableArrObj(schema?.type, { isPublic, isPrivate })) {
+    if (!isInsertableArrObj(type, { isPublic, isPrivate })) {
       return
     }
 
-    const {
-      name: collName,
-      dateFieldName,
-      model,
-      shouldNotApiMiddlewareBeLaunched
-    } = schema
+    const collName = schema.getModelField('NAME')
+    const dateFieldName = schema.getModelField('DATE_FIELD_NAME')
+    const model = schema.getModelField('MODEL')
+    const shouldNotApiMiddlewareBeLaunched = schema
+      .getModelField('SHOULD_NOT_API_MIDDLEWARE_BE_LAUNCHED')
 
     const _args = cloneDeep(args)
     _args.params.notThrowError = true

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -784,18 +784,19 @@ class DataInserter extends EventEmitter {
     methodApi,
     schema
   ) {
+    const type = schema.getModelField('TYPE')
+    const collName = schema.getModelField('NAME')
+    const projection = schema.getModelField('PROJECTION')
+    const shouldNotApiMiddlewareBeLaunched = schema
+      .getModelField('SHOULD_NOT_API_MIDDLEWARE_BE_LAUNCHED')
+
     if (
       this._isInterrupted ||
-      !isUpdatableArr(schema?.type, { isPublic: true })
+      !isUpdatableArr(type, { isPublic: true })
     ) {
       return
     }
 
-    const {
-      name: collName,
-      projection,
-      shouldNotApiMiddlewareBeLaunched
-    } = schema
     const _projection = Array.isArray(projection)
       ? projection
       : [projection]

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -394,7 +394,7 @@ class DataInserter extends EventEmitter {
         auth
       )
 
-      const { start } = schema ?? {}
+      const start = schema.getModelField('START')
 
       for (const syncUserStepData of start) {
         await this._insertApiData(

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -430,7 +430,8 @@ class DataInserter extends EventEmitter {
       return
     }
 
-    const hasCandlesSection = schema.name === this.ALLOWED_COLLS.CANDLES
+    const name = schema.getModelField('NAME')
+    const hasCandlesSection = name === this.ALLOWED_COLLS.CANDLES
     const _auth = (
       hasCandlesSection &&
       syncUserStepData?.auth

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -705,7 +705,9 @@ class DataInserter extends EventEmitter {
       hasTimeframe,
       areAllSymbolsRequired
     } = syncUserStepData
-    const hasStatusMessagesSection = schema?.name === this.ALLOWED_COLLS.STATUS_MESSAGES
+    const name = schema.getModelField('NAME')
+    const dateFieldName = schema.getModelField('DATE_FIELD_NAME')
+    const hasStatusMessagesSection = name === this.ALLOWED_COLLS.STATUS_MESSAGES
 
     const checkOpts = {
       shouldNotMtsBeChecked: true,
@@ -731,7 +733,7 @@ class DataInserter extends EventEmitter {
       const statusMessagesParams = {
         ...params,
         filter: {
-          $gte: { [schema?.dateFieldName]: baseStart }
+          $gte: { [dateFieldName]: baseStart }
         }
       }
 
@@ -756,7 +758,7 @@ class DataInserter extends EventEmitter {
       const statusMessagesParams = {
         ...params,
         filter: {
-          $gte: { [schema?.dateFieldName]: currStart }
+          $gte: { [dateFieldName]: currStart }
         }
       }
 

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -923,9 +923,12 @@ class DataInserter extends EventEmitter {
         const updatesForOneUserPromises = []
 
         for (const [collName, schema] of methodCollMap) {
+          const type = schema.getModelField('TYPE')
+          const start = schema.getModelField('START')
+
           if (
-            !Array.isArray(schema?.start) ||
-            schema.start.length === 0
+            !Array.isArray(start) ||
+            start.length === 0
           ) {
             continue
           }
@@ -938,8 +941,8 @@ class DataInserter extends EventEmitter {
             subUserId,
             syncedAt,
             ...this.syncUserStepManager.wereStepsSynced(
-              schema.start,
-              { shouldNotMtsBeChecked: isUpdatable(schema?.type) }
+              start,
+              { shouldNotMtsBeChecked: isUpdatable(type) }
             )
           }, { doNotQueueQuery: true })
           updatesForOneUserPromises.push(promise)
@@ -948,16 +951,20 @@ class DataInserter extends EventEmitter {
         await Promise.all(updatesForOneUserPromises)
       }
       for (const [collName, schema] of pubMethodCollMap) {
+        const name = schema.getModelField('NAME')
+        const type = schema.getModelField('TYPE')
+        const start = schema.getModelField('START')
+
         if (
-          !Array.isArray(schema?.start) ||
-          schema.start.length === 0
+          !Array.isArray(start) ||
+          start.length === 0
         ) {
           continue
         }
 
-        const startWithAuth = schema.start
+        const startWithAuth = start
           .filter((syncUserStepData) => syncUserStepData?.auth)
-        const startWithoutAuth = schema.start
+        const startWithoutAuth = start
           .filter((syncUserStepData) => !syncUserStepData?.auth)
 
         if (startWithAuth.length > 0) {
@@ -972,8 +979,8 @@ class DataInserter extends EventEmitter {
               ...this.syncUserStepManager.wereStepsSynced(
                 [syncUserStepData],
                 {
-                  shouldNotMtsBeChecked: isUpdatable(schema?.type),
-                  shouldStartMtsBeChecked: schema?.name === this.ALLOWED_COLLS.STATUS_MESSAGES
+                  shouldNotMtsBeChecked: isUpdatable(type),
+                  shouldStartMtsBeChecked: name === this.ALLOWED_COLLS.STATUS_MESSAGES
                 }
               )
             }, { doNotQueueQuery: true })
@@ -986,10 +993,10 @@ class DataInserter extends EventEmitter {
             collName,
             syncedAt,
             ...this.syncUserStepManager.wereStepsSynced(
-              schema.start,
+              start,
               {
-                shouldNotMtsBeChecked: isUpdatable(schema?.type),
-                shouldStartMtsBeChecked: schema?.name === this.ALLOWED_COLLS.STATUS_MESSAGES
+                shouldNotMtsBeChecked: isUpdatable(type),
+                shouldStartMtsBeChecked: name === this.ALLOWED_COLLS.STATUS_MESSAGES
               }
             )
           }, { doNotQueueQuery: true })

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -843,18 +843,18 @@ class DataInserter extends EventEmitter {
     methodApi,
     schema
   ) {
+    const type = schema.getModelField('TYPE')
+    const collName = schema.getModelField('NAME')
+    const model = schema.getModelField('MODEL')
+    const shouldNotApiMiddlewareBeLaunched = schema
+      .getModelField('SHOULD_NOT_API_MIDDLEWARE_BE_LAUNCHED')
+
     if (
       this._isInterrupted ||
-      !isUpdatableArrObj(schema?.type, { isPublic: true })
+      !isUpdatableArrObj(type, { isPublic: true })
     ) {
       return
     }
-
-    const {
-      name: collName,
-      model,
-      shouldNotApiMiddlewareBeLaunched
-    } = schema ?? {}
 
     const apiRes = await this._getDataFromApi(
       methodApi,

--- a/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.temp.tables.manager/index.js
@@ -42,7 +42,12 @@ class SyncTempTablesManager {
 
   async createTempDBStructureForCurrSync (methodCollMap) {
     const models = [...methodCollMap]
-      .map(([method, schema]) => [schema.name, schema.model])
+      .map(([method, schema]) => {
+        const name = schema.getModelField('NAME')
+        const model = schema.getModelField('MODEL')
+
+        return [name, model]
+      })
     const namePrefix = this.getCurrNamePrefix()
 
     await this.dao.createDBStructure({ models, namePrefix })

--- a/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
+++ b/workers/loc.api/sync/data.inserter/sync.user.step.manager/index.js
@@ -200,14 +200,13 @@ class SyncUserStepManager {
       defaultStart: _defaultStart = MIN_START_MTS,
       currMts = Date.now()
     } = params ?? {}
-    const {
-      name: tableName,
-      dateFieldName,
-      symbolFieldName,
-      timeframeFieldName,
-      sort: tableOrder,
-      model
-    } = syncSchema ?? {}
+    const tableName = syncSchema.getModelField('NAME')
+    const dateFieldName = syncSchema.getModelField('DATE_FIELD_NAME')
+    const symbolFieldName = syncSchema.getModelField('SYMBOL_FIELD_NAME')
+    const timeframeFieldName = syncSchema.getModelField('TIMEFRAME_FIELD_NAME')
+    const tableOrder = syncSchema.getModelField('ORDER')
+    const type = syncSchema.getModelField('TYPE')
+    const model = syncSchema.getModelField('MODEL')
 
     const defaultStart = this._getMinStart(_defaultStart)
     const hasUserIdField = (
@@ -243,7 +242,7 @@ class SyncUserStepManager {
 
     if (
       tableName !== this.TABLES_NAMES.CANDLES &&
-      isPublic(syncSchema?.type) !== shouldCollBePublic
+      isPublic(type) !== shouldCollBePublic
     ) {
       throw new LastSyncedInfoGettingError()
     }
@@ -390,7 +389,7 @@ class SyncUserStepManager {
         currEnd: min([currEnd, firstElemMtsFromTempTable]) ?? lastElemMtsFromMainTable ?? currMts
       })
 
-      if (isUpdatable(syncSchema?.type)) {
+      if (isUpdatable(type)) {
         syncUserStepData.setParams({
           currStart: defaultStart,
           currEnd: currMts
@@ -403,7 +402,7 @@ class SyncUserStepManager {
         baseEnd: min([baseEnd, firstElemMtsFromTempTable]) ?? lastElemMtsFromMainTable ?? currMts
       })
 
-      if (isUpdatable(syncSchema?.type)) {
+      if (isUpdatable(type)) {
         syncUserStepData.setParams({
           baseStart: defaultStart,
           baseEnd: currMts

--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -40,7 +40,7 @@ class Movements {
       end = Date.now(),
       filter: _filter,
       sort = [['mtsUpdated', -1]],
-      projection = this.movementsModel,
+      projection = this.movementsModelFields,
       exclude = ['user_id'],
       isExcludePrivate = true,
       isWithdrawals = false,

--- a/workers/loc.api/sync/performing.loan/index.js
+++ b/workers/loc.api/sync/performing.loan/index.js
@@ -391,10 +391,10 @@ class PerformingLoan {
     const ledgers = await this._getLedgers(args)
     const balances = await this._getFundingBalances(args)
 
-    const {
-      dateFieldName: ledgersDateFieldName,
-      symbolFieldName: ledgersSymbolFieldName
-    } = this.ledgersMethodColl
+    const ledgersDateFieldName = this.ledgersMethodColl
+      .getModelField('DATE_FIELD_NAME')
+    const ledgersSymbolFieldName = this.ledgersMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
 
     const ledgersGroupedByTimeframe = await groupByTimeframe(
       ledgers,

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -54,7 +54,8 @@ class PositionsSnapshot {
       .getModelFields()
     this.positionsSnapshotMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.POSITIONS_SNAPSHOT)
-    this.positionsSnapshotSymbolFieldName = this.positionsSnapshotMethodColl.symbolFieldName
+    this.positionsSnapshotSymbolFieldName = this.positionsSnapshotMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
   }
 
   _getPositionsHistory (

--- a/workers/loc.api/sync/schema/sync-schema/model/index.js
+++ b/workers/loc.api/sync/schema/sync-schema/model/index.js
@@ -85,6 +85,16 @@ class SyncSchemaModel extends BaseSyncSchemaModel {
     return this[this.constructor[fieldkey]]
   }
 
+  setModelField (fieldkey, value) {
+    if (this.#isNotAllowedModelFieldKey(fieldkey)) {
+      throw new SyncSchemaModelFieldKeyNameAccessError()
+    }
+
+    this[this.constructor[fieldkey]] = value
+
+    return this
+  }
+
   getModelFields (opts) {
     return opts?.isCloned
       ? cloneDeep(this.#modelFields)

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -37,7 +37,8 @@ class SummaryByAsset {
     this.ledgersModelFields = this.syncSchema
       .getModelOf(this.ALLOWED_COLLS.LEDGERS)
       .getModelFields()
-    this.ledgersSymbolFieldName = this.ledgersMethodColl.symbolFieldName
+    this.ledgersSymbolFieldName = this.ledgersMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
   }
 
   async getSummaryByAsset (args) {

--- a/workers/loc.api/sync/sync.colls.manager/index.js
+++ b/workers/loc.api/sync/sync.colls.manager/index.js
@@ -90,11 +90,10 @@ class SyncCollsManager {
     const checkingRes = []
 
     for (const [method, schema] of this._methodCollMap) {
-      const {
-        name,
-        type,
-        isSyncRequiredAtLeastOnce
-      } = schema
+      const name = schema.getModelField('NAME')
+      const type = schema.getModelField('TYPE')
+      const isSyncRequiredAtLeastOnce = schema
+        .getModelField('IS_SYNC_REQUIRED_AT_LEAST_ONCE')
 
       if (
         isHidden(type) ||

--- a/workers/loc.api/sync/sync.queue/index.js
+++ b/workers/loc.api/sync/sync.queue/index.js
@@ -259,7 +259,9 @@ class SyncQueue extends EventEmitter {
 
   _filterMethodCollMap (methodCollMap, regExp) {
     return new Map([...methodCollMap]
-      .filter(([key, { type }]) => (regExp.test(type))))
+      .filter(([key, schema]) => (
+        regExp.test(schema.getModelField('TYPE'))
+      )))
   }
 
   _getAllMultipliers () {

--- a/workers/loc.api/sync/total.fees.report/index.js
+++ b/workers/loc.api/sync/total.fees.report/index.js
@@ -71,10 +71,10 @@ class TotalFeesReport {
 
     const ledgers = await this._getLedgers(_args)
 
-    const {
-      dateFieldName: ledgersDateFieldName,
-      symbolFieldName: ledgersSymbolFieldName
-    } = this.ledgersMethodColl
+    const ledgersDateFieldName = this.ledgersMethodColl
+      .getModelField('DATE_FIELD_NAME')
+    const ledgersSymbolFieldName = this.ledgersMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
 
     const ledgersGroupedByTimeframe = await groupByTimeframe(
       ledgers,

--- a/workers/loc.api/sync/trades/index.js
+++ b/workers/loc.api/sync/trades/index.js
@@ -206,10 +206,10 @@ class Trades {
       symbol
     }
 
-    const {
-      symbolFieldName: tradesSymbolFieldName,
-      dateFieldName: tradesDateFieldName
-    } = this.tradesMethodColl
+    const tradesSymbolFieldName = this.tradesMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
+    const tradesDateFieldName = this.tradesMethodColl
+      .getModelField('DATE_FIELD_NAME')
 
     const trades = await this._getTrades(args)
     const calcedTradesAmount = this._calcAmounts(
@@ -267,9 +267,8 @@ class Trades {
       end = Date.now(),
       timeframe = 'day'
     } = params ?? {}
-    const {
-      symbolFieldName: tradesSymbolFieldName
-    } = this.tradesMethodColl
+    const tradesSymbolFieldName = this.tradesMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
     const args = {
       auth,
       params: {

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -48,8 +48,10 @@ class WinLoss {
       .get(this.SYNC_API_METHODS.MOVEMENTS)
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)
-    this.movementsSymbolFieldName = this.movementsMethodColl.symbolFieldName
-    this.ledgersSymbolFieldName = this.ledgersMethodColl.symbolFieldName
+    this.movementsSymbolFieldName = this.movementsMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
+    this.ledgersSymbolFieldName = this.ledgersMethodColl
+      .getModelField('SYMBOL_FIELD_NAME')
   }
 
   sumMovementsWithPrevRes (


### PR DESCRIPTION
This PR reworks sync schema model usage to use the new model interface implemented in the previous PR https://github.com/bitfinexcom/bfx-reports-framework/pull/459
It speeds up the work by avoiding the usage of `cloneDeep` fn based on `JSON.parse(JSON.stringify(obj))` for the models

---

The PR is part of the refactoring and doesn't have the changes of the main logic and functionality