### PR TITLE
Dedicate separate file for report queue event names

### DIFF
--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -39,6 +39,9 @@ const {
   PDFBufferUnderElectronCreationError,
   PDFBufferUnderFrameworkCreationError
 } = require('@bitfinex/bfx-report/workers/loc.api/errors')
+const QUEUE_EVENT_NAMES = require(
+  '@bitfinex/bfx-report/workers/loc.api/queue/queue.event.names'
+)
 
 const appDeps = require('./loc.api/di/app.deps')
 const TYPES = require('./loc.api/di/types')
@@ -208,7 +211,7 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
 
     await wsTransport.start()
 
-    processorQueue.on('error:base', (err, job) => {
+    processorQueue.on(QUEUE_EVENT_NAMES.ERROR_BASE, (err, job) => {
       if (
         !(err instanceof PDFBufferUnderElectronCreationError) &&
         !(err instanceof PDFBufferUnderFrameworkCreationError)
@@ -223,7 +226,7 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
         this.logger.error(`WS_EVENT_EMITTER:REPORT_FILE_FAILED: ${err.stack || err}`)
       })
     })
-    aggregatorQueue.on('completed', (res) => {
+    aggregatorQueue.on(QUEUE_EVENT_NAMES.COMPLETED, (res) => {
       const {
         reportFilesMetadata,
         csvFilesMetadata, // For compatibility with old implementation

--- a/workers/loc.api/generate-report-file/csv-writer/full-snapshot-report-csv-writer.js
+++ b/workers/loc.api/generate-report-file/csv-writer/full-snapshot-report-csv-writer.js
@@ -9,6 +9,9 @@ const {
 const {
   omitExtraParamFieldsForReportExport
 } = require('@bitfinex/bfx-report/workers/loc.api/generate-report-file/helpers')
+const QUEUE_EVENT_NAMES = require(
+  '@bitfinex/bfx-report/workers/loc.api/queue/queue.event.names'
+)
 
 module.exports = (
   rService,
@@ -29,7 +32,7 @@ module.exports = (
     ...args?.params
   }
 
-  queue.emit('progress', 0)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 0)
 
   if (typeof jobData === 'string') {
     await streamWriter(
@@ -40,7 +43,7 @@ module.exports = (
       }]
     )
 
-    queue.emit('progress', 100)
+    queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 
     return
   }
@@ -173,5 +176,5 @@ module.exports = (
     ]
   )
 
-  queue.emit('progress', 100)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 }

--- a/workers/loc.api/generate-report-file/csv-writer/full-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-report-file/csv-writer/full-tax-report-csv-writer.js
@@ -9,6 +9,9 @@ const {
 const {
   omitExtraParamFieldsForReportExport
 } = require('@bitfinex/bfx-report/workers/loc.api/generate-report-file/helpers')
+const QUEUE_EVENT_NAMES = require(
+  '@bitfinex/bfx-report/workers/loc.api/queue/queue.event.names'
+)
 
 module.exports = (
   rService,
@@ -30,7 +33,7 @@ module.exports = (
     ...args?.params
   }
 
-  queue.emit('progress', 0)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 0)
 
   if (typeof jobData === 'string') {
     await streamWriter(
@@ -41,7 +44,7 @@ module.exports = (
       }]
     )
 
-    queue.emit('progress', 100)
+    queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 
     return
   }
@@ -206,5 +209,5 @@ module.exports = (
     ]
   )
 
-  queue.emit('progress', 100)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 }

--- a/workers/loc.api/generate-report-file/csv-writer/transaction-tax-report-csv-writer.js
+++ b/workers/loc.api/generate-report-file/csv-writer/transaction-tax-report-csv-writer.js
@@ -12,6 +12,9 @@ const TRANSLATION_NAMESPACES = require(
 const {
   omitExtraParamFieldsForReportExport
 } = require('@bitfinex/bfx-report/workers/loc.api/generate-report-file/helpers')
+const QUEUE_EVENT_NAMES = require(
+  '@bitfinex/bfx-report/workers/loc.api/queue/queue.event.names'
+)
 
 module.exports = (
   rService,
@@ -35,7 +38,7 @@ module.exports = (
   }
   const { language } = params ??
 
-  queue.emit('progress', 0)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 0)
 
   if (typeof jobData === 'string') {
     await streamWriter(
@@ -46,7 +49,7 @@ module.exports = (
       }]
     )
 
-    queue.emit('progress', 100)
+    queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 
     return
   }
@@ -108,5 +111,5 @@ ${i18next.t('template.delistedCcyMessageEnd', transOpts)}\
     csvStreamDataMap
   )
 
-  queue.emit('progress', 100)
+  queue.emit(QUEUE_EVENT_NAMES.PROGRESS, 100)
 }


### PR DESCRIPTION
This PR makes refactoring to dedicate separate file for report queue event names

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/483
