### PR TITLE
Use grenache-grape from npm repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@bitfinex/bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
-        "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
+        "bfx-api-mock-srv": "2.0.0",
         "chai": "4.3.4",
         "concurrently": "9.2.1",
         "cross-env": "10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
         "bignumber.js": "9.1.2",
         "csv": "5.5.3",
-        "grenache-nodejs-ws": "git+https://github.com/bitfinexcom/grenache-nodejs-ws.git",
+        "grenache-nodejs-ws": "1.0.0",
         "inversify": "6.0.1",
         "mathjs": "14.8.1",
         "moment": "2.29.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "chai": "4.3.4",
         "concurrently": "9.2.1",
         "cross-env": "10.1.0",
-        "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
+        "grenache-grape": "1.0.0",
         "mocha": "11.1.0",
         "nodemon": "3.1.14",
         "standard": "17.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@bitfinex/lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "bignumber.js": "9.1.2",
     "csv": "5.5.3",
-    "grenache-nodejs-ws": "git+https://github.com/bitfinexcom/grenache-nodejs-ws.git",
+    "grenache-nodejs-ws": "1.0.0",
     "inversify": "6.0.1",
     "mathjs": "14.8.1",
     "moment": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chai": "4.3.4",
     "concurrently": "9.2.1",
     "cross-env": "10.1.0",
-    "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
+    "grenache-grape": "1.0.0",
     "mocha": "11.1.0",
     "nodemon": "3.1.14",
     "standard": "17.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@bitfinex/bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
-    "bfx-api-mock-srv": "git+https://github.com/bitfinexcom/bfx-api-mock-srv.git",
+    "bfx-api-mock-srv": "2.0.0",
     "chai": "4.3.4",
     "concurrently": "9.2.1",
     "cross-env": "10.1.0",


### PR DESCRIPTION
This PR uses `grenache-grape` dep from npm repository. Also, uses `bfx-api-mock-srv` and `grenache-nodejs-ws` from npm repo