### PR TITLE
Fix symbols/pairs duplication

### DIFF
--- a/workers/loc.api/sync/dao/dao.better.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.better.sqlite.js
@@ -34,6 +34,10 @@ const {
 } = require('./helpers')
 
 const {
+  isUpdatable
+} = require('../schema/utils')
+
+const {
   DbVersionTypeError,
   SqlCorrectnessError,
   UpdateRecordError,
@@ -511,6 +515,7 @@ class BetterSqliteDAO extends DAO {
     }
 
     await this._beginTrans(async () => {
+      const methodCollMap = [...this._getMethodCollMap()]
       const tableNames = await this.getTablesNames({ doNotQueueQuery })
       const filteredTempTableNames = tableNames.filter((name) => (
         name.includes(namePrefix)
@@ -524,11 +529,19 @@ class BetterSqliteDAO extends DAO {
           continue
         }
 
+        const syncSchema = methodCollMap.find(([key, schema]) => (
+          schema.getModelField('NAME') === name
+        ))?.[1]
+        const type = syncSchema?.getModelField('TYPE') ?? ''
+
         const projection = model.getModelFieldKeys()
           .filter((fieldName) => fieldName !== Model.UID_FIELD_NAME)
           .join(', ')
 
-        if (isStrictEqual) {
+        if (
+          isStrictEqual ||
+          isUpdatable(type)
+        ) {
           await this.query({
             action: MAIN_DB_WORKER_ACTIONS.RUN,
             sql: `DELETE FROM ${name}`


### PR DESCRIPTION
This PR fixes symbols/pairs duplication. When sync data is moved from the temp tables to the main ones it's needed to remove previous data for the updatable collections such as symbols, etc to prevent deleted currencies from getting stuck
