### PR TITLE
Fix GH Actions workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,8 @@ jobs:
         path: test-report.json
   web-page-report:
     needs: linux-test-runner
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     uses: ./.github/workflows/test-report.yml


### PR DESCRIPTION
This PR fixes GH Actions workflow permissions

---

The workflow is requesting 'actions: read, checks: write', but is only allowed 'actions: none, checks: none'
