### PR TITLE
Add weighted-average-report export to pdf file for consistency

### DIFF
--- a/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/additional-api-sync-mode-sqlite-test-cases.js
@@ -1271,11 +1271,6 @@ module.exports = (
   it('it should be successfully performed by the getWeightedAveragesReportFile method', async function () {
     this.timeout(60000)
 
-    // TODO: Wait for implementation of pdf template in the next release
-    if (isPDFRequired) {
-      this.skip()
-    }
-
     const procPromise = queueToPromise(params.processorQueue)
     const aggrPromise = queueToPromise(params.aggregatorQueue)
 


### PR DESCRIPTION
This PR adds `weighted-average-report` export to PDF file for consistency with other report exports. Also, prevents skipping weighted-averages-report export test for pdf as it was added some time ago

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/487
