### PR TITLE
Implement order by util to remove lodash totally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,9 +1402,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5644,9 +5644,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "csv": "5.5.3",
         "grenache-nodejs-ws": "git+https://github.com/bitfinexcom/grenache-nodejs-ws.git",
         "inversify": "6.0.1",
-        "lodash": "4.17.23",
         "mathjs": "14.8.1",
         "moment": "2.29.4",
         "puppeteer": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "csv": "5.5.3",
     "grenache-nodejs-ws": "git+https://github.com/bitfinexcom/grenache-nodejs-ws.git",
     "inversify": "6.0.1",
-    "lodash": "4.17.23",
     "mathjs": "14.8.1",
     "moment": "2.29.4",
     "puppeteer": "24.1.0",

--- a/workers/loc.api/di/factories/helpers/get-migration-file-metadata.js
+++ b/workers/loc.api/di/factories/helpers/get-migration-file-metadata.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { orderBy } = require('lodash')
+const { orderBy } = require('../../../helpers')
 
 module.exports = (migrationFileDirents) => {
   const metadata = migrationFileDirents.reduce((accum, dirent) => {

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -11,7 +11,8 @@ const {
   sumAllObjectsNumbers,
   pickAllLowerObjectsNumbers,
   sumArrayVolumes,
-  pushLargeArr
+  pushLargeArr,
+  orderBy
 } = require('./utils')
 const {
   isSubAccountApiKeys,
@@ -35,5 +36,6 @@ module.exports = {
   pickAllLowerObjectsNumbers,
   sumArrayVolumes,
   pushLargeArr,
+  orderBy,
   isBfxApiStaging
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -155,36 +155,6 @@ const pickLowerObjectsNumbers = (propName, objects = []) => {
   }, null)
 }
 
-const pickAllLowerObjectsNumbers = (propName, objects = []) => {
-  return objects.reduce((accum, curr) => {
-    if (
-      !curr?.[propName] ||
-      typeof curr?.[propName] !== 'object'
-    ) {
-      return accum
-    }
-
-    const entries = Object.entries(curr[propName])
-
-    return entries.reduce((accum, [key, val]) => {
-      if (!Number.isFinite(val)) {
-        return accum
-      }
-      if (!Number.isFinite(accum?.[key])) {
-        accum[key] = val
-
-        return accum
-      }
-
-      accum[key] = val < accum[key]
-        ? val
-        : accum[key]
-
-      return accum
-    }, accum)
-  }, {})
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -192,6 +162,5 @@ module.exports = {
   getDateString,
   isNotSyncRequired,
   sumObjectsNumbers,
-  pickLowerObjectsNumbers,
-  pickAllLowerObjectsNumbers
+  pickLowerObjectsNumbers
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -185,32 +185,6 @@ const pickAllLowerObjectsNumbers = (propName, objects = []) => {
   }, {})
 }
 
-const sumAllObjectsNumbers = (propName, objects = []) => {
-  return objects.reduce((accum, curr) => {
-    if (
-      !curr?.[propName] ||
-      typeof curr?.[propName] !== 'object'
-    ) {
-      return accum
-    }
-
-    const entries = Object.entries(curr[propName])
-
-    return entries.reduce((accum, [key, val]) => {
-      const prevVal = Number.isFinite(accum?.[key])
-        ? accum[key]
-        : 0
-      const currVal = Number.isFinite(val)
-        ? val
-        : 0
-
-      accum[key] = prevVal + currVal
-
-      return accum
-    }, accum)
-  }, {})
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -219,6 +193,5 @@ module.exports = {
   isNotSyncRequired,
   sumObjectsNumbers,
   pickLowerObjectsNumbers,
-  sumAllObjectsNumbers,
   pickAllLowerObjectsNumbers
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -272,6 +272,58 @@ const pushLargeArr = (dest, src) => {
   }
 }
 
+const _getValue = (obj, path) => {
+  if (typeof path !== 'string') {
+    return obj?.[path]
+  }
+
+  return path.split('.').reduce((accum, key) => accum?.[key], obj)
+}
+
+const orderBy = (collection, iteratees = [], orders = []) => {
+  // It's able to consider iterable objects as well
+  const copiedColl = [...collection]
+
+  return copiedColl.sort((a, b) => {
+    for (const [i, iteratee] of iteratees.entries()) {
+      const direction = orders[i] === 'desc' ? -1 : 1
+
+      const valA = typeof iteratee === 'function'
+        ? iteratee(a)
+        : _getValue(a, iteratee)
+      const valB = typeof iteratee === 'function'
+        ? iteratee(b)
+        : _getValue(b, iteratee)
+
+      if (valA === valB) {
+        continue
+      }
+
+      if (
+        valA === undefined ||
+        valA === null
+      ) {
+        return 1
+      }
+      if (
+        valB === undefined ||
+        valB === null
+      ) {
+        return -1
+      }
+
+      if (valA > valB) {
+        return direction
+      }
+      if (valA < valB) {
+        return -direction
+      }
+    }
+
+    return 0
+  })
+}
+
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -283,5 +335,6 @@ module.exports = {
   sumAllObjectsNumbers,
   pickAllLowerObjectsNumbers,
   sumArrayVolumes,
-  pushLargeArr
+  pushLargeArr,
+  orderBy
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -122,20 +122,9 @@ const getDateString = (mc) => {
   return new Date(mc).toDateString().split(' ').join('-')
 }
 
-const isNotSyncRequired = (args) => {
-  return (
-    args &&
-    typeof args === 'object' &&
-    args.params &&
-    typeof args.params === 'object' &&
-    args.params.isNotSyncRequired
-  )
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
-  getDateString,
-  isNotSyncRequired
+  getDateString
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -28,32 +28,6 @@ const checkParamsAuth = (args) => {
   }
 }
 
-const tryParseJSON = (
-  jsonString,
-  isNotObject
-) => {
-  try {
-    if (typeof jsonString !== 'string') {
-      return false
-    }
-
-    const obj = JSON.parse(jsonString)
-
-    if (
-      isNotObject ||
-      (
-        obj &&
-        typeof obj === 'object'
-      )
-    ) {
-      return obj
-    }
-  } catch (e) { }
-
-  return false
-}
-
 module.exports = {
-  checkParamsAuth,
-  tryParseJSON
+  checkParamsAuth
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -1,15 +1,8 @@
 'use strict'
 
-const { pick } = require('@bitfinex/lib-js-util-base')
-
 const {
   AuthError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
-
-const {
-  isUpdatableArr,
-  isUpdatableArrObj
-} = require('../sync/schema/utils')
 
 const checkParamsAuth = (args) => {
   const {
@@ -60,66 +53,7 @@ const tryParseJSON = (
   return false
 }
 
-const collObjToArr = (coll = [], opts) => {
-  const {
-    projection,
-    type
-  } = opts ?? {}
-  const _projection = Array.isArray(projection)
-    ? projection
-    : [projection]
-  const isProjectionExisted = (
-    _projection[0] &&
-    typeof _projection[0] === 'string'
-  )
-
-  const res = []
-
-  if (isUpdatableArr(type)) {
-    const fieldName = isProjectionExisted
-      ? _projection[0]
-      : null
-
-    for (const obj of coll) {
-      if (
-        !obj ||
-        typeof obj !== 'object'
-      ) {
-        continue
-      }
-
-      const _fieldName = fieldName ?? Object.keys(obj)
-        .filter((key) => key !== '_id')[0]
-
-      if (typeof obj?.[_fieldName] === 'undefined') {
-        continue
-      }
-
-      res.push(obj?.[_fieldName])
-    }
-  }
-  if (isUpdatableArrObj(type)) {
-    if (!isProjectionExisted) {
-      return coll
-    }
-
-    for (const obj of coll) {
-      if (
-        !obj ||
-        typeof obj !== 'object'
-      ) {
-        continue
-      }
-
-      res.push(pick(obj, projection))
-    }
-  }
-
-  return res
-}
-
 module.exports = {
   checkParamsAuth,
-  tryParseJSON,
-  collObjToArr
+  tryParseJSON
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -140,27 +140,11 @@ const sumObjectsNumbers = (propName, objects = []) => {
   }, 0)
 }
 
-const pickLowerObjectsNumbers = (propName, objects = []) => {
-  return objects.reduce((accum, curr) => {
-    if (!Number.isFinite(curr?.[propName])) {
-      return accum
-    }
-    if (!Number.isFinite(accum)) {
-      return curr[propName]
-    }
-
-    return curr[propName] < accum
-      ? curr[propName]
-      : accum
-  }, null)
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
   getDateString,
   isNotSyncRequired,
-  sumObjectsNumbers,
-  pickLowerObjectsNumbers
+  sumObjectsNumbers
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -211,61 +211,6 @@ const sumAllObjectsNumbers = (propName, objects = []) => {
   }, {})
 }
 
-const sumArrayVolumes = (propName, objects = []) => {
-  return objects.reduce((accum, curr) => {
-    if (!Array.isArray(curr?.[propName])) {
-      return accum
-    }
-
-    for (const obj of curr[propName]) {
-      if (typeof obj?.curr !== 'string') {
-        continue
-      }
-
-      const entries = Object.entries(obj)
-        .filter(([key]) => key !== 'curr')
-
-      if (entries.length === 0) {
-        continue
-      }
-
-      if (accum.length === 0) {
-        accum.push({ ...obj })
-
-        continue
-      }
-
-      const accumObjIndex = accum
-        .findIndex((item) => item?.curr === obj.curr)
-
-      if (accumObjIndex === -1) {
-        accum.push({ ...obj })
-
-        continue
-      }
-
-      const resObj = entries.reduce((accum, [key, vol]) => {
-        const accumVol = Number.isFinite(accum?.[key])
-          ? accum[key]
-          : 0
-        const currVol = Number.isFinite(vol)
-          ? vol
-          : 0
-
-        accum[key] = accumVol + currVol
-
-        return accum
-      }, accum[accumObjIndex])
-
-      // For right order in resulting array
-      accum.splice(accumObjIndex, 1)
-      accum.push(resObj)
-    }
-
-    return accum
-  }, [])
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -275,6 +220,5 @@ module.exports = {
   sumObjectsNumbers,
   pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
-  pickAllLowerObjectsNumbers,
-  sumArrayVolumes
+  pickAllLowerObjectsNumbers
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -266,12 +266,6 @@ const sumArrayVolumes = (propName, objects = []) => {
   }, [])
 }
 
-const pushLargeArr = (dest, src) => {
-  for (const item of src) {
-    dest.push(item)
-  }
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -282,6 +276,5 @@ module.exports = {
   pickLowerObjectsNumbers,
   sumAllObjectsNumbers,
   pickAllLowerObjectsNumbers,
-  sumArrayVolumes,
-  pushLargeArr
+  sumArrayVolumes
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -132,19 +132,10 @@ const isNotSyncRequired = (args) => {
   )
 }
 
-const sumObjectsNumbers = (propName, objects = []) => {
-  return objects.reduce((accum, curr) => {
-    return Number.isFinite(curr?.[propName])
-      ? accum + curr[propName]
-      : accum
-  }, 0)
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
   collObjToArr,
   getDateString,
-  isNotSyncRequired,
-  sumObjectsNumbers
+  isNotSyncRequired
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -118,13 +118,8 @@ const collObjToArr = (coll = [], opts) => {
   return res
 }
 
-const getDateString = (mc) => {
-  return new Date(mc).toDateString().split(' ').join('-')
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
-  collObjToArr,
-  getDateString
+  collObjToArr
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -272,58 +272,6 @@ const pushLargeArr = (dest, src) => {
   }
 }
 
-const _getValue = (obj, path) => {
-  if (typeof path !== 'string') {
-    return obj?.[path]
-  }
-
-  return path.split('.').reduce((accum, key) => accum?.[key], obj)
-}
-
-const orderBy = (collection, iteratees = [], orders = []) => {
-  // It's able to consider iterable objects as well
-  const copiedColl = [...collection]
-
-  return copiedColl.sort((a, b) => {
-    for (const [i, iteratee] of iteratees.entries()) {
-      const direction = orders[i] === 'desc' ? -1 : 1
-
-      const valA = typeof iteratee === 'function'
-        ? iteratee(a)
-        : _getValue(a, iteratee)
-      const valB = typeof iteratee === 'function'
-        ? iteratee(b)
-        : _getValue(b, iteratee)
-
-      if (valA === valB) {
-        continue
-      }
-
-      if (
-        valA === undefined ||
-        valA === null
-      ) {
-        return 1
-      }
-      if (
-        valB === undefined ||
-        valB === null
-      ) {
-        return -1
-      }
-
-      if (valA > valB) {
-        return direction
-      }
-      if (valA < valB) {
-        return -direction
-      }
-    }
-
-    return 0
-  })
-}
-
 module.exports = {
   checkParamsAuth,
   tryParseJSON,
@@ -335,6 +283,5 @@ module.exports = {
   sumAllObjectsNumbers,
   pickAllLowerObjectsNumbers,
   sumArrayVolumes,
-  pushLargeArr,
-  orderBy
+  pushLargeArr
 }

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -40,4 +40,28 @@ describe('orderBy util', () => {
       { name: 'yyy' }
     ])
   })
+
+  it('Order array of objects by name and value prop in desc and asc', () => {
+    const mockedArr = [
+      { name: 'aaa', value: 't' },
+      { name: 'www', value: 'b' },
+      { name: 'bbb', value: 'f' },
+      { name: 'www', value: 'a' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(
+      mockedArr,
+      ['name', 'value'],
+      ['desc', 'asc']
+    )
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www', value: 'a' },
+      { name: 'www', value: 'b' },
+      { name: 'bbb', value: 'f' },
+      { name: 'aaa', value: 't' }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -252,4 +252,32 @@ describe('orderBy util', () => {
       { name: null }
     ])
   })
+
+  it('Order array of objects by name prop in asc with null and undefined', () => {
+    const mockedArr = [
+      { name: undefined },
+      { name: 'aaa' },
+      { name: null },
+      { name: 'www' },
+      { name: null },
+      { name: undefined },
+      { name: null },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['asc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'aaa' },
+      { name: 'bbb' },
+      { name: 'www' },
+      { name: 'yyy' },
+      { name: undefined },
+      { name: null },
+      { name: null },
+      { name: undefined },
+      { name: null }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -131,4 +131,22 @@ describe('orderBy util', () => {
       { nestedObj: { arr: [0, 'aaa'] } }
     ])
   })
+
+  it('Order array of array by index in desc', () => {
+    const mockedArr = [
+      ['name', 'aaa'],
+      ['name', 'www'],
+      ['name', 'bbb'],
+      ['name', 'yyy']
+    ]
+
+    const orderedArr = orderBy(mockedArr, [1], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      ['name', 'yyy'],
+      ['name', 'www'],
+      ['name', 'bbb'],
+      ['name', 'aaa']
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -202,4 +202,26 @@ describe('orderBy util', () => {
       ['key1', { name: 'aaa' }]
     ])
   })
+
+  it('Order array of objects by name prop in desc with equal values', () => {
+    const mockedArr = [
+      { name: 'aaa' },
+      { name: 'www' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'yyy' },
+      { name: 'aaa' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'aaa' },
+      { name: 'aaa' }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -109,4 +109,26 @@ describe('orderBy util', () => {
       { nestedObj: { name: 'aaa' } }
     ])
   })
+
+  it('Order array of objects by second item of array in desc using fn', () => {
+    const mockedArr = [
+      { nestedObj: { arr: [0, 'aaa'] } },
+      { nestedObj: { arr: [0, 'www'] } },
+      { nestedObj: { arr: [0, 'bbb'] } },
+      { nestedObj: { arr: [0, 'yyy'] } }
+    ]
+
+    const orderedArr = orderBy(
+      mockedArr,
+      [(item) => item?.nestedObj?.arr?.[1]],
+      ['desc']
+    )
+
+    assert.deepStrictEqual(orderedArr, [
+      { nestedObj: { arr: [0, 'yyy'] } },
+      { nestedObj: { arr: [0, 'www'] } },
+      { nestedObj: { arr: [0, 'bbb'] } },
+      { nestedObj: { arr: [0, 'aaa'] } }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -288,4 +288,11 @@ describe('orderBy util', () => {
       { name: null }
     ])
   })
+
+  it('Throw TypeError if non-iterable object is ordered', () => {
+    assert.throws(
+      () => orderBy(null, ['name'], ['desc']),
+      TypeError
+    )
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -224,4 +224,32 @@ describe('orderBy util', () => {
       { name: 'aaa' }
     ])
   })
+
+  it('Order array of objects by name prop in desc with null and undefined', () => {
+    const mockedArr = [
+      { name: undefined },
+      { name: 'aaa' },
+      { name: null },
+      { name: 'www' },
+      { name: null },
+      { name: undefined },
+      { name: null },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'aaa' },
+      { name: undefined },
+      { name: null },
+      { name: null },
+      { name: undefined },
+      { name: null }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -150,6 +150,14 @@ describe('orderBy util', () => {
     ])
   })
 
+  it('Order array by index in desc', () => {
+    const mockedArr = ['aaa', 'www', 'bbb', 'yyy']
+
+    const orderedArr = orderBy(mockedArr, [(item) => item], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, ['yyy', 'www', 'bbb', 'aaa'])
+  })
+
   it('Order iterable object (Set) of objects by name prop in desc', () => {
     const mockedSet = new Set([
       { name: 'aaa' },

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -168,4 +168,38 @@ describe('orderBy util', () => {
       { name: 'aaa' }
     ])
   })
+
+  it('Order iterable object (Map) of objects by name prop and key in desc', () => {
+    const mockedMap = new Map([
+      ['key1', { name: 'aaa' }],
+      ['key2', { name: 'www' }],
+      ['key3', { name: 'bbb' }],
+      ['key4', { name: 'yyy' }]
+    ])
+
+    const orderedArrByVal = orderBy(
+      mockedMap,
+      [([key, val]) => val?.name],
+      ['desc']
+    )
+    const orderedArrByKey = orderBy(
+      mockedMap,
+      [([key, val]) => key],
+      ['desc']
+    )
+
+    // If iterable object is required, just create it after ordering
+    assert.deepStrictEqual(orderedArrByVal, [
+      ['key4', { name: 'yyy' }],
+      ['key2', { name: 'www' }],
+      ['key3', { name: 'bbb' }],
+      ['key1', { name: 'aaa' }]
+    ])
+    assert.deepStrictEqual(orderedArrByKey, [
+      ['key4', { name: 'yyy' }],
+      ['key3', { name: 'bbb' }],
+      ['key2', { name: 'www' }],
+      ['key1', { name: 'aaa' }]
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -64,4 +64,27 @@ describe('orderBy util', () => {
       { name: 'aaa', value: 't' }
     ])
   })
+
+  it('Order array of objects by name and value prop in asc by default', () => {
+    const mockedArr = [
+      { name: 'aaa', value: 't' },
+      { name: 'www', value: 'b' },
+      { name: 'bbb', value: 'f' },
+      { name: 'www', value: 'a' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(
+      mockedArr,
+      ['name', 'value']
+    )
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'aaa', value: 't' },
+      { name: 'bbb', value: 'f' },
+      { name: 'www', value: 'a' },
+      { name: 'www', value: 'b' },
+      { name: 'yyy' }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -22,4 +22,22 @@ describe('orderBy util', () => {
       { name: 'aaa' }
     ])
   })
+
+  it('Order array of objects by name prop in asc', () => {
+    const mockedArr = [
+      { name: 'aaa' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['asc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'aaa' },
+      { name: 'bbb' },
+      { name: 'www' },
+      { name: 'yyy' }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -41,7 +41,7 @@ describe('orderBy util', () => {
     ])
   })
 
-  it('Order array of objects by name and value prop in desc and asc', () => {
+  it('Order array of objects by name and value props in desc and asc', () => {
     const mockedArr = [
       { name: 'aaa', value: 't' },
       { name: 'www', value: 'b' },
@@ -65,7 +65,7 @@ describe('orderBy util', () => {
     ])
   })
 
-  it('Order array of objects by name and value prop in asc by default', () => {
+  it('Order array of objects by name and value props in asc by default', () => {
     const mockedArr = [
       { name: 'aaa', value: 't' },
       { name: 'www', value: 'b' },
@@ -85,6 +85,28 @@ describe('orderBy util', () => {
       { name: 'www', value: 'a' },
       { name: 'www', value: 'b' },
       { name: 'yyy' }
+    ])
+  })
+
+  it('Order array of objects by name prop in desc using dot syntax', () => {
+    const mockedArr = [
+      { nestedObj: { name: 'aaa' } },
+      { nestedObj: { name: 'www' } },
+      { nestedObj: { name: 'bbb' } },
+      { nestedObj: { name: 'yyy' } }
+    ]
+
+    const orderedArr = orderBy(
+      mockedArr,
+      ['nestedObj.name'],
+      ['desc']
+    )
+
+    assert.deepStrictEqual(orderedArr, [
+      { nestedObj: { name: 'yyy' } },
+      { nestedObj: { name: 'www' } },
+      { nestedObj: { name: 'bbb' } },
+      { nestedObj: { name: 'aaa' } }
     ])
   })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { assert } = require('chai')
+
+const orderBy = require('../order-by')
+
+describe('orderBy util', () => {
+  it('Order array of objects by name prop in desc', () => {
+    const mockedArr = [
+      { name: 'aaa' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'aaa' }
+    ])
+  })
+})

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -149,4 +149,23 @@ describe('orderBy util', () => {
       ['name', 'aaa']
     ])
   })
+
+  it('Order iterable object (Set) of objects by name prop in desc', () => {
+    const mockedSet = new Set([
+      { name: 'aaa' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ])
+
+    const orderedArr = orderBy(mockedSet, ['name'], ['desc'])
+
+    // If iterable object is required, just create it after ordering
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'aaa' }
+    ])
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -295,4 +295,18 @@ describe('orderBy util', () => {
       TypeError
     )
   })
+
+  it('Throw TypeError if non-iterable object is prop name list', () => {
+    const mockedArr = [
+      { name: 'aaa' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'yyy' }
+    ]
+
+    assert.throws(
+      () => orderBy(mockedArr, null, ['desc']),
+      TypeError
+    )
+  })
 })

--- a/workers/loc.api/helpers/utils/__test__/order-by.spec.js
+++ b/workers/loc.api/helpers/utils/__test__/order-by.spec.js
@@ -289,6 +289,44 @@ describe('orderBy util', () => {
     ])
   })
 
+  it('Order array of objects by name prop in desc with null and undefined items', () => {
+    const mockedArr = [
+      { name: undefined },
+      { name: 'aaa' },
+      { name: null },
+      { name: 'www' },
+      null,
+      undefined,
+      { name: null },
+      { name: undefined },
+      { name: null },
+      { name: 'bbb' },
+      null,
+      { name: 'yyy' }
+    ]
+
+    const orderedArr = orderBy(mockedArr, ['name'], ['desc'])
+
+    assert.deepStrictEqual(orderedArr, [
+      { name: 'yyy' },
+      { name: 'www' },
+      { name: 'bbb' },
+      { name: 'aaa' },
+      { name: undefined },
+      { name: null },
+      null,
+      { name: null },
+      { name: undefined },
+      { name: null },
+      null,
+      /**
+       * Array.prototype.sort() behaviour: all undefined elements
+       * are sorted to the end of the array, with no call to compareFn
+       */
+      undefined
+    ])
+  })
+
   it('Throw TypeError if non-iterable object is ordered', () => {
     assert.throws(
       () => orderBy(null, ['name'], ['desc']),

--- a/workers/loc.api/helpers/utils/check-params-auth.js
+++ b/workers/loc.api/helpers/utils/check-params-auth.js
@@ -4,7 +4,7 @@ const {
   AuthError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
 
-const checkParamsAuth = (args) => {
+module.exports = (args) => {
   const {
     apiKey,
     apiSecret,
@@ -26,8 +26,4 @@ const checkParamsAuth = (args) => {
   ) {
     throw new AuthError()
   }
-}
-
-module.exports = {
-  checkParamsAuth
 }

--- a/workers/loc.api/helpers/utils/coll-obj-to-arr.js
+++ b/workers/loc.api/helpers/utils/coll-obj-to-arr.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const { pick } = require('@bitfinex/lib-js-util-base')
+
+const {
+  isUpdatableArr,
+  isUpdatableArrObj
+} = require('../../sync/schema/utils')
+
+module.exports = (coll = [], opts) => {
+  const {
+    projection,
+    type
+  } = opts ?? {}
+  const _projection = Array.isArray(projection)
+    ? projection
+    : [projection]
+  const isProjectionExisted = (
+    _projection[0] &&
+    typeof _projection[0] === 'string'
+  )
+
+  const res = []
+
+  if (isUpdatableArr(type)) {
+    const fieldName = isProjectionExisted
+      ? _projection[0]
+      : null
+
+    for (const obj of coll) {
+      if (
+        !obj ||
+        typeof obj !== 'object'
+      ) {
+        continue
+      }
+
+      const _fieldName = fieldName ?? Object.keys(obj)
+        .filter((key) => key !== '_id')[0]
+
+      if (typeof obj?.[_fieldName] === 'undefined') {
+        continue
+      }
+
+      res.push(obj?.[_fieldName])
+    }
+  }
+  if (isUpdatableArrObj(type)) {
+    if (!isProjectionExisted) {
+      return coll
+    }
+
+    for (const obj of coll) {
+      if (
+        !obj ||
+        typeof obj !== 'object'
+      ) {
+        continue
+      }
+
+      res.push(pick(obj, projection))
+    }
+  }
+
+  return res
+}

--- a/workers/loc.api/helpers/utils/get-date-string.js
+++ b/workers/loc.api/helpers/utils/get-date-string.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = (mc) => {
+  return new Date(mc).toDateString().split(' ').join('-')
+}

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,15 +1,17 @@
 'use strict'
 
-const orderBy = require('./order-by')
-const pushLargeArr = require('./push-large-arr')
-const sumArrayVolumes = require('./sum-array-volumes')
-const sumAllObjectsNumbers = require('./sum-all-objects-numbers')
-const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
 const pickLowerObjectsNumbers = require('./pick-lower-objects-numbers')
+const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
+const sumObjectsNumbers = require('./sum-objects-numbers')
+const sumAllObjectsNumbers = require('./sum-all-objects-numbers')
+const sumArrayVolumes = require('./sum-array-volumes')
+const pushLargeArr = require('./push-large-arr')
+const orderBy = require('./order-by')
 
 module.exports = {
   pickLowerObjectsNumbers,
   pickAllLowerObjectsNumbers,
+  sumObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes,
   pushLargeArr,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const collObjToArr = require('./coll-obj-to-arr')
 const getDateString = require('./get-date-string')
 const isNotSyncRequired = require('./is-not-sync-required')
 const pickLowerObjectsNumbers = require('./pick-lower-objects-numbers')
@@ -11,6 +12,7 @@ const pushLargeArr = require('./push-large-arr')
 const orderBy = require('./order-by')
 
 module.exports = {
+  collObjToArr,
   getDateString,
   isNotSyncRequired,
   pickLowerObjectsNumbers,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const orderBy = require('./order-by')
+
+module.exports = {
+  orderBy
+}

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -5,8 +5,10 @@ const pushLargeArr = require('./push-large-arr')
 const sumArrayVolumes = require('./sum-array-volumes')
 const sumAllObjectsNumbers = require('./sum-all-objects-numbers')
 const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
+const pickLowerObjectsNumbers = require('./pick-lower-objects-numbers')
 
 module.exports = {
+  pickLowerObjectsNumbers,
   pickAllLowerObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -2,8 +2,10 @@
 
 const orderBy = require('./order-by')
 const pushLargeArr = require('./push-large-arr')
+const sumArrayVolumes = require('./sum-array-volumes')
 
 module.exports = {
+  sumArrayVolumes,
   pushLargeArr,
   orderBy
 }

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const getDateString = require('./get-date-string')
 const isNotSyncRequired = require('./is-not-sync-required')
 const pickLowerObjectsNumbers = require('./pick-lower-objects-numbers')
 const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
@@ -10,6 +11,7 @@ const pushLargeArr = require('./push-large-arr')
 const orderBy = require('./order-by')
 
 module.exports = {
+  getDateString,
   isNotSyncRequired,
   pickLowerObjectsNumbers,
   pickAllLowerObjectsNumbers,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const isNotSyncRequired = require('./is-not-sync-required')
 const pickLowerObjectsNumbers = require('./pick-lower-objects-numbers')
 const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
 const sumObjectsNumbers = require('./sum-objects-numbers')
@@ -9,6 +10,7 @@ const pushLargeArr = require('./push-large-arr')
 const orderBy = require('./order-by')
 
 module.exports = {
+  isNotSyncRequired,
   pickLowerObjectsNumbers,
   pickAllLowerObjectsNumbers,
   sumObjectsNumbers,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const tryParseJSON = require('./try-parse-json')
 const collObjToArr = require('./coll-obj-to-arr')
 const getDateString = require('./get-date-string')
 const isNotSyncRequired = require('./is-not-sync-required')
@@ -12,6 +13,7 @@ const pushLargeArr = require('./push-large-arr')
 const orderBy = require('./order-by')
 
 module.exports = {
+  tryParseJSON,
   collObjToArr,
   getDateString,
   isNotSyncRequired,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -4,8 +4,10 @@ const orderBy = require('./order-by')
 const pushLargeArr = require('./push-large-arr')
 const sumArrayVolumes = require('./sum-array-volumes')
 const sumAllObjectsNumbers = require('./sum-all-objects-numbers')
+const pickAllLowerObjectsNumbers = require('./pick-all-lower-objects-numbers')
 
 module.exports = {
+  pickAllLowerObjectsNumbers,
   sumAllObjectsNumbers,
   sumArrayVolumes,
   pushLargeArr,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const checkParamsAuth = require('./check-params-auth')
 const tryParseJSON = require('./try-parse-json')
 const collObjToArr = require('./coll-obj-to-arr')
 const getDateString = require('./get-date-string')
@@ -13,6 +14,7 @@ const pushLargeArr = require('./push-large-arr')
 const orderBy = require('./order-by')
 
 module.exports = {
+  checkParamsAuth,
   tryParseJSON,
   collObjToArr,
   getDateString,

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const orderBy = require('./order-by')
+const pushLargeArr = require('./push-large-arr')
 
 module.exports = {
+  pushLargeArr,
   orderBy
 }

--- a/workers/loc.api/helpers/utils/index.js
+++ b/workers/loc.api/helpers/utils/index.js
@@ -3,8 +3,10 @@
 const orderBy = require('./order-by')
 const pushLargeArr = require('./push-large-arr')
 const sumArrayVolumes = require('./sum-array-volumes')
+const sumAllObjectsNumbers = require('./sum-all-objects-numbers')
 
 module.exports = {
+  sumAllObjectsNumbers,
   sumArrayVolumes,
   pushLargeArr,
   orderBy

--- a/workers/loc.api/helpers/utils/is-not-sync-required.js
+++ b/workers/loc.api/helpers/utils/is-not-sync-required.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (args) => !!args?.params?.isNotSyncRequired

--- a/workers/loc.api/helpers/utils/order-by.js
+++ b/workers/loc.api/helpers/utils/order-by.js
@@ -16,11 +16,12 @@ module.exports = (collection, iteratees = [], orders = []) => {
   return copiedColl.sort((a, b) => {
     for (const [i, iteratee] of iteratees.entries()) {
       const direction = orders[i] === 'desc' ? -1 : 1
+      const isIterateeFn = typeof iteratee === 'function'
 
-      const valA = typeof iteratee === 'function'
+      const valA = isIterateeFn
         ? iteratee(a)
         : _getValue(a, iteratee)
-      const valB = typeof iteratee === 'function'
+      const valB = isIterateeFn
         ? iteratee(b)
         : _getValue(b, iteratee)
 

--- a/workers/loc.api/helpers/utils/order-by.js
+++ b/workers/loc.api/helpers/utils/order-by.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const _getValue = (obj, path) => {
+  if (typeof path !== 'string') {
+    return obj?.[path]
+  }
+
+  return path.split('.').reduce((accum, key) => accum?.[key], obj)
+}
+
+module.exports = (collection, iteratees = [], orders = []) => {
+  // It's able to consider iterable objects as well
+  const copiedColl = [...collection]
+
+  return copiedColl.sort((a, b) => {
+    for (const [i, iteratee] of iteratees.entries()) {
+      const direction = orders[i] === 'desc' ? -1 : 1
+
+      const valA = typeof iteratee === 'function'
+        ? iteratee(a)
+        : _getValue(a, iteratee)
+      const valB = typeof iteratee === 'function'
+        ? iteratee(b)
+        : _getValue(b, iteratee)
+
+      if (valA === valB) {
+        continue
+      }
+
+      if (
+        valA === undefined ||
+        valA === null
+      ) {
+        return 1
+      }
+      if (
+        valB === undefined ||
+        valB === null
+      ) {
+        return -1
+      }
+
+      if (valA > valB) {
+        return direction
+      }
+      if (valA < valB) {
+        return -direction
+      }
+    }
+
+    return 0
+  })
+}

--- a/workers/loc.api/helpers/utils/order-by.js
+++ b/workers/loc.api/helpers/utils/order-by.js
@@ -10,6 +10,7 @@ const _getValue = (obj, path) => {
 
 module.exports = (collection, iteratees = [], orders = []) => {
   // It's able to consider iterable objects as well
+  // If iterable object is required, just create it after ordering, not here
   const copiedColl = [...collection]
 
   return copiedColl.sort((a, b) => {

--- a/workers/loc.api/helpers/utils/order-by.js
+++ b/workers/loc.api/helpers/utils/order-by.js
@@ -1,6 +1,12 @@
 'use strict'
 
 const _getValue = (obj, path) => {
+  if (
+    obj === undefined ||
+    obj === null
+  ) {
+    return obj
+  }
   if (typeof path !== 'string') {
     return obj?.[path]
   }

--- a/workers/loc.api/helpers/utils/pick-all-lower-objects-numbers.js
+++ b/workers/loc.api/helpers/utils/pick-all-lower-objects-numbers.js
@@ -1,0 +1,31 @@
+'use strict'
+
+module.exports = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (
+      !curr?.[propName] ||
+      typeof curr?.[propName] !== 'object'
+    ) {
+      return accum
+    }
+
+    const entries = Object.entries(curr[propName])
+
+    return entries.reduce((accum, [key, val]) => {
+      if (!Number.isFinite(val)) {
+        return accum
+      }
+      if (!Number.isFinite(accum?.[key])) {
+        accum[key] = val
+
+        return accum
+      }
+
+      accum[key] = val < accum[key]
+        ? val
+        : accum[key]
+
+      return accum
+    }, accum)
+  }, {})
+}

--- a/workers/loc.api/helpers/utils/pick-lower-objects-numbers.js
+++ b/workers/loc.api/helpers/utils/pick-lower-objects-numbers.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (!Number.isFinite(curr?.[propName])) {
+      return accum
+    }
+    if (!Number.isFinite(accum)) {
+      return curr[propName]
+    }
+
+    return curr[propName] < accum
+      ? curr[propName]
+      : accum
+  }, null)
+}

--- a/workers/loc.api/helpers/utils/push-large-arr.js
+++ b/workers/loc.api/helpers/utils/push-large-arr.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = (dest, src) => {
+  for (const item of src) {
+    dest.push(item)
+  }
+}

--- a/workers/loc.api/helpers/utils/sum-all-objects-numbers.js
+++ b/workers/loc.api/helpers/utils/sum-all-objects-numbers.js
@@ -1,0 +1,27 @@
+'use stricts'
+
+module.exports = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (
+      !curr?.[propName] ||
+      typeof curr?.[propName] !== 'object'
+    ) {
+      return accum
+    }
+
+    const entries = Object.entries(curr[propName])
+
+    return entries.reduce((accum, [key, val]) => {
+      const prevVal = Number.isFinite(accum?.[key])
+        ? accum[key]
+        : 0
+      const currVal = Number.isFinite(val)
+        ? val
+        : 0
+
+      accum[key] = prevVal + currVal
+
+      return accum
+    }, accum)
+  }, {})
+}

--- a/workers/loc.api/helpers/utils/sum-array-volumes.js
+++ b/workers/loc.api/helpers/utils/sum-array-volumes.js
@@ -1,0 +1,56 @@
+'use strict'
+
+module.exports = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    if (!Array.isArray(curr?.[propName])) {
+      return accum
+    }
+
+    for (const obj of curr[propName]) {
+      if (typeof obj?.curr !== 'string') {
+        continue
+      }
+
+      const entries = Object.entries(obj)
+        .filter(([key]) => key !== 'curr')
+
+      if (entries.length === 0) {
+        continue
+      }
+
+      if (accum.length === 0) {
+        accum.push({ ...obj })
+
+        continue
+      }
+
+      const accumObjIndex = accum
+        .findIndex((item) => item?.curr === obj.curr)
+
+      if (accumObjIndex === -1) {
+        accum.push({ ...obj })
+
+        continue
+      }
+
+      const resObj = entries.reduce((accum, [key, vol]) => {
+        const accumVol = Number.isFinite(accum?.[key])
+          ? accum[key]
+          : 0
+        const currVol = Number.isFinite(vol)
+          ? vol
+          : 0
+
+        accum[key] = accumVol + currVol
+
+        return accum
+      }, accum[accumObjIndex])
+
+      // For right order in resulting array
+      accum.splice(accumObjIndex, 1)
+      accum.push(resObj)
+    }
+
+    return accum
+  }, [])
+}

--- a/workers/loc.api/helpers/utils/sum-objects-numbers.js
+++ b/workers/loc.api/helpers/utils/sum-objects-numbers.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = (propName, objects = []) => {
+  return objects.reduce((accum, curr) => {
+    return Number.isFinite(curr?.[propName])
+      ? accum + curr[propName]
+      : accum
+  }, 0)
+}

--- a/workers/loc.api/helpers/utils/try-parse-json.js
+++ b/workers/loc.api/helpers/utils/try-parse-json.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = (
+  jsonString,
+  isNotObject
+) => {
+  try {
+    if (typeof jsonString !== 'string') {
+      return false
+    }
+
+    const obj = JSON.parse(jsonString)
+
+    if (
+      isNotObject ||
+      (
+        obj &&
+        typeof obj === 'object'
+      )
+    ) {
+      return obj
+    }
+  } catch (e) { }
+
+  return false
+}

--- a/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
+++ b/workers/loc.api/sync/colls.accessors/public.colls.conf.accessors.js
@@ -1,9 +1,6 @@
 'use strict'
 
 const {
-  orderBy
-} = require('lodash')
-const {
   omit,
   pick,
   isEmpty
@@ -15,6 +12,9 @@ const {
   FindMethodError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
 
+const {
+  orderBy
+} = require('../../helpers')
 const {
   GetPublicDataError
 } = require('../../errors')

--- a/workers/loc.api/sync/currency.converter/index.js
+++ b/workers/loc.api/sync/currency.converter/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const moment = require('moment')
-const { orderBy } = require('lodash')
 
 const {
   FindMethodError
@@ -16,7 +15,10 @@ const {
 const {
   isForexSymb
 } = require('../helpers')
-const { tryParseJSON } = require('../../helpers')
+const {
+  tryParseJSON,
+  orderBy
+} = require('../../helpers')
 const SyncTempTablesManager = require(
   '../data.inserter/sync.temp.tables.manager'
 )

--- a/workers/loc.api/sync/dao/db.backup.manager/index.js
+++ b/workers/loc.api/sync/dao/db.backup.manager/index.js
@@ -4,9 +4,11 @@ const { mkdirSync } = require('fs')
 const { readdir, rm, copyFile } = require('fs/promises')
 const path = require('path')
 const moment = require('moment')
-const { orderBy } = require('lodash')
 
-const { isBfxApiStaging } = require('../../../helpers')
+const {
+  isBfxApiStaging,
+  orderBy
+} = require('../../../helpers')
 
 const { decorateInjectable } = require('../../../di/utils')
 

--- a/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
+++ b/workers/loc.api/sync/data.inserter/hooks/recalc.sub.account.ledgers.balances.hook.js
@@ -3,14 +3,12 @@
 const { promisify } = require('util')
 const setImmediatePromise = promisify(setImmediate)
 
-const {
-  orderBy
-} = require('lodash')
 const { merge } = require('@bitfinex/lib-js-util-base')
 
 const SyncTempTablesManager = require('../sync.temp.tables.manager')
 const DataInserterHook = require('./data.inserter.hook')
 const { getAuthFromDb } = require('../helpers/utils')
+const { orderBy } = require('../../../helpers')
 const {
   SubAccountLedgersBalancesRecalcError
 } = require('../../../errors')

--- a/workers/loc.api/sync/movements/index.js
+++ b/workers/loc.api/sync/movements/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
-const { orderBy } = require('lodash')
 const { merge } = require('@bitfinex/lib-js-util-base')
 
-const { pushLargeArr } = require('../../helpers/utils')
+const {
+  pushLargeArr,
+  orderBy
+} = require('../../helpers/utils')
 
 const { decorateInjectable } = require('../../di/utils')
 
@@ -119,7 +121,7 @@ class Movements {
       const {
         propNames,
         orders
-      } = this._getLodashOrder(sort)
+      } = this._getOrder(sort)
       const orderedRes = orderBy(
         movements,
         propNames,
@@ -158,7 +160,7 @@ class Movements {
     const {
       propNames,
       orders
-    } = this._getLodashOrder(sort)
+    } = this._getOrder(sort)
     const orderedRes = orderBy(
       movements,
       propNames,
@@ -338,7 +340,7 @@ class Movements {
     return [['mts', orderSign], ['id', orderSign]]
   }
 
-  _getLodashOrder (sort) {
+  _getOrder (sort) {
     const propNames = []
     const orders = []
 

--- a/workers/loc.api/sync/positions.snapshot/index.js
+++ b/workers/loc.api/sync/positions.snapshot/index.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { orderBy } = require('lodash')
-
 const {
   splitSymbolPairs
 } = require('@bitfinex/bfx-report/workers/loc.api/helpers')
+
+const { orderBy } = require('../../helpers')
 const {
   groupByTimeframe,
   getMtsGroupedByTimeframe,

--- a/workers/loc.api/sync/sub.account.api.data/index.js
+++ b/workers/loc.api/sync/sub.account.api.data/index.js
@@ -1,9 +1,6 @@
 'use strict'
 
 const {
-  orderBy
-} = require('lodash')
-const {
   isEmpty
 } = require('@bitfinex/lib-js-util-base')
 const {
@@ -14,6 +11,9 @@ const {
   FindMethodError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
 
+const {
+  orderBy
+} = require('../../helpers')
 const {
   DatePropNameError
 } = require('../../errors')

--- a/workers/loc.api/sync/sub.account/index.js
+++ b/workers/loc.api/sync/sub.account/index.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const { orderBy } = require('lodash')
-
 const {
   AuthError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
 
 const {
   isSubAccountApiKeys,
-  getSubAccountAuthFromAuth
+  getSubAccountAuthFromAuth,
+  orderBy
 } = require('../../helpers')
 const {
   SubAccountCreatingError,


### PR DESCRIPTION
This PR implements `orderBy` util to remove lodash totally

---

Basic changes:
- adds `orderBy` util
- removes `lodash`
- refactors `utils` file: separates utils into files without logic changes
