### PR TITLE
Remove unused report pgp signature

### DIFF
--- a/workers/loc.api/data-validator/schemas/fwGetCandlesFileReq.js
+++ b/workers/loc.api/data-validator/schemas/fwGetCandlesFileReq.js
@@ -51,9 +51,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getBalanceHistoryFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getBalanceHistoryFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getFullSnapshotReportFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getFullSnapshotReportFileReq.js
@@ -34,9 +34,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getFullTaxReportFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getFullTaxReportFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getPerformingLoanFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getPerformingLoanFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getPositionsSnapshotFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getPositionsSnapshotFileReq.js
@@ -28,9 +28,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getTotalFeesReportFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getTotalFeesReportFileReq.js
@@ -43,9 +43,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getTradedVolumeFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getTradedVolumeFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getTransactionTaxReportFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getTransactionTaxReportFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getWinLossFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getWinLossFileReq.js
@@ -37,9 +37,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getWinLossVSAccountBalanceFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getWinLossVSAccountBalanceFileReq.js
@@ -40,9 +40,6 @@ module.exports = {
     },
     isPDFRequired: {
       $ref: 'defs#/definitions/isPDFRequired'
-    },
-    isSignatureRequired: {
-      $ref: 'defs#/definitions/isSignatureRequired'
     }
   }
 }


### PR DESCRIPTION
This PR removes unused report `PGP` signature since the ability to create a signature for reports was implemented 7 years ago and has still not been merged into the repository: https://github.com/bitfinexcom/bfx-ext-gpg-js/pull/1
And it's time to remove unused part of the codebase

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/472
