### PR TITLE
Add summary statistics info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "inversify": "6.0.1",
         "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
         "lodash": "4.17.21",
+        "mathjs": "14.8.1",
         "moment": "2.29.4",
         "puppeteer": "24.1.0",
         "uuid": "9.0.0",
@@ -2067,6 +2068,19 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "node_modules/complex.js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -2409,6 +2423,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -2847,6 +2867,12 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3757,6 +3783,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -5010,6 +5049,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "license": "MIT"
+    },
     "node_modules/js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
@@ -5464,6 +5509,29 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "14.8.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.8.1.tgz",
+      "integrity": "sha512-7UDitJFsXoPbFdK2V7S6uJp7krx9B5bQSzAvCnh7ecsceSK4w0PBbEt9B3IRg9lHqzjk3YJNT1fZg/BNK+4CQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {
@@ -7114,6 +7182,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -7916,6 +7990,12 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8118,6 +8198,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/typed-query-selector": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "inversify": "6.0.1",
     "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "lodash": "4.17.21",
+    "mathjs": "14.8.1",
     "moment": "2.29.4",
     "puppeteer": "24.1.0",
     "uuid": "9.0.0",

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -821,7 +821,12 @@ module.exports = (
       'volumeUsd',
       'tradingFeesUsd',
       'allFeesUsd',
-      'depositsWithdrawalsUsd'
+      'depositsWithdrawalsUsd',
+      'plUsd',
+      'volatilityPerc',
+      'sharpeRatio',
+      'sortinoRatio',
+      'maxDrawdownPerc'
     ])
   })
 
@@ -870,7 +875,12 @@ module.exports = (
       'volumeUsd',
       'tradingFeesUsd',
       'allFeesUsd',
-      'depositsWithdrawalsUsd'
+      'depositsWithdrawalsUsd',
+      'plUsd',
+      'volatilityPerc',
+      'sharpeRatio',
+      'sortinoRatio',
+      'maxDrawdownPerc'
     ])
   })
 

--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -819,7 +819,9 @@ module.exports = (
       'balanceChangeUsd',
       'balanceChangePerc',
       'volumeUsd',
-      'tradingFeesUsd'
+      'tradingFeesUsd',
+      'allFeesUsd',
+      'depositsWithdrawalsUsd'
     ])
   })
 
@@ -866,7 +868,9 @@ module.exports = (
       'balanceChangeUsd',
       'balanceChangePerc',
       'volumeUsd',
-      'tradingFeesUsd'
+      'tradingFeesUsd',
+      'allFeesUsd',
+      'depositsWithdrawalsUsd'
     ])
   })
 

--- a/workers/loc.api/data-validator/schemas/getSummaryByAssetReq.js
+++ b/workers/loc.api/data-validator/schemas/getSummaryByAssetReq.js
@@ -12,6 +12,9 @@ module.exports = {
     },
     end: {
       $ref: 'defs#/definitions/end'
+    },
+    isUnrealizedProfitExcluded: {
+      $ref: 'fwDefs#/definitions/isUnrealizedProfitExcluded'
     }
   }
 }

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -181,6 +181,7 @@ class Checkers {
         auth,
         params: {
           schema: [
+            this.SYNC_API_METHODS.TRADES,
             this.SYNC_API_METHODS.LEDGERS,
             this.SYNC_API_METHODS.CANDLES,
             this.SYNC_API_METHODS.MOVEMENTS

--- a/workers/loc.api/sync/data.consistency.checker/checkers.js
+++ b/workers/loc.api/sync/data.consistency.checker/checkers.js
@@ -184,7 +184,9 @@ class Checkers {
             this.SYNC_API_METHODS.TRADES,
             this.SYNC_API_METHODS.LEDGERS,
             this.SYNC_API_METHODS.CANDLES,
-            this.SYNC_API_METHODS.MOVEMENTS
+            this.SYNC_API_METHODS.MOVEMENTS,
+            this.SYNC_API_METHODS.POSITIONS_SNAPSHOT,
+            this.SYNC_API_METHODS.POSITIONS_HISTORY
           ]
         }
       })

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -297,6 +297,7 @@ class SummaryByAsset {
       balanceChangePerc: 0,
       volumeUsd: 0,
       tradingFeesUsd: 0,
+      allFeesUsd: 0,
 
       calcedStartWalletBalanceUsd: 0
     }
@@ -310,6 +311,7 @@ class SummaryByAsset {
           'balanceChangeUsd',
           'volumeUsd',
           'tradingFeesUsd',
+          'allFeesUsd',
 
           'calcedStartWalletBalanceUsd'
         ]

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -351,7 +351,9 @@ class SummaryByAsset {
     )
     const plUsd = this.#calcPLUsd(dailyBalancesAndPL)
     const returns = this.#getDailyReturns(dailyBalancesAndPL)
-    const volatilityPerc = this.#calcVolatilityPerc(returns)
+    const {
+      volatilityPerc
+    } = this.#calcDailyReturnStatistics(returns)
 
     const initTotal = {
       balanceUsd: 0,
@@ -461,8 +463,14 @@ class SummaryByAsset {
     return dailyBalancesAndPL.map((item) => item?.returns)
   }
 
-  #calcVolatilityPerc (dailyReturns) {
-    return math.std(dailyReturns) * Math.sqrt(365) * 100
+  #calcDailyReturnStatistics (dailyReturns) {
+    const returnsStd = math.std(dailyReturns)
+
+    const volatilityPerc = returnsStd * Math.sqrt(365) * 100
+
+    return {
+      volatilityPerc
+    }
   }
 }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -104,7 +104,6 @@ class SummaryByAsset {
           timeframe: 'day',
           isUnrealizedProfitExcluded: args?.params
             ?.isUnrealizedProfitExcluded,
-          isVSPrevDayBalance: true,
           shouldTimeframePLBeReturned: true
         }
       })
@@ -126,7 +125,6 @@ class SummaryByAsset {
       depositsPromise,
       dailyBalancesAndPLPromise
     ])
-    console.log('[dailyBalancesAndPL]:', dailyBalancesAndPL)
 
     const _summaryByAsset = await this.#calcSummaryByAsset({
       trades,

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -124,7 +124,8 @@ class SummaryByAsset {
       omit(item, [
         'balanceChangeUsd',
         'tradingFeesUsd',
-        'calcedStartWalletBalanceUsd'
+        'calcedStartWalletBalanceUsd',
+        'allFeesUsd'
       ])
     ))
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -2,6 +2,7 @@
 
 const { omit } = require('lib-js-util-base')
 const moment = require('moment')
+const math = require('mathjs')
 
 const { pushLargeArr } = require('../../helpers/utils')
 
@@ -350,6 +351,7 @@ class SummaryByAsset {
     )
     const plUsd = this.#calcPLUsd(dailyBalancesAndPL)
     const returns = this.#getDailyReturns(dailyBalancesAndPL)
+    const volatilityPerc = this.#calcVolatilityPerc(returns)
 
     const initTotal = {
       balanceUsd: 0,
@@ -365,7 +367,8 @@ class SummaryByAsset {
         calcedWithdrawalsUsd +
         calcedDepositsUsd
       ),
-      plUsd
+      plUsd,
+      volatilityPerc
     }
 
     const res = summaryByAsset.reduce((accum, curr) => {
@@ -456,6 +459,10 @@ class SummaryByAsset {
     }
 
     return dailyBalancesAndPL.map((item) => item?.returns)
+  }
+
+  #calcVolatilityPerc (dailyReturns) {
+    return math.std(dailyReturns) * Math.sqrt(365) * 100
   }
 }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -352,7 +352,8 @@ class SummaryByAsset {
     const plUsd = this.#calcPLUsd(dailyBalancesAndPL)
     const returns = this.#getDailyReturns(dailyBalancesAndPL)
     const {
-      volatilityPerc
+      volatilityPerc,
+      sharpeRatio
     } = this.#calcDailyReturnStatistics(returns)
 
     const initTotal = {
@@ -370,7 +371,8 @@ class SummaryByAsset {
         calcedDepositsUsd
       ),
       plUsd,
-      volatilityPerc
+      volatilityPerc,
+      sharpeRatio
     }
 
     const res = summaryByAsset.reduce((accum, curr) => {
@@ -464,12 +466,16 @@ class SummaryByAsset {
   }
 
   #calcDailyReturnStatistics (dailyReturns) {
-    const returnsStd = math.std(dailyReturns)
+    const returnStd = math.std(dailyReturns)
+    const avgReturn = math.mean(dailyReturns)
+    const sqrt365 = Math.sqrt(365)
 
-    const volatilityPerc = returnsStd * Math.sqrt(365) * 100
+    const volatilityPerc = returnStd * sqrt365 * 100
+    const sharpeRatio = (avgReturn / returnStd) * sqrt365
 
     return {
-      volatilityPerc
+      volatilityPerc,
+      sharpeRatio
     }
   }
 }

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -353,7 +353,8 @@ class SummaryByAsset {
     const returns = this.#getDailyReturns(dailyBalancesAndPL)
     const {
       volatilityPerc,
-      sharpeRatio
+      sharpeRatio,
+      sortinoRatio
     } = this.#calcDailyReturnStatistics(returns)
 
     const initTotal = {
@@ -372,7 +373,8 @@ class SummaryByAsset {
       ),
       plUsd,
       volatilityPerc,
-      sharpeRatio
+      sharpeRatio,
+      sortinoRatio
     }
 
     const res = summaryByAsset.reduce((accum, curr) => {
@@ -473,9 +475,16 @@ class SummaryByAsset {
     const volatilityPerc = returnStd * sqrt365 * 100
     const sharpeRatio = (avgReturn / returnStd) * sqrt365
 
+    const negativeReturns = dailyReturns.filter((r) => r < 0)
+    const downsideStd = negativeReturns.length > 0
+      ? math.std(negativeReturns)
+      : 0.00001
+    const sortinoRatio = (avgReturn / downsideStd) * sqrt365
+
     return {
       volatilityPerc,
-      sharpeRatio
+      sharpeRatio,
+      sortinoRatio
     }
   }
 }

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -161,6 +161,7 @@ class SummaryByAsset {
         ? 1
         : calcedActualRate
 
+      // TODO:
       const ledgersForCurrency = ledgers.filter((ledger) => (
         ledger[this.ledgersSymbolFieldName] === currency
       ))
@@ -317,6 +318,39 @@ class SummaryByAsset {
         ? accum[propName] + curr[propName]
         : accum[propName]
     }
+  }
+
+  #makeLedgerMapFilteredByCcyGroupedByCategory (
+    ledgers, ccy, categories
+  ) {
+    const ledgerMap = new Map()
+
+    if (
+      !Array.isArray(categories) ||
+      categories.length === 0
+    ) {
+      return ledgerMap
+    }
+
+    for (const category of categories) {
+      ledgerMap.set(category, [])
+    }
+
+    for (const ledger of ledgers) {
+      if (ledger?.[this.ledgersSymbolFieldName] !== ccy) {
+        continue
+      }
+
+      for (const [category, arr] of ledgerMap) {
+        if (ledger?._category !== category) {
+          continue
+        }
+
+        arr.push(ledger)
+      }
+    }
+
+    return ledgerMap
   }
 }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -349,6 +349,7 @@ class SummaryByAsset {
       'amountUsd'
     )
     const plUsd = this.#calcPLUsd(dailyBalancesAndPL)
+    const returns = this.#getDailyReturns(dailyBalancesAndPL)
 
     const initTotal = {
       balanceUsd: 0,
@@ -447,6 +448,14 @@ class SummaryByAsset {
       ?.balanceWithoutMovementsUsd ?? 0
 
     return lastBalance - firstBalance
+  }
+
+  #getDailyReturns (dailyBalancesAndPL) {
+    if (!Array.isArray(dailyBalancesAndPL)) {
+      return []
+    }
+
+    return dailyBalancesAndPL.map((item) => item?.returns)
   }
 }
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -476,13 +476,17 @@ class SummaryByAsset {
     const sqrt365 = Math.sqrt(365)
 
     const volatilityPerc = returnStd * sqrt365 * 100
-    const sharpeRatio = (avgReturn / returnStd) * sqrt365
+    const sharpeRatio = returnStd !== 0
+      ? (avgReturn / returnStd) * sqrt365
+      : 0
 
     const negativeReturns = dailyReturns.filter((r) => r < 0)
     const downsideStd = negativeReturns.length > 0
       ? math.std(negativeReturns)
       : 0.00001
-    const sortinoRatio = (avgReturn / downsideStd) * sqrt365
+    const sortinoRatio = downsideStd !== 0
+      ? (avgReturn / downsideStd) * sqrt365
+      : 0
 
     return {
       volatilityPerc,

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -438,17 +438,14 @@ class SummaryByAsset {
     }
 
     for (const ledger of ledgers) {
-      if (ledger?.[this.ledgersSymbolFieldName] !== ccy) {
+      if (
+        ledger?.[this.ledgersSymbolFieldName] !== ccy ||
+        !ledgerMap.has(ledger?._category)
+      ) {
         continue
       }
 
-      for (const [category, arr] of ledgerMap) {
-        if (ledger?._category !== category) {
-          continue
-        }
-
-        arr.push(ledger)
-      }
+      ledgerMap.get(ledger?._category).push(ledger)
     }
 
     return ledgerMap

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -21,8 +21,14 @@ const depsTypes = (TYPES) => [
   TYPES.WinLossVSAccountBalance
 ]
 class SummaryByAsset {
-  #ledgerFeeCats = [201, 204, 207, 222, 224, 228, 241,
-    243, 251, 254, 255, 258, 905]
+  #ledgerMarginFundingPaymentCat = 28
+  #ledgerTradingFeeCat = 201
+
+  #ledgerFeeCats = [this.#ledgerTradingFeeCat, 204, 207, 222, 224,
+    228, 241, 243, 251, 254, 255, 258, 905]
+
+  #allUsedLedgerCats = [this.#ledgerMarginFundingPaymentCat,
+    ...this.#ledgerFeeCats]
 
   constructor (
     dao,
@@ -215,13 +221,15 @@ class SummaryByAsset {
       const ledgerMap = this.#makeLedgerMapFilteredByCcyGroupedByCategory(
         ledgers,
         currency,
-        [28, ...this.#ledgerFeeCats]
+        this.#allUsedLedgerCats
       )
       const tradesForCurrency = trades.filter((trade) => (
         trade?.baseCurrency === currency
       ))
-      const marginFundingPaymentLedgers = ledgerMap.get(28) ?? []
-      const tradingFeeLedgers = ledgerMap.get(201) ?? []
+      const marginFundingPaymentLedgers = ledgerMap
+        .get(this.#ledgerMarginFundingPaymentCat) ?? []
+      const tradingFeeLedgers = ledgerMap
+        .get(this.#ledgerTradingFeeCat) ?? []
       const allFeeLedgers = this.#ledgerFeeCats.reduce((accum, cat) => {
         pushLargeArr(accum, ledgerMap.get(cat) ?? [])
 

--- a/workers/loc.api/sync/summary.by.asset/index.js
+++ b/workers/loc.api/sync/summary.by.asset/index.js
@@ -14,7 +14,8 @@ const depsTypes = (TYPES) => [
   TYPES.SYNC_API_METHODS,
   TYPES.ALLOWED_COLLS,
   TYPES.Wallets,
-  TYPES.Trades
+  TYPES.Trades,
+  TYPES.Movements
 ]
 class SummaryByAsset {
   #ledgerFeeCats = [201, 204, 207, 222, 224, 228, 241,
@@ -27,7 +28,8 @@ class SummaryByAsset {
     SYNC_API_METHODS,
     ALLOWED_COLLS,
     wallets,
-    trades
+    trades,
+    movements
   ) {
     this.dao = dao
     this.syncSchema = syncSchema
@@ -36,6 +38,7 @@ class SummaryByAsset {
     this.ALLOWED_COLLS = ALLOWED_COLLS
     this.wallets = wallets
     this.trades = trades
+    this.movements = movements
 
     this.ledgersMethodColl = this.syncSchema.getMethodCollMap()
       .get(this.SYNC_API_METHODS.LEDGERS)

--- a/workers/loc.api/sync/win.loss.vs.account.balance/index.js
+++ b/workers/loc.api/sync/win.loss.vs.account.balance/index.js
@@ -58,7 +58,10 @@ class WinLossVSAccountBalance {
       plGroupedByTimeframe
     } = await this.winLoss.getDataToCalcWinLoss(args)
 
-    const getWinLossPercByTimeframe = isVSPrevDayBalance
+    const getWinLossPercByTimeframe = (
+      isVSPrevDayBalance ||
+      shouldTimeframePLBeReturned
+    )
       ? this._getWinLossPrevDayBalanceByTimeframe(
         {
           shouldTimeframePLBeReturned,
@@ -99,10 +102,14 @@ class WinLossVSAccountBalance {
 
           return res
         })
-    pickedRes.push({
-      mts: start,
-      perc: 0
-    })
+
+    if (!shouldTimeframePLBeReturned) {
+      pickedRes.push({
+        mts: start,
+        perc: 0
+      })
+    }
+
     const res = this.winLoss.shiftMtsToNextTimeframe(
       pickedRes,
       { timeframe, end }

--- a/workers/loc.api/sync/win.loss.vs.account.balance/index.js
+++ b/workers/loc.api/sync/win.loss.vs.account.balance/index.js
@@ -253,9 +253,12 @@ class WinLossVSAccountBalance {
         : pl - prevPL
 
       const winLoss = realized + unrealized
-      const balanceWithoutMovements = wallets - totalMovements
 
-      prevWallets = wallets
+      const balanceWithoutMovements = wallets - totalMovements
+      const fullBalanceWithoutMovements = isUnrealizedProfitExcluded
+        ? balanceWithoutMovements
+        : balanceWithoutMovements + pl
+
       prevPL = pl
 
       if (
@@ -264,10 +267,8 @@ class WinLossVSAccountBalance {
       ) {
         if (shouldTimeframePLBeReturned) {
           return {
-            balanceWithoutMovements,
-            pl: Number.isFinite(winLoss)
-              ? winLoss
-              : 0,
+            balanceWithoutMovementsUsd: fullBalanceWithoutMovements,
+            returns: 0,
             perc: prevPerc
           }
         }
@@ -277,15 +278,16 @@ class WinLossVSAccountBalance {
 
       prevMultiplying = ((prevWallets + winLoss) / prevWallets) * prevMultiplying
       const perc = (prevMultiplying - 1) * 100
+      const returns = winLoss / prevWallets
+
       prevPerc = perc
+      prevWallets = wallets
 
       if (shouldTimeframePLBeReturned) {
         return {
-          balanceWithoutMovements,
-          pl: Number.isFinite(winLoss)
-            ? winLoss
-            : 0,
-          perc: prevPerc
+          balanceWithoutMovementsUsd: fullBalanceWithoutMovements,
+          returns,
+          perc
         }
       }
 

--- a/workers/loc.api/sync/win.loss/index.js
+++ b/workers/loc.api/sync/win.loss/index.js
@@ -12,7 +12,6 @@ const {
 const { decorateInjectable } = require('../../di/utils')
 
 const depsTypes = (TYPES) => [
-  TYPES.DAO,
   TYPES.SyncSchema,
   TYPES.BalanceHistory,
   TYPES.PositionsSnapshot,
@@ -24,7 +23,6 @@ const depsTypes = (TYPES) => [
 ]
 class WinLoss {
   constructor (
-    dao,
     syncSchema,
     balanceHistory,
     positionsSnapshot,
@@ -34,7 +32,6 @@ class WinLoss {
     movements,
     wallets
   ) {
-    this.dao = dao
     this.syncSchema = syncSchema
     this.balanceHistory = balanceHistory
     this.positionsSnapshot = positionsSnapshot


### PR DESCRIPTION
This PR adds summary `statistics` info into `getSummaryByAsset` endpoint

---

Basic changes:
- adds `allFeesUsd` taken from the ledgers with `201, 204, 207, 222, 224,
    228, 241, 243, 251, 254, 255, 258, 905` categories  to be used in UI as `Fees occurred` field
- adds `depositsWithdrawalsUsd` to be used in UI as `Deposits/Withdrawals` field
- adds `plUsd` to be used in UI as `Profit` field
- adds `volatilityPerc` to be used in UI as `Volatility` field
- adds `sharpeRatio` to be used in UI as `Sharpe Ratio` field
- adds `sortinoRatio` to be used in UI as `Sortino Ratio` field
- adds `maxDrawdownPerc` to be used in UI as `Max Drawdown` field
- adds support for `isUnrealizedProfitExcluded` flag, it's the same flag that we use for `Account Balance` and `Profits` charts
- adds the corresponding test coverage

Also for the `Balance` and `Volume` fields of the statistics can be used the already done response of the same `getSummaryByAsset` endpoint:
- `volumeUsd`
- `balanceUsd`

---

Request example:
```jsonc
{
  "auth": {
    "token": "auth-token"
  },
  "method": "getSummaryByAsset",
  "params": {
    "start": 1727775188000,
    "end": 1759397588266,
    "isUnrealizedProfitExcluded": true // or false, the same flag that we use for `Account Balance` and `Profits` charts
  }
}
```

Response example:
```jsonc
{
    "jsonrpc": "2.0",
    "result": {
        "summaryByAsset": [
            {
                "currency": "LEO",
                "balance": 1.23,
                "balanceUsd": 32.1,
                "balanceChange": 0,
                "balanceChangePerc": 0,
                "volume": 0,
                "volumeUsd": 0,
                "tradingFees": 0,
                "marginFundingPayment": 0
            },
            // ...
        ],
        "total": {
            "balanceUsd": 32.1,
            "balanceChangeUsd": 32.1,
            "balanceChangePerc": 1.23,
            "volumeUsd": 32.1,
            "tradingFeesUsd": 1.23,
            "allFeesUsd": 12.3,
            "depositsWithdrawalsUsd": -12.3,
            "plUsd": 12.3,
            "volatilityPerc": 12.3,
            "sharpeRatio": 1.23,
            "sortinoRatio": 1.23,
            "maxDrawdownPerc": 12.3
        }
    },
    "id": null
}
```
