### PR TITLE
Migrate to inversifyjs v7

### DIFF
--- a/Dockerfile.express
+++ b/Dockerfile.express
@@ -1,4 +1,4 @@
-FROM node:20.18.1-alpine3.20
+FROM node:24.1.0-alpine3.20
 
 ENV BIND_HOST="0.0.0.0"
 

--- a/Dockerfile.grenache-grape
+++ b/Dockerfile.grenache-grape
@@ -1,4 +1,4 @@
-FROM node:20.18.1-alpine3.20
+FROM node:24.1.0-alpine3.20
 
 ENV BIND_HOST="0.0.0.0"
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -1,4 +1,4 @@
-FROM node:20.18.1-alpine3.20
+FROM node:24.1.0-alpine3.20
 
 WORKDIR /home/node/bfx-report-ui
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:20.18.1-alpine3.20
+FROM node:24.1.0-alpine3.20
 
 ARG GRC_VER="0.8.2"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "bignumber.js": "9.1.2",
         "csv": "5.5.3",
         "grenache-nodejs-ws": "1.0.0",
-        "inversify": "6.0.1",
+        "inversify": "7.11.0",
         "mathjs": "14.8.1",
         "moment": "2.29.4",
         "puppeteer": "24.1.0",
@@ -335,6 +335,12 @@
         }
       }
     },
+    "node_modules/@bitfinex/bfx-report/node_modules/inversify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
+      "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==",
+      "license": "MIT"
+    },
     "node_modules/@bitfinex/bfx-svc-boot-js": {
       "version": "1.1.0",
       "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-svc-boot-js.git#be28ca5387eef34e651042e64d278feedf9b3a61",
@@ -523,6 +529,54 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@inversifyjs/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-WlzR9xGadABS9gtgZQ+luoZ8V6qm4Ii6RQfcfC9Ho2SOlE6ZuemFo7PKJvKI0ikm8cmKbU8hw5UK6E4qovH21w==",
+      "license": "MIT"
+    },
+    "node_modules/@inversifyjs/core": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-9.2.0.tgz",
+      "integrity": "sha512-Nm7BR6KmpgshIHpVQWuEDehqRVb6GBm8LFEuhc2s4kSZWrArZ15RmXQzROLk4m+hkj4kMXgvMm5Qbopot/D6Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/prototype-utils": "0.1.3",
+        "@inversifyjs/reflect-metadata-utils": "1.4.1"
+      }
+    },
+    "node_modules/@inversifyjs/core/node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.4.1.tgz",
+      "integrity": "sha512-Cp77C4d2wLaHXiUB7iH6Cxb7i1lD/YDuTIHLTDzKINqGSz0DCSoL/Dg2wVkW/6Qx03r/yQMLJ+32Agl32N2X8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
+    "node_modules/@inversifyjs/core/node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@inversifyjs/plugin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/plugin/-/plugin-0.2.0.tgz",
+      "integrity": "sha512-R/JAdkTSD819pV1zi0HP54mWHyX+H2m8SxldXRgPQarS3ySV4KPyRdosWcfB8Se0JJZWZLHYiUNiS6JvMWSPjw==",
+      "license": "MIT"
+    },
+    "node_modules/@inversifyjs/prototype-utils": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/prototype-utils/-/prototype-utils-0.1.3.tgz",
+      "integrity": "sha512-EzRamZzNgE9Sn3QtZ8NncNa2lpPMZfspqbK6BWFguWnOpK8ymp2TUuH46ruFHZhrHKnknPd7fG22ZV7iF517TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4820,9 +4874,46 @@
       }
     },
     "node_modules/inversify": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
-      "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ=="
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-7.11.0.tgz",
+      "integrity": "sha512-yZDprSSr8TyVeMGI/AOV4ws6gwjX22hj9Z8/oHAVpJORY6WRFTcUzhnZtibBUHEw2U8ArvHcR+i863DplQ3Cwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/container": "1.15.0",
+        "@inversifyjs/core": "9.2.0"
+      }
+    },
+    "node_modules/inversify/node_modules/@inversifyjs/container": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/container/-/container-1.15.0.tgz",
+      "integrity": "sha512-U2xYsPrJTz5za2TExi5lg8qOWf8TEVBpN+pQM7B8BVA2rajtbRE9A66SLRHk8c1eGXmg+0K4Hdki6tWAsSQBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/core": "9.2.0",
+        "@inversifyjs/plugin": "0.2.0",
+        "@inversifyjs/reflect-metadata-utils": "1.4.1"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
+    "node_modules/inversify/node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.4.1.tgz",
+      "integrity": "sha512-Cp77C4d2wLaHXiUB7iH6Cxb7i1lD/YDuTIHLTDzKINqGSz0DCSoL/Dg2wVkW/6Qx03r/yQMLJ+32Agl32N2X8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
+    "node_modules/inversify/node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ip-address": {
       "version": "9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "supertest": "7.1.0"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,16 +134,16 @@
       }
     },
     "node_modules/@bitfinex/bfx-facs-db-better-sqlite": {
-      "version": "2.1.1",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-db-better-sqlite.git#c0c129a39ae52200575052091750a16d43e772cc",
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-db-better-sqlite.git#1909d26a936fafd1f61565df6dc98d3802396d1a",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitfinex/bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
         "async": "3.2.4",
-        "better-sqlite3": "12.6.2"
+        "better-sqlite3": "13.0.1"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22"
       }
     },
     "node_modules/@bitfinex/bfx-facs-deflate": {
@@ -1481,17 +1481,16 @@
       "dev": true
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.1.tgz",
+      "integrity": "sha512-LYpmOXdkpQYf4wmlxkdzW01XGlOXNIbjLg45yNkh0FQ4814VbK9PdOFmhZpYbej+EZtR/i3FDdhEG98HqZdgnA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": ">=22"
       }
     },
     "node_modules/bfx-api-mock-srv": {
@@ -1679,15 +1678,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bitfinex-api-node": {
@@ -2116,12 +2106,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/chrome-dgram": {
       "version": "3.0.6",
@@ -2871,21 +2855,6 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2895,15 +2864,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2983,15 +2943,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/devtools-protocol": {
@@ -3906,15 +3857,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -4073,12 +4015,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -4453,12 +4389,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4956,12 +4886,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6096,18 +6020,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6124,6 +6036,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6149,12 +6062,6 @@
       "engines": {
         "node": ">= 8.0.0"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "11.1.0",
@@ -6356,12 +6263,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6385,16 +6286,13 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-fetch": {
@@ -7006,33 +6904,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7427,30 +7298,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -8033,51 +7880,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-sha1": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.1.0.tgz",
@@ -8520,18 +8322,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -8662,18 +8452,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,7 +222,7 @@
     },
     "node_modules/@bitfinex/bfx-facs-scheduler": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-scheduler.git#b7b3f86bc4be45599d7870d6f75a04fecd3f3e02",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-facs-scheduler.git#404efe844e939b896466f8eaa51050b873dc256d",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitfinex/bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "mathjs": "14.8.1",
         "moment": "2.29.4",
         "puppeteer": "24.1.0",
-        "uuid": "9.0.0",
+        "uuid": "11.1.0",
         "yargs": "17.2.1"
       },
       "devDependencies": {
@@ -340,6 +340,16 @@
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
       "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==",
       "license": "MIT"
+    },
+    "node_modules/@bitfinex/bfx-report/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@bitfinex/bfx-svc-boot-js": {
       "version": "1.1.0",
@@ -4499,19 +4509,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/grenache-nodejs-base/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/grenache-nodejs-http": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/grenache-nodejs-http/-/grenache-nodejs-http-1.0.1.tgz",
@@ -4554,19 +4551,6 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/grenache-nodejs-link/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/grenache-nodejs-ws": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/bitfinexcom/grenache-nodejs-ws.git#7b12c0b450fa44f2502ae1d21770186b273bbecc",
@@ -4580,19 +4564,6 @@
       },
       "engines": {
         "node": ">=16.0"
-      }
-    },
-    "node_modules/grenache-nodejs-ws/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/has-bigints": {
@@ -8782,11 +8753,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@bitfinex/bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
         "bfx-api-mock-srv": "2.0.0",
         "chai": "4.3.4",
-        "concurrently": "9.2.1",
+        "concurrently": "10.0.4",
         "cross-env": "10.1.0",
         "grenache-grape": "1.0.0",
         "mocha": "11.1.0",
@@ -2374,62 +2374,182 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.9.0",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/concurrently/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
-    "node_modules/concurrently/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/config": {
@@ -4220,6 +4340,19 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-func-name": {
@@ -7804,9 +7937,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,11 +352,11 @@
       }
     },
     "node_modules/@bitfinex/bfx-svc-boot-js": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-svc-boot-js.git#be28ca5387eef34e651042e64d278feedf9b3a61",
+      "version": "1.3.1",
+      "resolved": "git+ssh://git@github.com/bitfinexcom/bfx-svc-boot-js.git#c9217dadefeb194cc77d79cba5666b61eb7310d9",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "yargs": "^17.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mathjs": "14.8.1",
     "moment": "2.29.4",
     "puppeteer": "24.1.0",
-    "uuid": "9.0.0",
+    "uuid": "11.1.0",
     "yargs": "17.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bignumber.js": "9.1.2",
     "csv": "5.5.3",
     "grenache-nodejs-ws": "1.0.0",
-    "inversify": "6.0.1",
+    "inversify": "7.11.0",
     "mathjs": "14.8.1",
     "moment": "2.29.4",
     "puppeteer": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@bitfinex/bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",
     "bfx-api-mock-srv": "2.0.0",
     "chai": "4.3.4",
-    "concurrently": "9.2.1",
+    "concurrently": "10.0.4",
     "cross-env": "10.1.0",
     "grenache-grape": "1.0.0",
     "mocha": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bitfinex reports framework",
   "main": "worker.js",
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=22"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -67,7 +67,7 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
     const _appDeps = appDeps(...args)
 
     this.appDeps.push(_appDeps)
-    this.container.load(_appDeps)
+    this.container.loadSync(_appDeps)
   }
 
   getGrcConf () {

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -130,7 +130,7 @@ decorate(injectable(), EventEmitter)
 module.exports = ({
   grcBfxOpts
 }) => {
-  return new ContainerModule((bind, unbind, isBound, rebind) => {
+  return new ContainerModule(({ bind, rebindSync }) => {
     bind(TYPES.FrameworkRServiceDepsSchema)
       .toDynamicValue((ctx) => {
         return [
@@ -173,14 +173,14 @@ module.exports = ({
           ['_wsEventEmitterFactory', TYPES.WSEventEmitterFactory]
         ]
       })
-    rebind(TYPES.RServiceDepsSchemaAliase)
+    rebindSync(TYPES.RServiceDepsSchemaAliase)
       .toDynamicValue((ctx) => [
         ...ctx.get(TYPES.RServiceDepsSchema),
         ...ctx.get(TYPES.FrameworkRServiceDepsSchema)
       ])
     bind(TYPES.WSEventEmitterFactory)
       .toFactory(wsEventEmitterFactory)
-    rebind(TYPES.Responder).toConstantValue(
+    rebindSync(TYPES.Responder).toConstantValue(
       bindDepsToFn(
         responder,
         [
@@ -190,7 +190,7 @@ module.exports = ({
         ]
       )
     )
-    rebind(TYPES.PdfWriter)
+    rebindSync(TYPES.PdfWriter)
       .to(PdfWriter)
       .inSingletonScope()
     bind(TYPES.PrivResponder)
@@ -416,12 +416,12 @@ module.exports = ({
     bind(TYPES.TransactionTaxReport)
       .to(TransactionTaxReport)
       .inSingletonScope()
-    rebind(TYPES.WeightedAveragesReport)
+    rebindSync(TYPES.WeightedAveragesReport)
       .to(WeightedAveragesReport)
-    rebind(TYPES.ReportFileJobData)
+    rebindSync(TYPES.ReportFileJobData)
       .to(ReportFileJobData)
       .inSingletonScope()
-    rebind(TYPES.GetDataFromApi).toConstantValue(
+    rebindSync(TYPES.GetDataFromApi).toConstantValue(
       bindDepsToFn(
         getDataFromApi,
         [
@@ -430,10 +430,10 @@ module.exports = ({
         ]
       )
     )
-    rebind(TYPES.BfxApiRouter)
+    rebindSync(TYPES.BfxApiRouter)
       .to(BfxApiRouter)
       .inSingletonScope()
-    rebind(TYPES.GetREST).toConstantValue(
+    rebindSync(TYPES.GetREST).toConstantValue(
       bindDepsToFn(
         getREST,
         [
@@ -442,7 +442,7 @@ module.exports = ({
         ]
       )
     )
-    rebind(TYPES.PrepareApiResponse).toConstantValue(
+    rebindSync(TYPES.PrepareApiResponse).toConstantValue(
       bindDepsToFn(
         prepareApiResponse,
         [

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -175,8 +175,8 @@ module.exports = ({
       })
     rebind(TYPES.RServiceDepsSchemaAliase)
       .toDynamicValue((ctx) => [
-        ...ctx.container.get(TYPES.RServiceDepsSchema),
-        ...ctx.container.get(TYPES.FrameworkRServiceDepsSchema)
+        ...ctx.get(TYPES.RServiceDepsSchema),
+        ...ctx.get(TYPES.FrameworkRServiceDepsSchema)
       ])
     bind(TYPES.WSEventEmitterFactory)
       .toFactory(wsEventEmitterFactory)
@@ -256,10 +256,10 @@ module.exports = ({
       .toFactory(dbMigratorFactory)
     bind(TYPES.DB)
       .toDynamicValue((ctx) => {
-        const { dbDriver } = ctx.container.get(
+        const { dbDriver } = ctx.get(
           TYPES.CONF
         )
-        const rService = ctx.container.get(
+        const rService = ctx.get(
           TYPES.RService
         )
 
@@ -271,12 +271,12 @@ module.exports = ({
       .to(BetterSqliteDAO)
     bind(TYPES.DAO)
       .toDynamicValue((ctx) => {
-        const { dbDriver } = ctx.container.get(
+        const { dbDriver } = ctx.get(
           TYPES.CONF
         )
 
         if (dbDriver === 'better-sqlite') {
-          return ctx.container.get(
+          return ctx.get(
             TYPES.BetterSqliteDAO
           )
         }

--- a/workers/loc.api/di/factories/data-inserter-factory.js
+++ b/workers/loc.api/di/factories/data-inserter-factory.js
@@ -4,7 +4,7 @@ const TYPES = require('../types')
 
 module.exports = (ctx) => {
   return (params) => {
-    const dataInserter = ctx.container.get(
+    const dataInserter = ctx.get(
       TYPES.DataInserter
     )
     dataInserter.init(params)

--- a/workers/loc.api/di/factories/db-migrator-factory.js
+++ b/workers/loc.api/di/factories/db-migrator-factory.js
@@ -3,17 +3,17 @@
 const TYPES = require('../types')
 
 module.exports = (ctx) => {
-  const { dbDriver } = ctx.container.get(
+  const { dbDriver } = ctx.get(
     TYPES.CONF
   )
 
   return () => {
-    const dao = ctx.container.get(
+    const dao = ctx.get(
       TYPES.DAO
     )
 
     if (dbDriver === 'better-sqlite') {
-      const sqliteDbMigrator = ctx.container.get(
+      const sqliteDbMigrator = ctx.get(
         TYPES.SqliteDbMigrator
       )
       sqliteDbMigrator.setDao(dao)

--- a/workers/loc.api/di/factories/interrupter-factory.js
+++ b/workers/loc.api/di/factories/interrupter-factory.js
@@ -7,7 +7,7 @@ const {
 const TYPES = require('../types')
 
 module.exports = (ctx) => {
-  const authenticator = ctx.container.get(TYPES.Authenticator)
+  const authenticator = ctx.get(TYPES.Authenticator)
 
   return (params) => {
     const { user, name } = params ?? {}
@@ -16,7 +16,7 @@ module.exports = (ctx) => {
       throw new AuthError()
     }
 
-    const interrupter = ctx.container.get(
+    const interrupter = ctx.get(
       TYPES.Interrupter
     ).setName(name)
 

--- a/workers/loc.api/di/factories/migrations-factory.js
+++ b/workers/loc.api/di/factories/migrations-factory.js
@@ -45,13 +45,13 @@ const _lookUpMigrations = (
 }
 
 module.exports = (ctx) => {
-  const { dbDriver } = ctx.container.get(
+  const { dbDriver } = ctx.get(
     TYPES.CONF
   )
-  const logger = ctx.container.get(
+  const logger = ctx.get(
     TYPES.Logger
   )
-  const processMessageManager = ctx.container.get(
+  const processMessageManager = ctx.get(
     TYPES.ProcessMessageManager
   )
 
@@ -71,7 +71,7 @@ module.exports = (ctx) => {
       TYPES.ProcessMessageManager
     ]
     const deps = depTypes.map((type) => {
-      return ctx.container.get(type)
+      return ctx.get(type)
     })
 
     const migrationFileDirents = fs.readdirSync(

--- a/workers/loc.api/di/factories/process-message-manager-factory.js
+++ b/workers/loc.api/di/factories/process-message-manager-factory.js
@@ -3,7 +3,7 @@
 const TYPES = require('../types')
 
 module.exports = (ctx) => {
-  const { dbDriver } = ctx.container.get(
+  const { dbDriver } = ctx.get(
     TYPES.CONF
   )
 
@@ -14,11 +14,11 @@ module.exports = (ctx) => {
       TYPES.RecalcSubAccountLedgersBalancesHook
     ]
     const deps = depTypes.map((type) => {
-      return ctx.container.get(type)
+      return ctx.get(type)
     })
 
     if (dbDriver === 'better-sqlite') {
-      const processMessageManager = ctx.container.get(
+      const processMessageManager = ctx.get(
         TYPES.ProcessMessageManager
       )
       processMessageManager.setDeps(...deps)

--- a/workers/loc.api/di/factories/sync-factory.js
+++ b/workers/loc.api/di/factories/sync-factory.js
@@ -4,7 +4,7 @@ const TYPES = require('../types')
 
 module.exports = (ctx) => {
   return () => {
-    const sync = ctx.container.get(
+    const sync = ctx.get(
       TYPES.Sync
     )
 

--- a/workers/loc.api/di/factories/sync-user-step-data-factory.js
+++ b/workers/loc.api/di/factories/sync-user-step-data-factory.js
@@ -4,7 +4,7 @@ const TYPES = require('../types')
 
 module.exports = (ctx) => {
   return (...args) => {
-    const syncUserStepData = ctx.container.get(
+    const syncUserStepData = ctx.get(
       TYPES.SyncUserStepData
     )
 

--- a/workers/loc.api/di/factories/ws-event-emitter-factory.js
+++ b/workers/loc.api/di/factories/ws-event-emitter-factory.js
@@ -4,7 +4,7 @@ const TYPES = require('../types')
 
 module.exports = (ctx) => {
   return () => {
-    const wsEventEmitter = ctx.container.get(
+    const wsEventEmitter = ctx.get(
       TYPES.WSEventEmitter
     )
 


### PR DESCRIPTION
This PR migrates `inversifyjs` to `v7` and considers the corresponding migration guide https://inversify.io/docs/7.x/guides/migrating-from-v6/. Also updates deps and applies `npm audit fix` to fix dep vulnerabilities. Bumps node engine ver to `>=v22`, and update node ver to `v24` for docker containers

---

TODO: for the future, there is a need to update inversifyjs to v8 to keep lib support, but not right now since v8 removed CommonJS
https://github.com/inversify/monorepo/releases/tag/inversify%408.0.0

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report/pull/490