### PR TITLE
Send error event via ws if report gen ends with error in aggregator

### DIFF
--- a/workers/api.framework.report.wrk.js
+++ b/workers/api.framework.report.wrk.js
@@ -210,6 +210,14 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
     const processMessageManager = this.container.get(TYPES.ProcessMessageManager)
 
     await wsTransport.start()
+    const emitReportFileGenFailedToOne = (e, job) => {
+      wsEventEmitter.emitReportFileGenerationFailedToOne(
+        { reportFilesMetadata: null },
+        job?.data?.userInfo
+      ).then(() => {}, (err) => {
+        this.logger.error(`WS_EVENT_EMITTER:REPORT_FILE_FAILED: ${err.stack || err}`)
+      })
+    }
 
     processorQueue.on(QUEUE_EVENT_NAMES.ERROR_BASE, (err, job) => {
       if (
@@ -219,13 +227,12 @@ class WrkReportFrameWorkApi extends WrkReportServiceApi {
         return
       }
 
-      wsEventEmitter.emitReportFileGenerationFailedToOne(
-        { reportFilesMetadata: null },
-        job?.data?.userInfo
-      ).then(() => {}, (err) => {
-        this.logger.error(`WS_EVENT_EMITTER:REPORT_FILE_FAILED: ${err.stack || err}`)
-      })
+      emitReportFileGenFailedToOne(err, job)
     })
+    aggregatorQueue.on(
+      QUEUE_EVENT_NAMES.ERROR_BASE,
+      emitReportFileGenFailedToOne
+    )
     aggregatorQueue.on(QUEUE_EVENT_NAMES.COMPLETED, (res) => {
       const {
         reportFilesMetadata,


### PR DESCRIPTION
This PR adds ability to send an error via ws if report generation ends with an error in the aggregator.
An error in the aggregator is possible if write access to the report folder is restricted by an antivirus. In addition to using the standard logging mechanism, we need to send the corresponding event via ws to UI to improve UX

---

Previously, the report generation state would get stuck when there was an error accessing the folder due to an antivirus
<img width="516" height="437" alt="Screenshot from 2026-08-20 11-36-54" src="https://github.com/user-attachments/assets/91b75ce4-9ed4-477c-828c-74946c152b47" />

Now it looks correct
<img width="516" height="435" alt="Screenshot from 2026-08-20 11-38-05" src="https://github.com/user-attachments/assets/40903db2-1819-4c05-b696-2ba4cdc10065" />
<img width="516" height="321" alt="Screenshot from 2026-08-20 11-37-50" src="https://github.com/user-attachments/assets/7119f3c9-f6ab-4625-ac7d-0b716a38fbbd" />
