### PR TITLE
Update grenache deps

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
 FROM node:20.18.1-alpine3.20
 
-ARG GRC_VER="0.7.1"
+ARG GRC_VER="0.8.2"
 
 WORKDIR /home/node/grenache-cli
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5321,8 +5321,8 @@
     },
     "node_modules/lib-js-util-base": {
       "name": "@bitfinexcom/lib-js-util-base",
-      "version": "1.19.1",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/lib-js-util-base.git#23bf8329d3c304404f0481293c847bbf108e5be5",
+      "version": "1.20.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/lib-js-util-base.git#c71422aea971508f6a605ac12a56bde4425f0d3b",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,9 +1578,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/bittorrent-dht": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-10.0.7.tgz",
-      "integrity": "sha512-o6elCANGteECXz82LFqG1Ov2fG4uNzfUU7pBMx9ixxKUh99ZXNrhbiNLRNN2F2vBnqKSN7SHlUW4LJ5Z2u1eKw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-10.0.0.tgz",
+      "integrity": "sha512-mrM18HMabvd3n/hQa4PYe942nWvBsJCBQb5PfT9kUJLlspNPGiulZYSCgWs7+XarS7nufYrGEp07f9eKTKIrgw==",
       "dev": true,
       "funding": [
         {
@@ -1596,16 +1596,17 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "bencode": "^2.0.3",
-        "debug": "^4.3.4",
-        "k-bucket": "^5.1.0",
-        "k-rpc": "^5.1.0",
+        "bencode": "^2.0.0",
+        "debug": "^4.1.1",
+        "k-bucket": "^5.0.0",
+        "k-rpc": "^5.0.0",
         "last-one-wins": "^1.0.4",
         "lru": "^3.1.0",
-        "randombytes": "^2.1.0",
-        "record-cache": "^1.2.0",
-        "simple-sha1": "^3.1.0"
+        "randombytes": "^2.0.5",
+        "record-cache": "^1.0.2",
+        "simple-sha1": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -1926,6 +1927,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "run-series": "^1.1.9"
@@ -1936,6 +1938,7 @@
       "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
       "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chrome-net": "^3.3.2"
       }
@@ -1959,6 +1962,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
       }
@@ -4070,23 +4074,32 @@
       "dev": true
     },
     "node_modules/grenache-grape": {
-      "version": "0.9.12",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/grenache-grape.git#7e57b0281e759140bc4624cd672fc3822ff95191",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/grenache-grape.git#3bd43a5422fd07ead1ec3fb241e0d032a93beb77",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.4",
-        "bittorrent-dht": "^10.0.0",
+        "async": "3.2.6",
+        "bittorrent-dht": "10.0.0",
         "cbq": "0.0.1",
-        "debug": "^4.0.1",
-        "lodash": "^4.17.21",
-        "raw-body": "^2.5.2",
-        "record-cache": "^1.2.0",
-        "yargs": "^17.7.1"
+        "debug": "4.4.1",
+        "raw-body": "2.5.2",
+        "record-cache": "1.2.0",
+        "yargs": "17.7.2"
       },
       "bin": {
         "grape": "bin/grape.js"
+      },
+      "engines": {
+        "node": ">=16.0"
       }
+    },
+    "node_modules/grenache-grape/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/grenache-grape/node_modules/cliui": {
       "version": "8.0.1",
@@ -4100,6 +4113,24 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/grenache-grape/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/grenache-grape/node_modules/yargs": {
@@ -5216,6 +5247,7 @@
       "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
       "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -5225,6 +5257,7 @@
       "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
       "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "k-bucket": "^5.0.0",
         "k-rpc-socket": "^1.7.2",
@@ -5236,6 +5269,7 @@
       "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
       "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bencode": "^2.0.0",
         "chrome-dgram": "^3.0.2",
@@ -5261,7 +5295,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
       "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -6966,6 +7001,7 @@
       "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
       "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.3.1"
       }
@@ -7192,13 +7228,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/rusha": {
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
       "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -7571,6 +7609,7 @@
       "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.1.0.tgz",
       "integrity": "sha512-ArTptMRC1v08H8ihPD6l0wesKvMfF9e8XL5rIHPanI7kGOsSsbY514MwVu6X1PITHCTB2F08zB7cyEbfc4wQjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2",
         "rusha": "^0.8.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,6 +337,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -370,6 +383,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -417,9 +440,10 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -850,26 +874,10 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/assert-never": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
       "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -925,7 +933,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -941,19 +950,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -1088,18 +1084,11 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/bencode": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
-      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w=="
+      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w==",
+      "dev": true
     },
     "node_modules/better-npm-run": {
       "version": "0.1.1",
@@ -1289,7 +1278,7 @@
     },
     "node_modules/bfx-facs-db-better-sqlite": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-db-better-sqlite.git#215fd82fe77da21e001024b41ba4997c58fab163",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-db-better-sqlite.git#dde950eefbf1bd4d161bb17ce6149eaad1bdb11f",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "3.2.4",
@@ -1308,16 +1297,18 @@
       }
     },
     "node_modules/bfx-facs-grc": {
-      "version": "0.0.3",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-grc.git#c58d3a9301e23f614b9198a307052a026d61ee18",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-grc.git#dc3ee03212d6b6ede799666bc1f5a9eb09282c8c",
       "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.1",
+        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base#v1.20.0",
+        "async": "3.2.6",
         "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
-        "grenache-nodejs-base": "^0.7.5",
-        "grenache-nodejs-http": "^0.7.13",
-        "grenache-nodejs-link": "^0.7.13",
-        "lodash": "^4.17.21"
+        "grenache-nodejs-http": "1.0.1",
+        "grenache-nodejs-link": "1.0.2"
+      },
+      "engines": {
+        "node": ">=16.0"
       }
     },
     "node_modules/bfx-facs-grc-slack": {
@@ -1328,19 +1319,11 @@
         "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git"
       }
     },
-    "node_modules/bfx-facs-grc/node_modules/grenache-nodejs-link": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-0.7.13.tgz",
-      "integrity": "sha512-BogCPtI2hBpn43by5YW+dQZCuVDdQWnxr8LI2hvhQ+jhquKzYGtBjLdo+gbEJb0LulD5ZsCXCEo71pPMmTG9CA==",
-      "dependencies": {
-        "async": "^3.2.4",
-        "bencode": "^2.0.3",
-        "cbq": "0.0.1",
-        "lodash": "^4.17.21",
-        "lru": "^3.1.0",
-        "request": "^2.88.0",
-        "uuid": "^9.0.0"
-      }
+    "node_modules/bfx-facs-grc/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/bfx-facs-interval": {
       "version": "0.0.1",
@@ -1445,59 +1428,6 @@
         "morgan": "1.10.0",
         "winston": "3.3.3",
         "ws": "8.18.1"
-      }
-    },
-    "node_modules/bfx-report-express/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bfx-report-express/node_modules/grenache-nodejs-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-1.0.0.tgz",
-      "integrity": "sha512-SHjd/CRckIPIx2oqqubjKx3E8G6KmaX/nn0ZmYe5A+Yp4s+d6X9ew8F9FcECcgNTTvaOLpkI0/7xePmKC3GrOw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#v1.20.0",
-        "async": "3.2.6",
-        "duplexify": "4.1.3",
-        "pump": "3.0.2",
-        "uuid": "11.1.0"
-      }
-    },
-    "node_modules/bfx-report-express/node_modules/grenache-nodejs-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-http/-/grenache-nodejs-http-1.0.1.tgz",
-      "integrity": "sha512-SLqq6eHTvAQzrSWUw1ExpFlkkUN2wXSKUnor1df/i2a3SeCcWeM1AJfO1DsK0DrJ9xARUISQA6yDFdDxaQjOXw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "3.2.6",
-        "duplexify": "4.1.3",
-        "grenache-nodejs-base": "1.0.0",
-        "grenache-nodejs-link": "1.0.2",
-        "node-fetch": "2.7.0",
-        "pump": "3.0.2"
-      },
-      "engines": {
-        "node": ">=16.0"
-      }
-    },
-    "node_modules/bfx-report-express/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/bfx-report-express/node_modules/ws": {
@@ -1859,11 +1789,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-    },
     "node_modules/cbq": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/cbq/-/cbq-0.0.1.tgz",
@@ -2110,6 +2035,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2378,17 +2304,6 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -2564,6 +2479,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2678,20 +2594,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/ecc-jsbn/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3583,11 +3485,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3607,14 +3504,6 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3628,7 +3517,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3807,36 +3697,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
       },
       "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
-      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
-      "dev": true,
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
-        "once": "^1.4.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -4028,14 +3901,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -4205,42 +4070,59 @@
       }
     },
     "node_modules/grenache-nodejs-base": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-0.7.5.tgz",
-      "integrity": "sha512-UmGj6c/MUPVXM7G8QEKBNQahydFRN87Vdi5BgEgjv5E3eEpkq6i8PLXblEpuATS82GTMj2FxXzpKXWvARsbfLw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-1.0.0.tgz",
+      "integrity": "sha512-SHjd/CRckIPIx2oqqubjKx3E8G6KmaX/nn0ZmYe5A+Yp4s+d6X9ew8F9FcECcgNTTvaOLpkI0/7xePmKC3GrOw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.4",
-        "duplexify": "^4.1.2",
-        "lodash": "^4.17.21",
-        "pump": "^3.0.0",
-        "uuid": "^9.0.0"
+        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#v1.20.0",
+        "async": "3.2.6",
+        "duplexify": "4.1.3",
+        "pump": "3.0.2",
+        "uuid": "11.1.0"
+      }
+    },
+    "node_modules/grenache-nodejs-base/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/grenache-nodejs-base/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/grenache-nodejs-http": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-http/-/grenache-nodejs-http-0.7.13.tgz",
-      "integrity": "sha512-SuOUCQrZhECN9vLGQzpKzNzPSQqkXipw9UhwTp5Uttb33v756lI5I2GV4+hehcaWENtt6csYIK9rSP5TeWtv2g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-http/-/grenache-nodejs-http-1.0.1.tgz",
+      "integrity": "sha512-SLqq6eHTvAQzrSWUw1ExpFlkkUN2wXSKUnor1df/i2a3SeCcWeM1AJfO1DsK0DrJ9xARUISQA6yDFdDxaQjOXw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.4",
-        "grenache-nodejs-base": "^0.7.5",
-        "grenache-nodejs-link": "^0.7.13",
-        "lodash": "^4.17.21",
-        "request": "^2.88.0"
+        "async": "3.2.6",
+        "duplexify": "4.1.3",
+        "grenache-nodejs-base": "1.0.0",
+        "grenache-nodejs-link": "1.0.2",
+        "node-fetch": "2.7.0",
+        "pump": "3.0.2"
+      },
+      "engines": {
+        "node": ">=16.0"
       }
     },
-    "node_modules/grenache-nodejs-http/node_modules/grenache-nodejs-link": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-0.7.13.tgz",
-      "integrity": "sha512-BogCPtI2hBpn43by5YW+dQZCuVDdQWnxr8LI2hvhQ+jhquKzYGtBjLdo+gbEJb0LulD5ZsCXCEo71pPMmTG9CA==",
-      "dependencies": {
-        "async": "^3.2.4",
-        "bencode": "^2.0.3",
-        "cbq": "0.0.1",
-        "lodash": "^4.17.21",
-        "lru": "^3.1.0",
-        "request": "^2.88.0",
-        "uuid": "^9.0.0"
-      }
+    "node_modules/grenache-nodejs-http/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/grenache-nodejs-link": {
       "version": "1.0.2",
@@ -4289,25 +4171,6 @@
         "node": ">=16.0"
       }
     },
-    "node_modules/grenache-nodejs-ws/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
-    "node_modules/grenache-nodejs-ws/node_modules/grenache-nodejs-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-1.0.0.tgz",
-      "integrity": "sha512-SHjd/CRckIPIx2oqqubjKx3E8G6KmaX/nn0ZmYe5A+Yp4s+d6X9ew8F9FcECcgNTTvaOLpkI0/7xePmKC3GrOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#v1.20.0",
-        "async": "3.2.6",
-        "duplexify": "4.1.3",
-        "pump": "3.0.2",
-        "uuid": "11.1.0"
-      }
-    },
     "node_modules/grenache-nodejs-ws/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -4320,47 +4183,6 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4454,15 +4276,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/hexoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
-      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4489,20 +4302,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5077,11 +4876,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -5148,11 +4942,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -5229,11 +5018,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -5245,11 +5029,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5260,20 +5039,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jstransformer": {
@@ -5708,6 +5473,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5716,6 +5482,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6098,14 +5865,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6474,11 +6233,6 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6710,17 +6464,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
-    },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -7128,54 +6871,6 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7378,7 +7073,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -7751,35 +7447,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sshpk/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -8161,9 +7828,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -8245,18 +7913,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -8306,11 +7962,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8526,19 +8177,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/void-elements": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bitfinexcom/lib-js-util-base": {
+      "version": "1.20.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/lib-js-util-base.git#c71422aea971508f6a605ac12a56bde4425f0d3b",
+      "license": "MIT"
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -4168,51 +4173,63 @@
       }
     },
     "node_modules/grenache-nodejs-ws": {
-      "version": "0.7.10",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/grenache-nodejs-ws.git#72ab3b983607e14bc2ad87788102d97fbcc8a1dc",
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/grenache-nodejs-ws.git#7b12c0b450fa44f2502ae1d21770186b273bbecc",
       "license": "Apache-2.0",
       "dependencies": {
         "cbq": "0.0.1",
-        "grenache-nodejs-base": "^0.7.4",
-        "grenache-nodejs-link": "^0.7.12",
-        "lodash": "^4.17.21",
-        "uuid": "^3.0.1",
-        "ws": "^7.5.5"
+        "grenache-nodejs-base": "1.0.0",
+        "grenache-nodejs-link": "1.0.2",
+        "uuid": "11.1.0",
+        "ws": "7.5.10"
+      },
+      "engines": {
+        "node": ">=16.0"
+      }
+    },
+    "node_modules/grenache-nodejs-ws/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/grenache-nodejs-ws/node_modules/grenache-nodejs-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-1.0.0.tgz",
+      "integrity": "sha512-SHjd/CRckIPIx2oqqubjKx3E8G6KmaX/nn0ZmYe5A+Yp4s+d6X9ew8F9FcECcgNTTvaOLpkI0/7xePmKC3GrOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#v1.20.0",
+        "async": "3.2.6",
+        "duplexify": "4.1.3",
+        "pump": "3.0.2",
+        "uuid": "11.1.0"
       }
     },
     "node_modules/grenache-nodejs-ws/node_modules/grenache-nodejs-link": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-0.7.13.tgz",
-      "integrity": "sha512-BogCPtI2hBpn43by5YW+dQZCuVDdQWnxr8LI2hvhQ+jhquKzYGtBjLdo+gbEJb0LulD5ZsCXCEo71pPMmTG9CA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-1.0.2.tgz",
+      "integrity": "sha512-f7A6+xyJ5Rx5WjTOxLawF0g5JzVZcsymIP9wCF9DjP10fxhWgk83xEdMOSp01IJFOdZkDrnL5PkQhdc5V+Xm9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.4",
-        "bencode": "^2.0.3",
+        "async": "3.2.6",
         "cbq": "0.0.1",
-        "lodash": "^4.17.21",
-        "lru": "^3.1.0",
-        "request": "^2.88.0",
-        "uuid": "^9.0.0"
+        "lru": "3.1.0",
+        "node-fetch": "2.7.0",
+        "uuid": "11.1.0"
       }
     },
-    "node_modules/grenache-nodejs-ws/node_modules/grenache-nodejs-link/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+    "node_modules/grenache-nodejs-ws/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/grenache-nodejs-ws/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/har-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1394,8 +1394,8 @@
       }
     },
     "node_modules/bfx-report": {
-      "version": "4.12.3",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report.git#f5be5d10ee943a07f87e4097a0e5587d46134efb",
+      "version": "4.12.4",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report.git#b1dc63bdf548819f5fe407cd1f4d11cd447609e1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,8 +1428,8 @@
       }
     },
     "node_modules/bfx-report-express": {
-      "version": "2.0.7",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report-express.git#26c2113d9c51f2bccbcdc3b624fa7168440e5ecc",
+      "version": "2.0.8",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-report-express.git#96b392dd8cc48a5cee6cc2d6b887686934e4b423",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1439,12 +1439,65 @@
         "cors": "2.8.5",
         "debug": "4.4.0",
         "express": "4.21.2",
-        "grenache-nodejs-http": "0.7.13",
-        "grenache-nodejs-link": "1.0.0",
-        "grenache-nodejs-ws": "git+https://github.com:bitfinexcom/grenache-nodejs-ws.git",
+        "grenache-nodejs-http": "1.0.1",
+        "grenache-nodejs-link": "1.0.2",
+        "grenache-nodejs-ws": "1.0.0",
         "morgan": "1.10.0",
         "winston": "3.3.3",
         "ws": "8.18.1"
+      }
+    },
+    "node_modules/bfx-report-express/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bfx-report-express/node_modules/grenache-nodejs-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-base/-/grenache-nodejs-base-1.0.0.tgz",
+      "integrity": "sha512-SHjd/CRckIPIx2oqqubjKx3E8G6KmaX/nn0ZmYe5A+Yp4s+d6X9ew8F9FcECcgNTTvaOLpkI0/7xePmKC3GrOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bitfinexcom/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git#v1.20.0",
+        "async": "3.2.6",
+        "duplexify": "4.1.3",
+        "pump": "3.0.2",
+        "uuid": "11.1.0"
+      }
+    },
+    "node_modules/bfx-report-express/node_modules/grenache-nodejs-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-http/-/grenache-nodejs-http-1.0.1.tgz",
+      "integrity": "sha512-SLqq6eHTvAQzrSWUw1ExpFlkkUN2wXSKUnor1df/i2a3SeCcWeM1AJfO1DsK0DrJ9xARUISQA6yDFdDxaQjOXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "3.2.6",
+        "duplexify": "4.1.3",
+        "grenache-nodejs-base": "1.0.0",
+        "grenache-nodejs-link": "1.0.2",
+        "node-fetch": "2.7.0",
+        "pump": "3.0.2"
+      },
+      "engines": {
+        "node": ">=16.0"
+      }
+    },
+    "node_modules/bfx-report-express/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/bfx-report-express/node_modules/ws": {
@@ -4190,17 +4243,35 @@
       }
     },
     "node_modules/grenache-nodejs-link": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-1.0.0.tgz",
-      "integrity": "sha512-TONPQ39L9sz4DSIR+LwPEWLvNvmNOZC2bNHxRrH4DM8cM06Qy/Q3rKQHXP1zqna9/pcuzRTLHOPTIgzeFDgdng==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-1.0.2.tgz",
+      "integrity": "sha512-f7A6+xyJ5Rx5WjTOxLawF0g5JzVZcsymIP9wCF9DjP10fxhWgk83xEdMOSp01IJFOdZkDrnL5PkQhdc5V+Xm9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "async": "^3.2.4",
+        "async": "3.2.6",
         "cbq": "0.0.1",
-        "lodash": "^4.17.21",
-        "lru": "^3.1.0",
-        "request": "^2.88.0",
-        "uuid": "^9.0.0"
+        "lru": "3.1.0",
+        "node-fetch": "2.7.0",
+        "uuid": "11.1.0"
+      }
+    },
+    "node_modules/grenache-nodejs-link/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/grenache-nodejs-link/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/grenache-nodejs-ws": {
@@ -4234,19 +4305,6 @@
         "async": "3.2.6",
         "duplexify": "4.1.3",
         "pump": "3.0.2",
-        "uuid": "11.1.0"
-      }
-    },
-    "node_modules/grenache-nodejs-ws/node_modules/grenache-nodejs-link": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grenache-nodejs-link/-/grenache-nodejs-link-1.0.2.tgz",
-      "integrity": "sha512-f7A6+xyJ5Rx5WjTOxLawF0g5JzVZcsymIP9wCF9DjP10fxhWgk83xEdMOSp01IJFOdZkDrnL5PkQhdc5V+Xm9w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "3.2.6",
-        "cbq": "0.0.1",
-        "lru": "3.1.0",
-        "node-fetch": "2.7.0",
         "uuid": "11.1.0"
       }
     },


### PR DESCRIPTION
This PR updates `Grenache` dependencies due to the last Grenache updates (removed unsupported `request` lib)

---

Basic changes:
- Updates `grenache-nodejs-ws`
- Updates `lib-js-util-base`
- Updates `grenache-grape`
- Updates `bfx-report-express`, https://github.com/bitfinexcom/bfx-report-express/pull/49
- Updates `grenache-cli` for docker container
- Updates `bfx-report`, https://github.com/bitfinexcom/bfx-report/pull/435
- Fixes high severity vulnerabilities by `npm audit`
