### PR TITLE
Add endpoints for recaptcha to overcome cors on framework

### DIFF
--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -51,6 +51,7 @@ const getMockDataOpts = () => ({
   login: null,
   login_verify: null,
   captcha_providers: null,
+  captcha_required: null,
   platform_status: null
 })
 
@@ -58,7 +59,8 @@ const getExtraMockMethods = () => (new Map([
   ['post', {
     '/v2/login': 'login',
     '/v2/login/verify': 'login_verify',
-    '/v2/int/captcha/providers': 'captcha_providers'
+    '/v2/int/captcha/providers': 'captcha_providers',
+    '/v2/int/captcha/required': 'captcha_required'
   }]
 ]))
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -50,13 +50,15 @@ const getMockDataOpts = () => ({
   delete_token: null,
   login: null,
   login_verify: null,
+  captcha_providers: null,
   platform_status: null
 })
 
 const getExtraMockMethods = () => (new Map([
   ['post', {
     '/v2/login': 'login',
-    '/v2/login/verify': 'login_verify'
+    '/v2/login/verify': 'login_verify',
+    '/v2/int/captcha/providers': 'captcha_providers'
   }]
 ]))
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -30,6 +30,10 @@ module.exports = new Map([
     ['hcaptcha']
   ],
   [
+    'captcha_required',
+    true
+  ],
+  [
     'generate_token',
     ['pub:api:88888888-4444-4444-4444-121212121212-caps:s:o:f:w:wd:a-write']
   ],

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -26,6 +26,10 @@ module.exports = new Map([
     ]
   ],
   [
+    'captcha_providers',
+    ['hcaptcha']
+  ],
+  [
     'generate_token',
     ['pub:api:88888888-4444-4444-4444-121212121212-caps:s:o:f:w:wd:a-write']
   ],

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -175,6 +175,26 @@ module.exports = (
     assert.isString(res.body.result[1])
   })
 
+  it('it should be successfully performed by the getCaptchaProviders method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        method: 'getCaptchaProviders',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isString(res.body.result[0])
+    assert.strictEqual(res.body.result[0], 'hcaptcha')
+  })
+
   it('it should be successfully performed by the signIn method', async function () {
     this.timeout(5000)
 

--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -195,6 +195,28 @@ module.exports = (
     assert.strictEqual(res.body.result[0], 'hcaptcha')
   })
 
+  it('it should be successfully performed by the isCaptchaRequired method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        method: 'isCaptchaRequired',
+        params: {
+          method: 'login'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isBoolean(res.body.result)
+    assert.isOk(res.body.result)
+  })
+
   it('it should be successfully performed by the signIn method', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/http.request/index.js
+++ b/workers/loc.api/http.request/index.js
@@ -61,6 +61,11 @@ class ExpandedRESTv2 extends RESTv2 {
     return makeRequestToBFX(() => this
       ._makePublicPostRequest('/int/captcha/providers', body))
   }
+
+  async isCaptchaRequired (body) {
+    return makeRequestToBFX(() => this
+      ._makePublicPostRequest('/int/captcha/required', body))
+  }
 }
 
 decorateInjectable(HTTPRequest, depsTypes)

--- a/workers/loc.api/http.request/index.js
+++ b/workers/loc.api/http.request/index.js
@@ -56,6 +56,11 @@ class ExpandedRESTv2 extends RESTv2 {
     return makeRequestToBFX(() => this
       ._makePublicPostRequest('/login/verify', body))
   }
+
+  async getCaptchaProviders (body) {
+    return makeRequestToBFX(() => this
+      ._makePublicPostRequest('/int/captcha/providers', body))
+  }
 }
 
 decorateInjectable(HTTPRequest, depsTypes)

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -106,6 +106,13 @@ class FrameworkReportService extends ReportService {
     }, 'getCaptchaProviders', args, cb)
   }
 
+  isCaptchaRequired (space, args, cb) {
+    return this._responder(() => {
+      return this._httpRequest.getRequest()
+        .isCaptchaRequired(args?.params)
+    }, 'isCaptchaRequired', args, cb)
+  }
+
   isStagingBfxApi (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.isStagingBfxApi()

--- a/workers/loc.api/service.report.framework.js
+++ b/workers/loc.api/service.report.framework.js
@@ -99,6 +99,13 @@ class FrameworkReportService extends ReportService {
     }, 'verifyOnBFX', args, cb)
   }
 
+  getCaptchaProviders (space, args, cb) {
+    return this._responder(() => {
+      return this._httpRequest.getRequest()
+        .getCaptchaProviders(args?.params)
+    }, 'getCaptchaProviders', args, cb)
+  }
+
   isStagingBfxApi (space, args, cb) {
     return this._responder(() => {
       return this._authenticator.isStagingBfxApi()


### PR DESCRIPTION
This PR adds endpoints for recaptcha to overcome cors on framework

---

Adds the following endpoints:
- method name `isCaptchaRequired`: https://api-pub.bitfinex.com/v2/int/captcha/required
- method name `getCaptchaProviders`: https://api-pub.bitfinex.com/v2/int/captcha/providers

---

Example of request for `isCaptchaRequired`:
```jsonc
{
 "method": "isCaptchaRequired",
 "id": 123,
 "params": {
   "method": "login"
 }
}
```

Response:
```jsonc
{
 "jsonrpc": "2.0",
 "result": true,
 "id": 123
}
```

Example of request for `getCaptchaProviders`:
```jsonc
{
 "method": "getCaptchaProviders",
 "id": 123
}
```

Response:
```jsonc
{
 "jsonrpc": "2.0",
 "result": [
   "hcaptcha"
 ],
 "id": 123
}
```

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/484
