### PR TITLE
Update gh actions to resolve: nodejs v20 actions are deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Setup configs
@@ -29,18 +29,14 @@ jobs:
           && cp config/facs/grc.config.json.example config/facs/grc.config.json \
           && cp config/facs/grc-slack.config.json.example config/facs/grc-slack.config.json
     - name: Install deps
-      run: npm i
+      run: npm ci
     - name: Run tests
-      uses: nick-fields/retry@v3
-      continue-on-error: false
-      with:
-        timeout_minutes: 20
-        retry_wait_seconds: 10
-        max_attempts: 3
-        retry_on: any
-        command: npm test -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v4
+      run: npm test -- --reporter=json --reporter-option output=test-report.json
+    - uses: actions/upload-artifact@v7.0.0
       if: success() || failure()
       with:
         name: test-results
         path: test-report.json
+  web-page-report:
+    needs: linux-test-runner
+    uses: ./.github/workflows/test-report.yml

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -2,10 +2,7 @@ name: 'Test Report'
 run-name: 'Test Report: Commit ${{ github.sha }}'
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types:
-      - completed
+  workflow_call
 
 permissions:
   contents: read
@@ -18,22 +15,18 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Download test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
-        run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: test-results
         path: test-results
-    - uses: dorny/test-reporter@v1
+    - uses: dorny/test-reporter@v3.0.0
       id: test-results
       with:
         name: Mocha Tests
         path: test-results/test-report.json
         reporter: mocha-json
+        collapsed: never
         # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
         # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
         max-annotations: 0
-    - name: Test Report Summary
-      run: |
-        echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
-        echo "And available at the following [Link](${{ steps.test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY

--- a/package-lock.json
+++ b/package-lock.json
@@ -1404,9 +1404,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1837,9 +1837,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6026,9 +6026,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6711,10 +6711,11 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",


### PR DESCRIPTION
This PR updates GH Actions to resolve GH warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/download-artifact@v4, dorny/test-reporter@v1.8.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24

---

Tested here:
- https://github.com/ZIMkaRU/bfx-reports-framework/actions/runs/24239261023
