### PR TITLE
Add more efficient way to filter ledgers by wallet

### DIFF
--- a/test/test-cases/api-sync-mode-sqlite-test-cases.js
+++ b/test/test-cases/api-sync-mode-sqlite-test-cases.js
@@ -1458,6 +1458,37 @@ module.exports = (
     })
   })
 
+  it('it should be successfully performed by the getLedgers method filtered by wallet', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLedgers',
+        params: {
+          wallet: 'exchange',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+
+    for (const resItem of res.body.result.res) {
+      assert.isObject(resItem)
+      assert.deepEqual(resItem.wallet, 'exchange')
+    }
+  })
+
   it('it should be successfully performed by the getLedgers method, without params', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
@@ -11,6 +11,9 @@ const getStatusMessagesFilter = require(
   '../get-status-messages-filter'
 )
 const TABLES_NAMES = require('../../../schema/tables-names')
+const SUPPORTED_MODEL_FIELDS = require(
+  '../../../schema/sync-schema/model/supported.model.fields'
+)
 
 module.exports = (args, methodColl, opts) => {
   const { auth, params } = { ...args }
@@ -28,24 +31,30 @@ module.exports = (args, methodColl, opts) => {
 
   const filter = {
     ...insertableArrayObjectsFilter,
-    ...statusMessagesfilter
+    ...statusMessagesfilter,
+    ...methodColl[SUPPORTED_MODEL_FIELDS.ADDITIONAL_FILTERING_PROPS]
   }
 
-  if (!isPublic) {
-    const { _id, isSubAccount } = { ...auth }
-
-    if (!Number.isInteger(_id)) {
-      throw new AuthError()
+  if (isPublic) {
+    return {
+      requestedFilter,
+      filter
     }
-    if (
-      methodColl.getModelField('NAME') === TABLES_NAMES.LEDGERS &&
-      isSubAccount
-    ) {
-      filter._isBalanceRecalced = 1
-    }
-
-    filter.user_id = _id
   }
+
+  const { _id, isSubAccount } = auth ?? {}
+
+  if (!Number.isInteger(_id)) {
+    throw new AuthError()
+  }
+  if (
+    methodColl.getModelField('NAME') === TABLES_NAMES.LEDGERS &&
+    isSubAccount
+  ) {
+    filter._isBalanceRecalced = 1
+  }
+
+  filter.user_id = _id
 
   return {
     requestedFilter,

--- a/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
+++ b/workers/loc.api/sync/dao/helpers/find-in-coll-by/get-filter-params.js
@@ -10,28 +10,35 @@ const getInsertableArrayObjectsFilter = require(
 const getStatusMessagesFilter = require(
   '../get-status-messages-filter'
 )
-const TABLES_NAMES = require('../../../schema/tables-names')
+const getLedgersFilter = require(
+  '../get-ledgers-filter'
+)
 const SUPPORTED_MODEL_FIELDS = require(
   '../../../schema/sync-schema/model/supported.model.fields'
 )
 
 module.exports = (args, methodColl, opts) => {
-  const { auth, params } = { ...args }
-  const { filter: requestedFilter } = { ...params }
-  const { isPublic } = { ...opts }
+  const { auth, params } = args ?? {}
+  const { filter: requestedFilter } = params ?? {}
+  const { isPublic } = opts ?? {}
 
   const statusMessagesfilter = getStatusMessagesFilter(
     methodColl,
-    params
+    args
   )
   const insertableArrayObjectsFilter = getInsertableArrayObjectsFilter(
     methodColl,
-    params
+    args
+  )
+  const ledgersFilter = getLedgersFilter(
+    methodColl,
+    args
   )
 
   const filter = {
     ...insertableArrayObjectsFilter,
     ...statusMessagesfilter,
+    ...ledgersFilter,
     ...methodColl[SUPPORTED_MODEL_FIELDS.ADDITIONAL_FILTERING_PROPS]
   }
 
@@ -42,19 +49,11 @@ module.exports = (args, methodColl, opts) => {
     }
   }
 
-  const { _id, isSubAccount } = auth ?? {}
-
-  if (!Number.isInteger(_id)) {
+  if (!Number.isInteger(auth?._id)) {
     throw new AuthError()
   }
-  if (
-    methodColl.getModelField('NAME') === TABLES_NAMES.LEDGERS &&
-    isSubAccount
-  ) {
-    filter._isBalanceRecalced = 1
-  }
 
-  filter.user_id = _id
+  filter.user_id = auth._id
 
   return {
     requestedFilter,

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -41,8 +41,7 @@ module.exports = (
     dateFieldName,
     model,
     symbolFieldName,
-    timeframeFieldName,
-    additionalFilteringProps
+    timeframeFieldName
   } = {},
   params = {}
 ) => {
@@ -74,7 +73,6 @@ module.exports = (
     _dateFieldName: dateFieldName,
     start,
     end,
-    ...additionalFilteringProps,
     ...symbFilter,
     ...timeframeFilter,
     ...fieldsFilters

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -43,7 +43,7 @@ module.exports = (
     symbolFieldName,
     timeframeFieldName
   } = {},
-  params = {}
+  args
 ) => {
   if (!isInsertableArrObj(type)) {
     return {}
@@ -55,17 +55,16 @@ module.exports = (
     symbol,
     timeframe,
     filter: reqFilter = {}
-  } = { ...params }
+  } = args?.params ?? {}
   const symbFilter = getSymbolFilter(symbol, symbolFieldName)
   const timeframeFilter = getTimeframeFilter(timeframe, timeframeFieldName)
   const fieldsFilters = getFieldsFilters(
     [
       'isMarginFundingPayment',
       'isAffiliateRebate',
-      'isStakingPayments',
-      'category'
+      'isStakingPayments'
     ],
-    params,
+    args?.params,
     model
   )
   const filter = {

--- a/workers/loc.api/sync/dao/helpers/get-ledgers-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-ledgers-filter.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const TABLES_NAMES = require('../../schema/tables-names')
+
+module.exports = (
+  methodColl,
+  args
+) => {
+  if (methodColl.getModelField('NAME') !== TABLES_NAMES.LEDGERS) {
+    return {}
+  }
+
+  const { auth, params } = args ?? {}
+  const filter = {}
+
+  if (auth?.isSubAccount) {
+    filter._isBalanceRecalced = 1
+  }
+  if (params?.wallet) {
+    filter.wallet = params.wallet
+  }
+  if (params?.category) {
+    filter._category = params.category
+  }
+
+  return filter
+}

--- a/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
@@ -6,8 +6,7 @@ const getSymbolFilter = require('./get-symbol-filter')
 module.exports = (
   {
     name,
-    symbolFieldName,
-    additionalFilteringProps
+    symbolFieldName
   } = {},
   params = {}
 ) => {
@@ -24,7 +23,6 @@ module.exports = (
   const filter = {
     ...reqFilter,
     _type: type,
-    ...additionalFilteringProps,
     ...symbFilter
   }
 

--- a/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-status-messages-filter.js
@@ -8,7 +8,7 @@ module.exports = (
     name,
     symbolFieldName
   } = {},
-  params = {}
+  args
 ) => {
   if (name !== TABLES_NAMES.STATUS_MESSAGES) {
     return {}
@@ -18,7 +18,7 @@ module.exports = (
     type,
     symbol,
     filter: reqFilter = {}
-  } = { ...params }
+  } = args?.params ?? {}
   const symbFilter = getSymbolFilter(symbol, symbolFieldName)
   const filter = {
     ...reqFilter,


### PR DESCRIPTION
This PR adds more efficient way to filter ledgers by `wallet` as rest_v2_api supports it:
- https://docs.bitfinex.com/reference/rest-auth-ledgers

---

Depends on these PRs:
- https://github.com/bitfinexcom/bfx-report/pull/489
- https://github.com/bitfinexcom/bfx-api-node-rest/pull/115
- https://github.com/bitfinexcom/bitfinex-api-node/pull/597